### PR TITLE
fix: 移除違反單一 array_contains 限制的 composite index (Closes #13)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,14 +15,6 @@
         { "fieldPath": "memberUids", "arrayConfig": "CONTAINS" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
-    },
-    {
-      "collectionGroup": "cards",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "memberUids", "arrayConfig": "CONTAINS" },
-        { "fieldPath": "tagIds", "arrayConfig": "CONTAINS" }
-      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## 修法
移除 \`memberUids + tagIds\` composite index（Firestore 禁止雙 array_contains）。

保留兩個生效中的 index：
- \`memberUids + lastContactedAt DESC\` — timeline「最近沒聯絡」排序
- \`memberUids + createdAt DESC\` — 「新建立」+ 名片列表預設排序

## 驗證
\`\`\`bash
npx firebase deploy --only firestore:rules,firestore:indexes
# ✓ firestore: deployed indexes successfully for (default) database
# ✓ firestore: released rules firestore.rules to cloud.firestore
\`\`\`

## Future
Tag filtering 於 Phase 4 實作：
- \`array-contains-any\` on tagIds（Firestore 允許 up to 30 values in-query）
- 或直接走 Typesense multi-field filter

Closes #13