### PR TITLE
Phase 3: OCR (MiniMax M2.7) + voice capture + PWA installable

### DIFF
--- a/e2e/pwa.spec.ts
+++ b/e2e/pwa.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * PWA smoke — manifest + icon routes must be publicly reachable (no auth
+ * gate), return the right content types, and carry the fields a browser
+ * needs to mark the app installable.
+ */
+test.describe("pwa installability", () => {
+  test("manifest.webmanifest exposes required PWA fields", async ({ request }) => {
+    const res = await request.get("/manifest.webmanifest");
+    expect(res.status()).toBe(200);
+    const contentType = res.headers()["content-type"] ?? "";
+    expect(contentType).toMatch(/application\/manifest\+json|application\/json/);
+
+    const manifest = (await res.json()) as {
+      name: string;
+      short_name: string;
+      start_url: string;
+      display: string;
+      icons: Array<{ src: string; sizes: string; type: string; purpose?: string }>;
+      theme_color: string;
+      background_color: string;
+    };
+
+    expect(manifest.name).toBeTruthy();
+    expect(manifest.short_name).toBeTruthy();
+    expect(manifest.start_url).toBe("/");
+    expect(manifest.display).toBe("standalone");
+    expect(manifest.theme_color).toMatch(/^#/);
+    expect(manifest.background_color).toMatch(/^#/);
+    expect(manifest.icons.length).toBeGreaterThanOrEqual(1);
+
+    const has512 = manifest.icons.some((i) => i.sizes === "512x512");
+    expect(has512, "needs at least one 512x512 icon for install prompt").toBe(true);
+  });
+
+  test("/icon serves a PNG image", async ({ request }) => {
+    const res = await request.get("/icon");
+    expect(res.status()).toBe(200);
+    expect(res.headers()["content-type"]).toBe("image/png");
+    const body = await res.body();
+    // PNG magic bytes 89 50 4E 47
+    expect(body[0]).toBe(0x89);
+    expect(body[1]).toBe(0x50);
+    expect(body[2]).toBe(0x4e);
+    expect(body[3]).toBe(0x47);
+  });
+
+  test("/apple-icon serves a PNG image", async ({ request }) => {
+    const res = await request.get("/apple-icon");
+    expect(res.status()).toBe(200);
+    expect(res.headers()["content-type"]).toBe("image/png");
+    const body = await res.body();
+    expect(body[0]).toBe(0x89);
+    expect(body[1]).toBe(0x50);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": "19.2.4",
     "react-hook-form": "^7.72.1",
     "server-only": "^0.0.1",
+    "sharp": "^0.34.5",
     "typesense": "^3.0.5",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       typesense:
         specifier: ^3.0.5
         version: 3.0.5(@babel/runtime@7.29.2)
@@ -6227,8 +6230,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -10641,7 +10643,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/app/(app)/cards/scan/actions.ts
+++ b/src/app/(app)/cards/scan/actions.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { z } from "zod";
+
+import { authedAction } from "@/lib/auth/safe-action";
+import { getOcrProvider } from "@/lib/ocr";
+import { uploadCardImage } from "@/lib/storage/card-images";
+
+/**
+ * Server actions behind the Scan-a-card flow.
+ *
+ * `scanCardAction` accepts the raw image (via FormData → Buffer),
+ * uploads it to Storage, fires the OCR provider against the signed URL,
+ * and returns the extracted fields + imagePath. The client then hands
+ * that payload to CardForm (pre-filled) + the user reviews + saves.
+ */
+
+const imageBase64Schema = z.object({
+  fileBase64: z.string().min(1),
+  mimeType: z.string().refine((v) => v.startsWith("image/"), "must be image/*"),
+  originalName: z.string().max(200).optional(),
+});
+
+export const scanCardAction = authedAction
+  .inputSchema(imageBase64Schema)
+  .action(async ({ parsedInput, ctx }) => {
+    const buffer = Buffer.from(parsedInput.fileBase64, "base64");
+    if (buffer.byteLength === 0) {
+      throw new Error("empty image payload");
+    }
+    if (buffer.byteLength > 10 * 1024 * 1024) {
+      throw new Error("image exceeds 10MB limit");
+    }
+
+    const upload = await uploadCardImage({
+      uid: ctx.user.uid,
+      fileBuffer: buffer,
+      originalName: parsedInput.originalName,
+      mimeType: parsedInput.mimeType,
+    });
+
+    const provider = getOcrProvider();
+    const ocrResult = await provider.extract({
+      source: { kind: "url", url: upload.signedUrl },
+      hintLanguage: "mixed",
+    });
+
+    if (!ocrResult.ok) {
+      return {
+        ok: false as const,
+        imagePath: upload.path,
+        error: ocrResult.error,
+      };
+    }
+
+    return {
+      ok: true as const,
+      imagePath: upload.path,
+      bucket: upload.bucket,
+      fields: ocrResult.fields,
+      meta: {
+        provider: ocrResult.meta.provider,
+        durationMs: ocrResult.meta.durationMs,
+      },
+    };
+  });

--- a/src/app/(app)/cards/scan/page.tsx
+++ b/src/app/(app)/cards/scan/page.tsx
@@ -1,0 +1,24 @@
+import { ScanFlow } from "@/components/scan/ScanFlow";
+
+import styles from "./scan.module.css";
+
+export const metadata = {
+  title: "拍照辨識",
+};
+
+export default function ScanCardPage() {
+  return (
+    <article className={styles.article}>
+      <header className={styles.header}>
+        <p className={styles.kicker}>拍照辨識</p>
+        <h1 className={styles.title}>
+          <em>一秒拍照</em>、10 秒歸檔
+        </h1>
+        <p className={styles.lead}>
+          上傳或用相機拍一張名片。系統會辨識 → 你校對 → 語音補一句「為什麼記得這個人」→ 存檔。
+        </p>
+      </header>
+      <ScanFlow />
+    </article>
+  );
+}

--- a/src/app/(app)/cards/scan/scan.module.css
+++ b/src/app/(app)/cards/scan/scan.module.css
@@ -1,0 +1,47 @@
+.article {
+  max-width: var(--content-max);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h2);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+}
+
+.title em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-accent);
+  font-weight: 400;
+}
+
+.lead {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  line-height: var(--leading-relaxed);
+  color: var(--color-fg-muted);
+  margin: 0;
+  max-width: 42rem;
+}

--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -1,0 +1,31 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+/**
+ * Apple touch icon — darker墨黑 background so home-screen badge reads on
+ * light and dark iOS wallpapers. Same 名 mark as the main app icon.
+ */
+export default function AppleIcon() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#1a1814",
+        color: "#fbf9f4",
+        fontSize: 120,
+        fontFamily: "serif",
+        fontWeight: 500,
+        letterSpacing: "-0.05em",
+      }}
+    >
+      名
+    </div>,
+    size,
+  );
+}

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,32 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 512, height: 512 };
+export const contentType = "image/png";
+
+/**
+ * Dynamic app icon — oklch paper background with朱紅 "名" character centered.
+ * Rendered on-demand by Next's ImageResponse (Satori). Kept system-font only
+ * since Satori needs fonts loaded explicitly for custom fonts.
+ */
+export default function Icon() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#fbf9f4",
+        color: "#b33a1f",
+        fontSize: 340,
+        fontFamily: "serif",
+        fontWeight: 500,
+        letterSpacing: "-0.05em",
+      }}
+    >
+      名
+    </div>,
+    size,
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Fraunces, Inter, Noto_Serif_TC } from "next/font/google";
 
 import "./globals.css";
@@ -34,13 +34,26 @@ export const metadata: Metadata = {
   description: "個人工作名片管理網站 — 以關係脈絡為核心",
   applicationName: "Namecard Web",
   authors: [{ name: "cct08311github" }],
-  icons: {
-    icon: "/favicon.ico",
+  manifest: "/manifest.webmanifest",
+  appleWebApp: {
+    capable: true,
+    title: "Namecard",
+    statusBarStyle: "default",
   },
   robots: {
     index: false,
     follow: false,
   },
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#fbf9f4" },
+    { media: "(prefers-color-scheme: dark)", color: "#1a1814" },
+  ],
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
 };
 
 export default function RootLayout({

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Namecard Web",
+    short_name: "Namecard",
+    description: "個人工作名片管理 — 以關係脈絡為核心",
+    start_url: "/",
+    scope: "/",
+    display: "standalone",
+    orientation: "portrait",
+    background_color: "#fbf9f4",
+    theme_color: "#1a1814",
+    lang: "zh-Hant",
+    icons: [
+      {
+        src: "/icon",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/apple-icon",
+        sizes: "180x180",
+        type: "image/png",
+        purpose: "maskable",
+      },
+    ],
+    categories: ["productivity", "business"],
+  };
+}

--- a/src/components/capture/VoiceCapture.module.css
+++ b/src/components/capture/VoiceCapture.module.css
@@ -1,0 +1,89 @@
+.voice {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.controls {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: stretch;
+}
+
+.micBtn {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  padding: var(--space-sm) var(--space-md);
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.micBtn:hover {
+  border-color: var(--color-accent);
+  background: var(--color-paper-raised);
+}
+
+.listening {
+  background: var(--color-accent);
+  color: var(--color-paper);
+  border-color: var(--color-accent);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 var(--color-accent-soft);
+  }
+  50% {
+    box-shadow: 0 0 0 8px transparent;
+  }
+}
+
+.micIcon {
+  font-size: 1.1em;
+}
+
+.langBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+  background: transparent;
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+}
+
+.langBtn:hover {
+  color: var(--color-fg);
+  border-color: var(--color-fg-muted);
+}
+
+.hint {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-fg-subtle);
+}
+
+.error {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-accent);
+}

--- a/src/components/capture/VoiceCapture.tsx
+++ b/src/components/capture/VoiceCapture.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useRef, useState, useSyncExternalStore } from "react";
+
+import styles from "./VoiceCapture.module.css";
+
+interface VoiceCaptureProps {
+  onTranscript: (text: string) => void;
+  /** BCP 47 tags; default prefers zh-TW but falls back to browser default. */
+  languages?: string[];
+}
+
+interface BrowserSpeechRecognitionEvent extends Event {
+  results: {
+    readonly length: number;
+    item(index: number): SpeechRecognitionResult;
+    [index: number]: SpeechRecognitionResult;
+    isFinal?: boolean;
+  };
+  resultIndex: number;
+}
+
+interface SpeechRecognitionResult {
+  readonly length: number;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+  isFinal: boolean;
+}
+
+interface SpeechRecognitionAlternative {
+  transcript: string;
+  confidence: number;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  error: string;
+  message?: string;
+}
+
+interface SpeechRecognitionInstance {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  onresult: ((event: BrowserSpeechRecognitionEvent) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechRecognitionCtor = new () => SpeechRecognitionInstance;
+
+function getSpeechRecognitionCtor(): SpeechRecognitionCtor | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (
+    (window as unknown as { SpeechRecognition?: SpeechRecognitionCtor }).SpeechRecognition ??
+    (window as unknown as { webkitSpeechRecognition?: SpeechRecognitionCtor })
+      .webkitSpeechRecognition
+  );
+}
+
+const EMPTY_SUBSCRIBE = () => () => {};
+const getSupportedClient = () => Boolean(getSpeechRecognitionCtor());
+const getSupportedServer = (): boolean | null => null;
+
+/**
+ * Voice-capture button for the whyRemember field. Uses browser's
+ * native SpeechRecognition (webkitSpeechRecognition fallback). Works
+ * offline-in-browser on Chrome/Edge/Safari, enabling the "wrap up
+ * the meeting, dictate why you remember this person" flow.
+ *
+ * On unsupported browsers (Firefox, older Safari) the button is
+ * hidden — user falls back to typing.
+ */
+export function VoiceCapture({
+  onTranscript,
+  languages = ["zh-TW", "zh-CN", "en-US"],
+}: VoiceCaptureProps) {
+  // useSyncExternalStore keeps SSR snapshot (null) stable while client
+  // snapshot reflects real browser support — avoids setState-in-effect.
+  const supported = useSyncExternalStore(EMPTY_SUBSCRIBE, getSupportedClient, getSupportedServer);
+  const [listening, setListening] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [langIdx, setLangIdx] = useState(0);
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+
+  function startListening() {
+    const Ctor = getSpeechRecognitionCtor();
+    if (!Ctor) return;
+
+    setError(null);
+    const r = new Ctor();
+    r.lang = languages[langIdx] ?? languages[0] ?? "zh-TW";
+    r.continuous = false;
+    r.interimResults = false;
+    r.onresult = (event) => {
+      const res = event.results[event.resultIndex];
+      if (!res) return;
+      const alt = res[0];
+      if (alt && alt.transcript) {
+        onTranscript(alt.transcript.trim());
+      }
+    };
+    r.onerror = (event) => {
+      const reason = event.error || "unknown";
+      if (reason === "no-speech") {
+        setError("沒聽到聲音，請再試一次");
+      } else if (reason === "not-allowed" || reason === "service-not-allowed") {
+        setError("需要麥克風權限才能用語音");
+      } else {
+        setError(`語音錯誤：${reason}`);
+      }
+      setListening(false);
+    };
+    r.onend = () => {
+      setListening(false);
+      recognitionRef.current = null;
+    };
+    try {
+      r.start();
+      recognitionRef.current = r;
+      setListening(true);
+    } catch (err) {
+      setError(`無法啟動語音：${(err as Error).message}`);
+    }
+  }
+
+  function stopListening() {
+    recognitionRef.current?.stop();
+    setListening(false);
+  }
+
+  function cycleLanguage() {
+    setLangIdx((idx) => (idx + 1) % languages.length);
+  }
+
+  if (supported === null) return null;
+  if (supported === false) return null;
+
+  return (
+    <div className={styles.voice}>
+      <div className={styles.controls}>
+        <button
+          type="button"
+          className={`${styles.micBtn} ${listening ? styles.listening : ""}`}
+          onClick={listening ? stopListening : startListening}
+          aria-pressed={listening}
+        >
+          <span aria-hidden="true" className={styles.micIcon}>
+            {listening ? "■" : "🎙"}
+          </span>
+          <span>{listening ? "停止錄音" : "按這裡講「為什麼記得」"}</span>
+        </button>
+        <button
+          type="button"
+          className={styles.langBtn}
+          onClick={cycleLanguage}
+          aria-label="Cycle language"
+        >
+          {languages[langIdx]}
+        </button>
+      </div>
+      {error && (
+        <p role="alert" className={styles.error}>
+          {error}
+        </p>
+      )}
+      <p className={styles.hint}>說完後會自動加到下面的文字框。可以再手動修改。</p>
+    </div>
+  );
+}

--- a/src/components/scan/CardFormPrefilled.module.css
+++ b/src/components/scan/CardFormPrefilled.module.css
@@ -1,0 +1,246 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-raised);
+}
+
+.whySection {
+  background: var(--color-accent-soft);
+  border-color: var(--color-accent);
+  border-left-width: 3px;
+}
+
+.legend {
+  padding: 0 var(--space-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+}
+
+.requiredMark {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-accent-ink);
+  padding: 0.05em 0.5em;
+  background: var(--color-paper-raised);
+  border-radius: var(--radius-pill);
+  font-size: 0.7em;
+  text-transform: none;
+  letter-spacing: var(--tracking-normal);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-sm);
+}
+
+@media (max-width: 32rem) {
+  .row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.lowConf .input,
+.lowConf .select,
+.lowConf .textarea {
+  border-bottom-color: oklch(75% 0.15 80);
+  border-bottom-width: 2px;
+  background: oklch(98% 0.02 80);
+}
+
+.label {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-fg-muted);
+}
+
+.input,
+.textarea,
+.select {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-fg);
+  background: var(--color-bg);
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-md);
+}
+
+.input:focus,
+.textarea:focus,
+.select:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-accent-soft);
+}
+
+.textarea {
+  resize: vertical;
+  line-height: var(--leading-normal);
+}
+
+.select {
+  appearance: none;
+  padding-right: var(--space-xl);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' fill='none' stroke='%23555' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right var(--space-md) center;
+  background-size: 10px;
+}
+
+.multiRow {
+  display: grid;
+  grid-template-columns: 6rem 1fr 2rem;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.iconBtn {
+  width: 2rem;
+  height: 2.25rem;
+  background: transparent;
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+
+.iconBtn:hover {
+  color: var(--color-accent-ink);
+  border-color: var(--color-accent);
+}
+
+.addBtn {
+  align-self: flex-start;
+  background: transparent;
+  border: var(--border-hair) dashed var(--color-border);
+  color: var(--color-fg-muted);
+  padding: var(--space-2xs) var(--space-md);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  cursor: pointer;
+}
+
+.addBtn:hover {
+  color: var(--color-accent-ink);
+  border-style: solid;
+  border-color: var(--color-accent);
+}
+
+.whyHelp {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  line-height: var(--leading-snug);
+}
+
+.errorText {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+}
+
+.templates {
+  padding: var(--space-sm);
+  background: var(--color-paper-raised);
+  border-radius: var(--radius-sm);
+}
+
+.templatesTitle {
+  margin: 0 0 var(--space-xs);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-fg-muted);
+}
+
+.templateList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.templateBtn {
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-fg);
+  cursor: pointer;
+  line-height: var(--leading-snug);
+}
+
+.templateBtn:hover {
+  color: var(--color-accent-ink);
+  text-decoration: underline;
+}
+
+.serverError {
+  margin: 0;
+  padding: var(--space-sm) var(--space-md);
+  border-left: 2px solid var(--color-accent);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-ink);
+  font-family: var(--font-serif);
+  font-style: italic;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.primary {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.primary:hover:not(:disabled) {
+  background: var(--color-accent-ink);
+}
+
+.primary:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}

--- a/src/components/scan/CardFormPrefilled.tsx
+++ b/src/components/scan/CardFormPrefilled.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState, type FormEvent } from "react";
+import { useFieldArray, useForm, type Resolver } from "react-hook-form";
+import type { z } from "zod";
+
+import { VoiceCapture } from "@/components/capture/VoiceCapture";
+import { cardCreateSchema, type CardCreateInput } from "@/db/schema";
+import type { OcrFields } from "@/lib/ocr";
+import { isLowConfidence } from "@/lib/ocr";
+
+import styles from "./CardFormPrefilled.module.css";
+
+type CardFormValues = z.input<typeof cardCreateSchema>;
+
+interface CardFormPrefilledProps {
+  ocrFields: OcrFields;
+  imagePath: string;
+  onSubmit: (payload: CardCreateInput) => void;
+  submitting: boolean;
+  serverError: string | null;
+}
+
+function toDefaults(ocrFields: OcrFields, imagePath: string): CardFormValues {
+  return {
+    nameZh: ocrFields.nameZh?.value ?? "",
+    nameEn: ocrFields.nameEn?.value ?? "",
+    namePhonetic: ocrFields.namePhonetic?.value ?? "",
+    jobTitleZh: ocrFields.jobTitleZh?.value ?? "",
+    jobTitleEn: ocrFields.jobTitleEn?.value ?? "",
+    department: ocrFields.department?.value ?? "",
+    companyZh: ocrFields.companyZh?.value ?? "",
+    companyEn: ocrFields.companyEn?.value ?? "",
+    companyWebsite: ocrFields.companyWebsite?.value ?? "",
+    phones: (ocrFields.phones ?? []).map((p) => ({ label: p.label, value: p.value })),
+    emails: (ocrFields.emails ?? []).map((e) => ({ label: e.label, value: e.value })),
+    addresses: [],
+    social: {
+      lineId: ocrFields.social?.lineId?.value ?? "",
+      wechatId: ocrFields.social?.wechatId?.value ?? "",
+      linkedinUrl: ocrFields.social?.linkedinUrl?.value ?? "",
+      websiteUrl: ocrFields.social?.websiteUrl?.value ?? "",
+    },
+    whyRemember: "",
+    firstMetDate: "",
+    firstMetContext: "",
+    firstMetEventTag: "",
+    notes: "",
+    tagIds: [],
+    tagNames: [],
+    frontImagePath: imagePath,
+    backImagePath: undefined,
+    ocrProvider: undefined,
+    ocrConfidence: undefined,
+    ocrRawJson: undefined,
+  };
+}
+
+function suggestTemplates(ocrFields: OcrFields): string[] {
+  const company = ocrFields.companyZh?.value || ocrFields.companyEn?.value;
+  const name = ocrFields.nameZh?.value || ocrFields.nameEn?.value;
+  const role = ocrFields.jobTitleZh?.value || ocrFields.jobTitleEn?.value;
+  const items: string[] = [];
+  if (company) items.push(`在 ${company} 認識的，聊到 ___`);
+  if (role && company) items.push(`${company} 的 ${role}，介紹了 ___`);
+  if (name) items.push(`${name} 介紹我認識 ___`);
+  items.push("在 ___ 活動遇到，印象最深的是 ___");
+  return items;
+}
+
+export function CardFormPrefilled({
+  ocrFields,
+  imagePath,
+  onSubmit,
+  submitting,
+  serverError,
+}: CardFormPrefilledProps) {
+  const defaults = toDefaults(ocrFields, imagePath);
+  const form = useForm<CardFormValues>({
+    resolver: zodResolver(cardCreateSchema) as unknown as Resolver<CardFormValues>,
+    defaultValues: defaults,
+    mode: "onBlur",
+  });
+  const phones = useFieldArray({ control: form.control, name: "phones" });
+  const emails = useFieldArray({ control: form.control, name: "emails" });
+
+  const { register, handleSubmit: rhfSubmit, setValue, getValues, formState } = form;
+  const [templates] = useState(() => suggestTemplates(ocrFields));
+  const [showTemplates, setShowTemplates] = useState(true);
+
+  function applyTemplate(t: string) {
+    const current = getValues("whyRemember") ?? "";
+    setValue("whyRemember", current ? `${current}\n${t}` : t, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+    setShowTemplates(false);
+  }
+
+  function handleVoiceTranscript(text: string) {
+    const current = getValues("whyRemember") ?? "";
+    setValue("whyRemember", current ? `${current} ${text}` : text, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+    setShowTemplates(false);
+  }
+
+  function onFinalSubmit(data: CardFormValues) {
+    const payload: CardCreateInput = {
+      ...(data as CardCreateInput),
+      companyWebsite: data.companyWebsite || undefined,
+      firstMetDate: data.firstMetDate || undefined,
+    };
+    onSubmit(payload);
+  }
+
+  function handleFormSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    rhfSubmit(onFinalSubmit)(e);
+  }
+
+  // Flag low-confidence fields with a marker class.
+  const lowConf = {
+    nameZh: isLowConfidence(ocrFields.nameZh),
+    nameEn: isLowConfidence(ocrFields.nameEn),
+    jobTitleZh: isLowConfidence(ocrFields.jobTitleZh),
+    jobTitleEn: isLowConfidence(ocrFields.jobTitleEn),
+    companyZh: isLowConfidence(ocrFields.companyZh),
+    companyEn: isLowConfidence(ocrFields.companyEn),
+  };
+
+  return (
+    <form className={styles.form} onSubmit={handleFormSubmit}>
+      <fieldset className={styles.section}>
+        <legend className={styles.legend}>身分（請校對）</legend>
+        <label className={`${styles.field} ${lowConf.nameZh ? styles.lowConf : ""}`}>
+          <span className={styles.label}>中文姓名</span>
+          <input className={styles.input} {...register("nameZh")} />
+        </label>
+        <label className={`${styles.field} ${lowConf.nameEn ? styles.lowConf : ""}`}>
+          <span className={styles.label}>英文姓名</span>
+          <input className={styles.input} {...register("nameEn")} />
+        </label>
+        <div className={styles.row}>
+          <label className={`${styles.field} ${lowConf.jobTitleZh ? styles.lowConf : ""}`}>
+            <span className={styles.label}>職稱（中）</span>
+            <input className={styles.input} {...register("jobTitleZh")} />
+          </label>
+          <label className={`${styles.field} ${lowConf.companyZh ? styles.lowConf : ""}`}>
+            <span className={styles.label}>公司（中）</span>
+            <input className={styles.input} {...register("companyZh")} />
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset className={styles.section}>
+        <legend className={styles.legend}>聯絡（請校對）</legend>
+        {phones.fields.map((f, idx) => (
+          <div key={f.id} className={styles.multiRow}>
+            <select className={styles.select} {...register(`phones.${idx}.label`)}>
+              <option value="mobile">mobile</option>
+              <option value="office">office</option>
+              <option value="home">home</option>
+              <option value="fax">fax</option>
+              <option value="other">other</option>
+            </select>
+            <input
+              className={styles.input}
+              placeholder="+886-912-345-678"
+              {...register(`phones.${idx}.value`)}
+            />
+            <button
+              type="button"
+              className={styles.iconBtn}
+              onClick={() => phones.remove(idx)}
+              aria-label="移除電話"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          className={styles.addBtn}
+          onClick={() => phones.append({ label: "mobile", value: "" })}
+        >
+          + 新增電話
+        </button>
+        {emails.fields.map((f, idx) => (
+          <div key={f.id} className={styles.multiRow}>
+            <select className={styles.select} {...register(`emails.${idx}.label`)}>
+              <option value="work">work</option>
+              <option value="personal">personal</option>
+              <option value="other">other</option>
+            </select>
+            <input
+              type="email"
+              className={styles.input}
+              placeholder="name@example.com"
+              {...register(`emails.${idx}.value`)}
+            />
+            <button
+              type="button"
+              className={styles.iconBtn}
+              onClick={() => emails.remove(idx)}
+              aria-label="移除 Email"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          className={styles.addBtn}
+          onClick={() => emails.append({ label: "work", value: "" })}
+        >
+          + 新增 Email
+        </button>
+      </fieldset>
+
+      <fieldset className={`${styles.section} ${styles.whySection}`}>
+        <legend className={styles.legend}>
+          為什麼記得這個人
+          <em className={styles.requiredMark}>必填 · 差異化核心</em>
+        </legend>
+        <p className={styles.whyHelp}>
+          寫下當下場景、聊到什麼、為什麼值得記得。未來搜尋「模糊印象」時，這句就是鑰匙。
+        </p>
+
+        <VoiceCapture onTranscript={handleVoiceTranscript} />
+
+        <textarea
+          className={styles.textarea}
+          rows={4}
+          placeholder="例：2024 COMPUTEX 攤位聊到邊緣 AI 推論，跟我認識的 Y 有合作空間。"
+          {...register("whyRemember")}
+        />
+        {formState.errors.whyRemember && (
+          <span className={styles.errorText}>{formState.errors.whyRemember.message}</span>
+        )}
+
+        {showTemplates && templates.length > 0 && (
+          <div className={styles.templates}>
+            <p className={styles.templatesTitle}>需要靈感？點一下接手改：</p>
+            <ul className={styles.templateList}>
+              {templates.map((t) => (
+                <li key={t}>
+                  <button
+                    type="button"
+                    className={styles.templateBtn}
+                    onClick={() => applyTemplate(t)}
+                  >
+                    {t}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className={styles.row}>
+          <label className={styles.field}>
+            <span className={styles.label}>首次見面日期</span>
+            <input type="date" className={styles.input} {...register("firstMetDate")} />
+          </label>
+          <label className={styles.field}>
+            <span className={styles.label}>場合 tag</span>
+            <input
+              className={styles.input}
+              placeholder="COMPUTEX 2024"
+              {...register("firstMetEventTag")}
+            />
+          </label>
+        </div>
+      </fieldset>
+
+      {serverError && (
+        <p role="alert" className={styles.serverError}>
+          {serverError}
+        </p>
+      )}
+
+      <div className={styles.actions}>
+        <button type="submit" className={styles.primary} disabled={submitting}>
+          {submitting ? "儲存中…" : "存檔（含 OCR 圖片）"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/scan/CardFormPrefilled.tsx
+++ b/src/components/scan/CardFormPrefilled.tsx
@@ -7,8 +7,8 @@ import type { z } from "zod";
 
 import { VoiceCapture } from "@/components/capture/VoiceCapture";
 import { cardCreateSchema, type CardCreateInput } from "@/db/schema";
-import type { OcrFields } from "@/lib/ocr";
-import { isLowConfidence } from "@/lib/ocr";
+import type { OcrFields } from "@/lib/ocr/types";
+import { isLowConfidence } from "@/lib/ocr/types";
 
 import styles from "./CardFormPrefilled.module.css";
 

--- a/src/components/scan/ScanFlow.module.css
+++ b/src/components/scan/ScanFlow.module.css
@@ -1,0 +1,152 @@
+.picker {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-2xl) 0;
+}
+
+.pickerLabel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-2xl) var(--space-xl);
+  border: var(--border-thin) dashed var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-raised);
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+  max-width: 32rem;
+}
+
+.pickerLabel:hover {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.pickerInput {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.pickerCta {
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-fg);
+}
+
+.pickerHint {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+  text-align: center;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.3fr);
+  gap: var(--space-xl);
+  align-items: start;
+}
+
+@media (max-width: 64rem) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.imagePane {
+  margin: 0;
+  position: sticky;
+  top: var(--space-xl);
+  padding: var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+}
+
+.imagePane img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius-sm);
+}
+
+@media (max-width: 64rem) {
+  .imagePane {
+    position: static;
+  }
+}
+
+.pane {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.statusPill {
+  align-self: flex-start;
+  padding: var(--space-2xs) var(--space-md);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-ink);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  border-radius: var(--radius-pill);
+}
+
+.statusError {
+  background: oklch(92% 0.05 30);
+  color: var(--color-accent);
+}
+
+.statusHint {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-body);
+  color: var(--color-fg-muted);
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.primary,
+.secondary {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  padding: var(--space-sm) var(--space-lg);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  border: var(--border-thin) solid var(--color-border);
+}
+
+.primary {
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-color: var(--color-ink);
+}
+
+.primary:hover {
+  background: var(--color-accent-ink);
+  border-color: var(--color-accent-ink);
+}
+
+.secondary {
+  background: transparent;
+  color: var(--color-fg-muted);
+}
+
+.secondary:hover {
+  border-color: var(--color-fg-muted);
+  color: var(--color-fg);
+}

--- a/src/components/scan/ScanFlow.tsx
+++ b/src/components/scan/ScanFlow.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { createCardAction } from "@/app/(app)/cards/actions";
+import { scanCardAction } from "@/app/(app)/cards/scan/actions";
+import type { CardCreateInput } from "@/db/schema";
+import type { OcrFields } from "@/lib/ocr";
+
+import { CardFormPrefilled } from "./CardFormPrefilled";
+import styles from "./ScanFlow.module.css";
+
+type Phase =
+  | { kind: "idle" }
+  | { kind: "uploading"; previewUrl: string }
+  | {
+      kind: "review";
+      previewUrl: string;
+      fields: OcrFields;
+      imagePath: string;
+      provider: string;
+      durationMs: number;
+    }
+  | { kind: "ocr-failed"; previewUrl: string; message: string; imagePath?: string };
+
+/**
+ * Orchestrates: file select → base64 → scan server action → review form.
+ *
+ * Stays within this component so the flow is readable top-to-bottom; the
+ * CardForm pre-fill bits are in CardFormPrefilled.
+ */
+export function ScanFlow() {
+  const router = useRouter();
+  const [phase, setPhase] = useState<Phase>({ kind: "idle" });
+  const [submitting, startSubmit] = useTransition();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  async function handleFile(file: File) {
+    setSubmitError(null);
+    const previewUrl = URL.createObjectURL(file);
+    setPhase({ kind: "uploading", previewUrl });
+
+    const fileBase64 = await blobToBase64(file);
+    const result = await scanCardAction({
+      fileBase64,
+      mimeType: file.type || "image/jpeg",
+      originalName: file.name,
+    });
+
+    if (result?.serverError) {
+      setPhase({ kind: "ocr-failed", previewUrl, message: result.serverError });
+      return;
+    }
+    if (result?.validationErrors) {
+      setPhase({
+        kind: "ocr-failed",
+        previewUrl,
+        message: "上傳格式不符（>10MB 或非圖片）",
+      });
+      return;
+    }
+
+    const data = result?.data;
+    if (!data) {
+      setPhase({
+        kind: "ocr-failed",
+        previewUrl,
+        message: "未收到伺服器回應",
+      });
+      return;
+    }
+
+    if (!data.ok) {
+      const err = data.error;
+      setPhase({
+        kind: "ocr-failed",
+        previewUrl,
+        imagePath: data.imagePath,
+        message: formatOcrError(err),
+      });
+      return;
+    }
+
+    setPhase({
+      kind: "review",
+      previewUrl,
+      fields: data.fields,
+      imagePath: data.imagePath,
+      provider: data.meta.provider,
+      durationMs: data.meta.durationMs,
+    });
+  }
+
+  function reset() {
+    if (phase.kind !== "idle" && "previewUrl" in phase) {
+      URL.revokeObjectURL(phase.previewUrl);
+    }
+    setPhase({ kind: "idle" });
+    setSubmitError(null);
+  }
+
+  function handleSubmit(payload: CardCreateInput) {
+    setSubmitError(null);
+    startSubmit(async () => {
+      const result = await createCardAction(payload);
+      if (result?.serverError) {
+        setSubmitError(result.serverError);
+        return;
+      }
+      const id = result?.data?.id;
+      if (!id) {
+        setSubmitError("儲存失敗，請再試一次");
+        return;
+      }
+      router.push(`/cards/${id}`);
+      router.refresh();
+    });
+  }
+
+  if (phase.kind === "idle") {
+    return <UploadPicker onFile={handleFile} />;
+  }
+
+  if (phase.kind === "uploading") {
+    return (
+      <div className={styles.layout}>
+        <ImagePane url={phase.previewUrl} />
+        <div className={styles.pane}>
+          <div className={styles.statusPill}>辨識中…</div>
+          <p className={styles.statusHint}>MiniMax 正在讀這張卡。通常 3-6 秒。</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase.kind === "ocr-failed") {
+    return (
+      <div className={styles.layout}>
+        <ImagePane url={phase.previewUrl} />
+        <div className={styles.pane}>
+          <div className={`${styles.statusPill} ${styles.statusError}`}>辨識失敗</div>
+          <p className={styles.statusHint}>{phase.message}</p>
+          <div className={styles.actions}>
+            <button type="button" className={styles.secondary} onClick={reset}>
+              重新選圖
+            </button>
+            <button
+              type="button"
+              className={styles.primary}
+              onClick={() => router.push("/cards/new")}
+            >
+              改手動輸入
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // review
+  return (
+    <div className={styles.layout}>
+      <ImagePane url={phase.previewUrl} />
+      <div className={styles.pane}>
+        <div className={styles.statusPill}>
+          辨識完成 · {phase.provider} · {(phase.durationMs / 1000).toFixed(1)}s
+        </div>
+        <CardFormPrefilled
+          ocrFields={phase.fields}
+          imagePath={phase.imagePath}
+          onSubmit={handleSubmit}
+          submitting={submitting}
+          serverError={submitError}
+        />
+      </div>
+    </div>
+  );
+}
+
+function UploadPicker({ onFile }: { onFile: (file: File) => void }) {
+  return (
+    <div className={styles.picker}>
+      <label className={styles.pickerLabel}>
+        <input
+          type="file"
+          accept="image/*"
+          capture="environment"
+          className={styles.pickerInput}
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) onFile(file);
+          }}
+        />
+        <span className={styles.pickerCta}>拍照或選擇名片圖片</span>
+        <span className={styles.pickerHint}>手機：相機直接拍照 / 桌機：選擇檔案。最大 10MB。</span>
+      </label>
+    </div>
+  );
+}
+
+function ImagePane({ url }: { url: string }) {
+  return (
+    <figure className={styles.imagePane}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={url} alt="Card preview" />
+    </figure>
+  );
+}
+
+function formatOcrError(err: { kind: string; message: string; retryAfterMs?: number }): string {
+  switch (err.kind) {
+    case "rate-limit":
+      return `API 流量限制，請 ${Math.ceil((err.retryAfterMs ?? 5000) / 1000)} 秒後再試`;
+    case "network":
+      return `網路錯誤：${err.message}`;
+    case "invalid-response":
+      return "OCR 回傳格式異常，改手動輸入較快";
+    case "unsupported":
+      return "OCR 服務未配置";
+    default:
+      return err.message;
+  }
+}
+
+async function blobToBase64(blob: Blob): Promise<string> {
+  const arrayBuf = await blob.arrayBuffer();
+  const bytes = new Uint8Array(arrayBuf);
+  // btoa only works on latin1; chunk-convert for large payloads safely.
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, Math.min(i + chunkSize, bytes.length)));
+  }
+  return btoa(binary);
+}

--- a/src/components/scan/ScanFlow.tsx
+++ b/src/components/scan/ScanFlow.tsx
@@ -6,7 +6,7 @@ import { useState, useTransition } from "react";
 import { createCardAction } from "@/app/(app)/cards/actions";
 import { scanCardAction } from "@/app/(app)/cards/scan/actions";
 import type { CardCreateInput } from "@/db/schema";
-import type { OcrFields } from "@/lib/ocr";
+import type { OcrFields } from "@/lib/ocr/types";
 
 import { CardFormPrefilled } from "./CardFormPrefilled";
 import styles from "./ScanFlow.module.css";

--- a/src/components/scan/ScanFlow.tsx
+++ b/src/components/scan/ScanFlow.tsx
@@ -200,6 +200,11 @@ function UploadPicker({ onFile }: { onFile: (file: File) => void }) {
 }
 
 function ImagePane({ url }: { url: string }) {
+  // Scheme allowlist — url is always a same-origin blob: from
+  // URL.createObjectURL, but a scheme check keeps XSS analyzers happy and
+  // defends against future refactors that might route signed URLs here.
+  const isSafe = url.startsWith("blob:") || url.startsWith("https://");
+  if (!isSafe) return null;
   return (
     <figure className={styles.imagePane}>
       {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/src/lib/ocr/__tests__/minimax.test.ts
+++ b/src/lib/ocr/__tests__/minimax.test.ts
@@ -1,0 +1,200 @@
+/**
+ * UT for MiniMax OCR provider with mocked fetch — exercises request
+ * shape, response parsing, error handling. Real API calls live in a
+ * separate `minimax.live.test.ts` that only runs when MINIMAX_API_KEY
+ * is set.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { createMinimaxProvider } from "../minimax";
+
+function mockResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+    status: 200,
+    ...init,
+  });
+}
+
+const GOOD_COMPLETION = {
+  choices: [
+    {
+      message: {
+        content: JSON.stringify({
+          nameZh: { value: "陳志明", confidence: 0.9 },
+          nameEn: { value: "Alice Chen", confidence: 0.88 },
+          jobTitleEn: { value: "PM", confidence: 0.8 },
+          phones: [{ label: "mobile", value: "+886-912-345-678", confidence: 0.9 }],
+          emails: [{ label: "work", value: "alice@example.com", confidence: 0.92 }],
+        }),
+      },
+    },
+  ],
+};
+
+describe("minimax provider", () => {
+  it("returns unsupported when MINIMAX_API_KEY missing", async () => {
+    const provider = createMinimaxProvider({
+      apiKey: "",
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+    });
+    const result = await provider.extract({
+      source: { kind: "url", url: "https://img.example/x.jpg" },
+    });
+    if (result.ok) throw new Error("expected not-ok");
+    expect(result.error.kind).toBe("unsupported");
+  });
+
+  it("returns unsupported when source.kind !== 'url'", async () => {
+    const provider = createMinimaxProvider({
+      apiKey: "fake",
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+    });
+    const result = await provider.extract({
+      source: { kind: "buffer", data: Buffer.from([1, 2, 3]), mimeType: "image/jpeg" },
+    });
+    if (result.ok) throw new Error("expected not-ok");
+    expect(result.error.kind).toBe("unsupported");
+  });
+
+  it("posts to chat/completions with system prompt + image_url", async () => {
+    let capturedUrl: string | URL | Request | undefined;
+    let capturedInit: RequestInit | undefined;
+    const fetchImpl = (async (url: unknown, init: unknown) => {
+      capturedUrl = url as string | URL | Request | undefined;
+      capturedInit = init as RequestInit | undefined;
+      return mockResponse(GOOD_COMPLETION);
+    }) as unknown as typeof fetch;
+    const provider = createMinimaxProvider({
+      apiKey: "test-key",
+      baseUrl: "https://fake.minimax/v1",
+      model: "MiniMax-M2.7",
+      fetchImpl,
+    });
+    await provider.extract({
+      source: { kind: "url", url: "https://img.example/card.jpg" },
+    });
+
+    expect(capturedUrl).toBe("https://fake.minimax/v1/chat/completions");
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer test-key");
+    const body = JSON.parse(capturedInit?.body as string);
+    expect(body.model).toBe("MiniMax-M2.7");
+    expect(body.messages[0].role).toBe("system");
+    expect(body.messages[0].content).toMatch(/名片/);
+    expect(body.messages[1].role).toBe("user");
+    expect(body.messages[1].content).toContainEqual({
+      type: "image_url",
+      image_url: { url: "https://img.example/card.jpg" },
+    });
+  });
+
+  it("parses a valid completion into OcrFields", async () => {
+    const provider = createMinimaxProvider({
+      apiKey: "test-key",
+      fetchImpl: (async () => mockResponse(GOOD_COMPLETION)) as unknown as typeof fetch,
+    });
+    const result = await provider.extract({
+      source: { kind: "url", url: "https://img.example/card.jpg" },
+    });
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.fields.nameZh?.value).toBe("陳志明");
+    expect(result.fields.nameEn?.value).toBe("Alice Chen");
+    expect(result.fields.phones[0].value).toBe("+886-912-345-678");
+    expect(result.fields.emails[0].value).toBe("alice@example.com");
+    expect(result.meta.provider).toBe("minimax");
+  });
+
+  it("strips ```json fences from completion text", async () => {
+    const fenced = {
+      choices: [
+        {
+          message: {
+            content:
+              "```json\n" + JSON.stringify({ nameEn: { value: "Bob", confidence: 0.7 } }) + "\n```",
+          },
+        },
+      ],
+    };
+    const provider = createMinimaxProvider({
+      apiKey: "test-key",
+      fetchImpl: (async () => mockResponse(fenced)) as unknown as typeof fetch,
+    });
+    const result = await provider.extract({
+      source: { kind: "url", url: "https://img.example/x.jpg" },
+    });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.fields.nameEn?.value).toBe("Bob");
+  });
+
+  it("surfaces 429 as rate-limit error", async () => {
+    const provider = createMinimaxProvider({
+      apiKey: "test-key",
+      fetchImpl: (async () =>
+        new Response("too many", {
+          status: 429,
+          headers: { "retry-after": "3" },
+        })) as unknown as typeof fetch,
+    });
+    const result = await provider.extract({
+      source: { kind: "url", url: "https://img.example/x.jpg" },
+    });
+    if (result.ok) throw new Error("expected not-ok");
+    expect(result.error.kind).toBe("rate-limit");
+    if (result.error.kind === "rate-limit") {
+      expect(result.error.retryAfterMs).toBe(3000);
+    }
+  });
+
+  it("surfaces non-OK non-429 as network error", async () => {
+    const provider = createMinimaxProvider({
+      apiKey: "test-key",
+      fetchImpl: (async () => new Response("boom", { status: 500 })) as unknown as typeof fetch,
+    });
+    const result = await provider.extract({
+      source: { kind: "url", url: "https://img.example/x.jpg" },
+    });
+    if (result.ok) throw new Error("expected not-ok");
+    expect(result.error.kind).toBe("network");
+    expect(result.error.message).toContain("500");
+  });
+
+  it("returns invalid-response when completion is not JSON", async () => {
+    const provider = createMinimaxProvider({
+      apiKey: "test-key",
+      fetchImpl: (async () =>
+        mockResponse({
+          choices: [{ message: { content: "sorry, no cards here" } }],
+        })) as unknown as typeof fetch,
+    });
+    const result = await provider.extract({
+      source: { kind: "url", url: "https://img.example/x.jpg" },
+    });
+    if (result.ok) throw new Error("expected not-ok");
+    expect(result.error.kind).toBe("invalid-response");
+  });
+
+  it("returns invalid-response when completion JSON fails Zod schema", async () => {
+    const provider = createMinimaxProvider({
+      apiKey: "test-key",
+      fetchImpl: (async () =>
+        mockResponse({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  nameEn: { value: 123, confidence: 2.5 }, // wrong types
+                  phones: "not-an-array",
+                }),
+              },
+            },
+          ],
+        })) as unknown as typeof fetch,
+    });
+    const result = await provider.extract({
+      source: { kind: "url", url: "https://img.example/x.jpg" },
+    });
+    if (result.ok) throw new Error("expected not-ok");
+    expect(result.error.kind).toBe("invalid-response");
+    expect(result.error.message).toContain("schema mismatch");
+  });
+});

--- a/src/lib/ocr/__tests__/post-process.test.ts
+++ b/src/lib/ocr/__tests__/post-process.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { detectMalformedEmails, postProcess } from "../post-process";
+import type { OcrFields } from "../types";
+
+function base(): OcrFields {
+  return { phones: [], emails: [], addresses: [], social: {} };
+}
+
+describe("postProcess", () => {
+  it("drops fields with empty value", () => {
+    const out = postProcess({
+      ...base(),
+      nameZh: { value: "", confidence: 0.5 },
+      nameEn: { value: "Alice", confidence: 0.9 },
+    });
+    expect(out.nameZh).toBeUndefined();
+    expect(out.nameEn?.value).toBe("Alice");
+  });
+
+  it("re-labels phone as mobile when prefixed 09XX", () => {
+    const out = postProcess({
+      ...base(),
+      phones: [{ label: "other", value: "0912-345-678", confidence: 0.9 }],
+    });
+    expect(out.phones[0].label).toBe("mobile");
+  });
+
+  it("re-labels phone as mobile from 行動 hint", () => {
+    const out = postProcess({
+      ...base(),
+      phones: [{ label: "other", value: "行動 0800-111", confidence: 0.5 }],
+    });
+    expect(out.phones[0].label).toBe("mobile");
+  });
+
+  it("re-labels 公司 as office", () => {
+    const out = postProcess({
+      ...base(),
+      phones: [{ label: "other", value: "公司 02-2345-6789", confidence: 0.5 }],
+    });
+    expect(out.phones[0].label).toBe("office");
+  });
+
+  it("re-labels fax", () => {
+    const out = postProcess({
+      ...base(),
+      phones: [{ label: "other", value: "FAX 02-1111-2222", confidence: 0.5 }],
+    });
+    expect(out.phones[0].label).toBe("fax");
+  });
+
+  it("trims whitespace in phone and email values", () => {
+    const out = postProcess({
+      ...base(),
+      phones: [{ label: "mobile", value: "  +886 912 345 678  " }],
+      emails: [{ label: "work", value: "  ALICE@example.com   " }],
+    });
+    expect(out.phones[0].value).toBe("+886 912 345 678");
+    expect(out.emails[0].value).toBe("ALICE@example.com");
+  });
+
+  it("drops emails with empty value", () => {
+    const out = postProcess({
+      ...base(),
+      emails: [
+        { label: "work", value: "alice@ex.com" },
+        { label: "other", value: "" },
+      ],
+    });
+    expect(out.emails).toHaveLength(1);
+  });
+
+  it("is idempotent", () => {
+    const input: OcrFields = {
+      ...base(),
+      nameEn: { value: "Alice", confidence: 0.9 },
+      phones: [{ label: "mobile", value: "+886-912-345-678" }],
+      emails: [{ label: "work", value: "alice@ex.com" }],
+    };
+    const first = postProcess(input);
+    const second = postProcess(first);
+    expect(second).toEqual(first);
+  });
+});
+
+describe("detectMalformedEmails", () => {
+  it("lists emails that don't parse", () => {
+    const out = detectMalformedEmails({
+      ...base(),
+      emails: [
+        { label: "work", value: "good@ex.com" },
+        { label: "other", value: "bad-email" },
+        { label: "other", value: "also@bad" },
+      ],
+    });
+    expect(out).toEqual(["bad-email", "also@bad"]);
+  });
+
+  it("returns empty when all emails look valid", () => {
+    const out = detectMalformedEmails({
+      ...base(),
+      emails: [{ label: "work", value: "alice@ex.com" }],
+    });
+    expect(out).toEqual([]);
+  });
+});

--- a/src/lib/ocr/__tests__/provider-selection.test.ts
+++ b/src/lib/ocr/__tests__/provider-selection.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getOcrProvider } from "../index";
+
+/**
+ * Provider selection is env-driven so prod swaps between MiniMax / stub /
+ * forced override without code changes. Covers the four decision paths in
+ * src/lib/ocr/index.ts so a regression (e.g. forgetting to consult
+ * OCR_PROVIDER) is caught immediately.
+ */
+describe("getOcrProvider — env-driven resolution", () => {
+  const originalProvider = process.env.OCR_PROVIDER;
+  const originalKey = process.env.MINIMAX_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.OCR_PROVIDER;
+    delete process.env.MINIMAX_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalProvider === undefined) delete process.env.OCR_PROVIDER;
+    else process.env.OCR_PROVIDER = originalProvider;
+    if (originalKey === undefined) delete process.env.MINIMAX_API_KEY;
+    else process.env.MINIMAX_API_KEY = originalKey;
+  });
+
+  it("returns stub when no env is set", () => {
+    const provider = getOcrProvider();
+    expect(provider.id).toBe("stub");
+  });
+
+  it("forces stub when OCR_PROVIDER=stub, even with MiniMax key present", () => {
+    process.env.OCR_PROVIDER = "stub";
+    process.env.MINIMAX_API_KEY = "sk-fake";
+    const provider = getOcrProvider();
+    expect(provider.id).toBe("stub");
+  });
+
+  it("forces minimax when OCR_PROVIDER=minimax", () => {
+    process.env.OCR_PROVIDER = "minimax";
+    process.env.MINIMAX_API_KEY = "sk-fake";
+    const provider = getOcrProvider();
+    expect(provider.id).toBe("minimax");
+  });
+
+  it("auto-selects minimax when MINIMAX_API_KEY is set and no override", () => {
+    process.env.MINIMAX_API_KEY = "sk-fake";
+    const provider = getOcrProvider();
+    expect(provider.id).toBe("minimax");
+  });
+
+  it("falls back to stub when MINIMAX_API_KEY is empty string", () => {
+    process.env.MINIMAX_API_KEY = "";
+    const provider = getOcrProvider();
+    expect(provider.id).toBe("stub");
+  });
+});

--- a/src/lib/ocr/index.ts
+++ b/src/lib/ocr/index.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import { createMinimaxProvider } from "./minimax";
+import { createStubProvider } from "./stub";
+import type { OcrProvider } from "./types";
+
+/**
+ * Resolve the active OCR provider. Order:
+ *   1. OCR_PROVIDER env hard-override (useful for E2E with "stub")
+ *   2. MiniMax if MINIMAX_API_KEY is present
+ *   3. Stub (so dev never 500s when keys are missing)
+ */
+export function getOcrProvider(): OcrProvider {
+  const forced = process.env.OCR_PROVIDER;
+  if (forced === "stub") return createStubProvider();
+  if (forced === "minimax") return createMinimaxProvider();
+  if (process.env.MINIMAX_API_KEY) return createMinimaxProvider();
+  return createStubProvider();
+}
+
+export type { OcrProvider, OcrOptions, OcrResult, OcrFields, OcrField, OcrError } from "./types";
+export { LOW_CONFIDENCE_THRESHOLD, isLowConfidence, ocrFieldsSchema } from "./types";

--- a/src/lib/ocr/minimax.ts
+++ b/src/lib/ocr/minimax.ts
@@ -1,0 +1,200 @@
+import "server-only";
+
+import { postProcess } from "./post-process";
+import { SYSTEM_PROMPT_ZH_EN_MIXED, USER_PROMPT_EXTRACT } from "./prompts";
+import { ocrFieldsSchema, type OcrOptions, type OcrProvider, type OcrResult } from "./types";
+
+/**
+ * MiniMax vision-chat OCR provider.
+ *
+ * MiniMax's chat-completion endpoint accepts multimodal content (text +
+ * image_url) and returns a completion. We ask for a strict JSON object
+ * and parse with Zod — anything that doesn't validate becomes an
+ * `invalid-response` error, not a silent bad-shape pass.
+ *
+ * Model name is configurable via MINIMAX_MODEL so the user can swap
+ * between MiniMax-M2.7 (if exists), abab6.5s-chat, MiniMax-VL-01 etc.
+ * without code change.
+ */
+
+const DEFAULT_BASE_URL = "https://api.minimax.chat/v1";
+const DEFAULT_MODEL = "MiniMax-M2.7";
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+interface MiniMaxChatResponse {
+  id?: string;
+  choices?: Array<{
+    message?: {
+      content?: string;
+    };
+  }>;
+}
+
+interface BuildRequestArgs {
+  imageUrl: string;
+  model: string;
+}
+
+function buildChatRequestBody({ imageUrl, model }: BuildRequestArgs): Record<string, unknown> {
+  return {
+    model,
+    temperature: 0.1,
+    max_tokens: 1500,
+    messages: [
+      {
+        role: "system",
+        content: SYSTEM_PROMPT_ZH_EN_MIXED,
+      },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: USER_PROMPT_EXTRACT },
+          { type: "image_url", image_url: { url: imageUrl } },
+        ],
+      },
+    ],
+  };
+}
+
+function extractJsonFromCompletion(raw: string): unknown {
+  // Models sometimes wrap the JSON in ```json ... ``` fences — strip them.
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const inner = fenced ? fenced[1] : trimmed;
+  return JSON.parse(inner);
+}
+
+export function createMinimaxProvider(overrides?: {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+  fetchImpl?: typeof fetch;
+}): OcrProvider {
+  const apiKey = overrides?.apiKey ?? process.env.MINIMAX_API_KEY ?? "";
+  const baseUrl = overrides?.baseUrl ?? process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = overrides?.model ?? process.env.MINIMAX_MODEL ?? DEFAULT_MODEL;
+  const fetchImpl = overrides?.fetchImpl ?? fetch;
+
+  return {
+    id: "minimax",
+    async extract(options: OcrOptions): Promise<OcrResult> {
+      if (!apiKey) {
+        return {
+          ok: false,
+          error: { kind: "unsupported", message: "MINIMAX_API_KEY not set" },
+        };
+      }
+      if (options.source.kind !== "url") {
+        return {
+          ok: false,
+          error: {
+            kind: "unsupported",
+            message:
+              "MiniMax provider requires a signed image URL, not raw buffer. Upload to Storage first.",
+          },
+        };
+      }
+
+      const startedAt = Date.now();
+      const body = buildChatRequestBody({
+        imageUrl: options.source.url,
+        model,
+      });
+      const abort = new AbortController();
+      const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      const timer = setTimeout(() => abort.abort(), timeoutMs);
+      try {
+        const res = await fetchImpl(`${baseUrl}/chat/completions`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+          signal: abort.signal,
+        });
+        if (res.status === 429) {
+          const retryAfter = Number(res.headers.get("retry-after") ?? 0) * 1000 || undefined;
+          return {
+            ok: false,
+            error: {
+              kind: "rate-limit",
+              message: `MiniMax 429; retry after ${retryAfter ?? "?"}ms`,
+              retryAfterMs: retryAfter,
+            },
+          };
+        }
+        if (!res.ok) {
+          const text = await res.text().catch(() => "");
+          return {
+            ok: false,
+            error: {
+              kind: "network",
+              message: `MiniMax ${res.status}: ${text.slice(0, 200)}`,
+            },
+          };
+        }
+        const json = (await res.json()) as MiniMaxChatResponse;
+        const rawText = json.choices?.[0]?.message?.content;
+        if (!rawText) {
+          return {
+            ok: false,
+            error: {
+              kind: "invalid-response",
+              message: "empty completion body",
+              raw: json,
+            },
+          };
+        }
+        let parsed: unknown;
+        try {
+          parsed = extractJsonFromCompletion(rawText);
+        } catch (err) {
+          return {
+            ok: false,
+            error: {
+              kind: "invalid-response",
+              message: `completion was not JSON: ${(err as Error).message}`,
+              raw: rawText,
+            },
+          };
+        }
+        const zodResult = ocrFieldsSchema.safeParse(parsed);
+        if (!zodResult.success) {
+          return {
+            ok: false,
+            error: {
+              kind: "invalid-response",
+              message: `schema mismatch: ${zodResult.error.issues
+                .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
+                .join("; ")}`,
+              raw: parsed,
+            },
+          };
+        }
+        const fields = postProcess(zodResult.data);
+        return {
+          ok: true,
+          fields,
+          meta: {
+            provider: "minimax",
+            model,
+            durationMs: Date.now() - startedAt,
+            rawResponse: rawText,
+          },
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          ok: false,
+          error: {
+            kind: msg.includes("abort") ? "network" : "unknown",
+            message: msg,
+          },
+        };
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}

--- a/src/lib/ocr/post-process.ts
+++ b/src/lib/ocr/post-process.ts
@@ -1,0 +1,82 @@
+import type { OcrFields } from "./types";
+
+/**
+ * Post-processing rules applied after raw OCR output lands. Strips obvious
+ * nonsense (empty strings, extra whitespace), re-labels phones when the
+ * label is missing-but-inferable (e.g. "行動 0912..." → mobile), and flags
+ * low-confidence e-mails that don't even parse.
+ *
+ * Keep this idempotent + pure — a lot of downstream logic depends on
+ * rerunning it safely.
+ */
+
+const MOBILE_HINTS_ZH = ["行動", "手機"];
+const OFFICE_HINTS_ZH = ["公司", "辦公", "電話"];
+const HOME_HINTS_ZH = ["住家", "宅"];
+const FAX_HINTS = ["fax", "傳真"];
+
+function dropEmptyTextFields<T extends Record<string, unknown>>(obj: T): T {
+  const out = { ...obj } as Record<string, unknown>;
+  for (const [key, val] of Object.entries(out)) {
+    if (val && typeof val === "object" && "value" in val) {
+      const v = val as { value: unknown };
+      if (typeof v.value !== "string" || v.value.trim() === "") {
+        delete out[key];
+      }
+    }
+  }
+  return out as T;
+}
+
+function normalizePhoneLabel(raw: string, fallback = "other"): string {
+  const s = raw.toLowerCase();
+  if (MOBILE_HINTS_ZH.some((h) => raw.includes(h)) || /^09\d/.test(s)) return "mobile";
+  if (OFFICE_HINTS_ZH.some((h) => raw.includes(h))) return "office";
+  if (HOME_HINTS_ZH.some((h) => raw.includes(h))) return "home";
+  if (FAX_HINTS.some((h) => s.includes(h.toLowerCase()))) return "fax";
+  return fallback;
+}
+
+function isLikelyEmail(s: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s.trim());
+}
+
+export function postProcess(fields: OcrFields): OcrFields {
+  const cleaned = dropEmptyTextFields(fields);
+
+  // Phones: normalize label
+  cleaned.phones = (cleaned.phones ?? []).map((p) => ({
+    ...p,
+    label: (normalizePhoneLabel(p.value, p.label) ?? p.label) as
+      | "mobile"
+      | "office"
+      | "home"
+      | "fax"
+      | "other",
+    value: p.value.trim(),
+  }));
+
+  // Emails: strip whitespace, drop obviously bad entries
+  cleaned.emails = (cleaned.emails ?? [])
+    .map((e) => ({ ...e, value: e.value.trim() }))
+    .filter((e) => e.value !== "");
+
+  // Social: drop whitespace
+  if (cleaned.social) {
+    for (const key of Object.keys(cleaned.social)) {
+      const k = key as keyof typeof cleaned.social;
+      const f = cleaned.social[k];
+      if (f && typeof f.value === "string") {
+        f.value = f.value.trim();
+      }
+    }
+  }
+
+  return cleaned;
+}
+
+/** Returns email values that look malformed — surface these as low-confidence
+ *  in the review UI so the user fixes them before saving. */
+export function detectMalformedEmails(fields: OcrFields): string[] {
+  return (fields.emails ?? []).map((e) => e.value).filter((v) => v && !isLikelyEmail(v));
+}

--- a/src/lib/ocr/prompts.ts
+++ b/src/lib/ocr/prompts.ts
@@ -1,0 +1,38 @@
+/**
+ * Prompt templates for business-card OCR. Kept here so we can tune the
+ * wording without touching provider impls.
+ */
+
+export const SYSTEM_PROMPT_ZH_EN_MIXED = `你是一個專門辨識東亞與英文混合名片的 OCR 助手。
+
+請從提供的名片影像中辨識下列欄位，並以 **嚴格的 JSON 物件** 回覆，
+**不加任何文字、註解或 markdown 程式碼標記**：
+
+{
+  "nameZh": { "value": "中文姓名", "confidence": 0.0-1.0 } | null,
+  "nameEn": { "value": "English name", "confidence": 0.0-1.0 } | null,
+  "jobTitleZh": { ... } | null,
+  "jobTitleEn": { ... } | null,
+  "department": { ... } | null,
+  "companyZh": { ... } | null,
+  "companyEn": { ... } | null,
+  "companyWebsite": { "value": "https://...", "confidence": ... } | null,
+  "phones": [{ "label": "mobile"|"office"|"home"|"fax"|"other", "value": "+886-...", "confidence": ... }],
+  "emails": [{ "label": "work"|"personal"|"other", "value": "name@example.com", "confidence": ... }],
+  "social": {
+    "lineId": { "value": "...", "confidence": ... } | null,
+    "wechatId": { ... } | null,
+    "linkedinUrl": { ... } | null
+  }
+}
+
+規則：
+- 若欄位在名片上找不到，回傳 null（不要編造）
+- 台灣手機格式 09XX-XXX-XXX；其它地區保留原格式
+- 辨識不清或模糊的欄位，confidence 必須小於 0.7
+- 完全辨識不出來的值不要填進 value，直接用 null
+- phones / emails 陣列若無值，回傳 []
+- 不要包含任何 \`\`\`json 或其他 markdown 標記
+`;
+
+export const USER_PROMPT_EXTRACT = "請辨識這張名片。";

--- a/src/lib/ocr/stub.ts
+++ b/src/lib/ocr/stub.ts
@@ -1,4 +1,4 @@
-import type { OcrOptions, OcrProvider, OcrResult } from "./types";
+import type { OcrProvider, OcrResult } from "./types";
 
 /**
  * Stub provider used for E2E / local dev so the OCR flow can be exercised
@@ -9,7 +9,7 @@ export function createStubProvider(opts?: { delayMs?: number }): OcrProvider {
   const delayMs = opts?.delayMs ?? 50;
   return {
     id: "stub",
-    async extract(_options: OcrOptions): Promise<OcrResult> {
+    async extract(): Promise<OcrResult> {
       await new Promise((r) => setTimeout(r, delayMs));
       return {
         ok: true,

--- a/src/lib/ocr/stub.ts
+++ b/src/lib/ocr/stub.ts
@@ -1,0 +1,33 @@
+import type { OcrOptions, OcrProvider, OcrResult } from "./types";
+
+/**
+ * Stub provider used for E2E / local dev so the OCR flow can be exercised
+ * without real API calls. Returns a fixed "Alice Chen" card after a short
+ * simulated latency.
+ */
+export function createStubProvider(opts?: { delayMs?: number }): OcrProvider {
+  const delayMs = opts?.delayMs ?? 50;
+  return {
+    id: "stub",
+    async extract(_options: OcrOptions): Promise<OcrResult> {
+      await new Promise((r) => setTimeout(r, delayMs));
+      return {
+        ok: true,
+        fields: {
+          nameZh: { value: "王小明", confidence: 0.92 },
+          nameEn: { value: "Alice Chen", confidence: 0.95 },
+          jobTitleEn: { value: "Product Manager", confidence: 0.88 },
+          companyEn: { value: "ACME Tech", confidence: 0.91 },
+          phones: [{ label: "mobile", value: "+886-912-345-678", confidence: 0.9 }],
+          emails: [{ label: "work", value: "alice@acme.example", confidence: 0.93 }],
+          addresses: [],
+          social: {},
+        },
+        meta: {
+          provider: "stub",
+          durationMs: delayMs,
+        },
+      };
+    },
+  };
+}

--- a/src/lib/ocr/types.ts
+++ b/src/lib/ocr/types.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+
+/**
+ * OCR provider contract — shared by MiniMax (primary), GPT-4o (fallback),
+ * and future local providers. Kept small so switching provider is just
+ * swapping the implementation module.
+ */
+
+export type ProviderId = "minimax" | "openai" | "stub";
+
+export interface OcrOptions {
+  /** Image source — Buffer (server-side) or URL (if provider accepts remote). */
+  source: { kind: "buffer"; data: Buffer; mimeType: string } | { kind: "url"; url: string };
+  /** Language hint to bias multilingual models. Defaults to "mixed". */
+  hintLanguage?: "zh-TW" | "zh-CN" | "en" | "ja" | "mixed";
+  /** Request timeout in ms. */
+  timeoutMs?: number;
+}
+
+export interface OcrProvider {
+  readonly id: ProviderId;
+  extract(options: OcrOptions): Promise<OcrResult>;
+}
+
+/** Result envelope — always structured so callers can pattern-match. */
+export type OcrResult =
+  | { ok: true; fields: OcrFields; meta: OcrMeta }
+  | { ok: false; error: OcrError };
+
+export interface OcrMeta {
+  provider: ProviderId;
+  model?: string;
+  durationMs: number;
+  rawResponse?: unknown;
+}
+
+export type OcrError =
+  | { kind: "network"; message: string }
+  | { kind: "rate-limit"; message: string; retryAfterMs?: number }
+  | { kind: "invalid-response"; message: string; raw?: unknown }
+  | { kind: "unsupported"; message: string }
+  | { kind: "unknown"; message: string };
+
+/**
+ * Fields the OCR layer extracts from a card image. Shape mirrors the
+ * user-facing CardCreateInput so pre-fill on the review form is a
+ * near-direct map. Every field carries its own confidence so the UI can
+ * highlight anything < 0.7 for manual review.
+ *
+ * `value` is the OCR-suggested string, `confidence` is 0..1 or null if
+ * the provider doesn't quote one.
+ */
+export const ocrFieldSchema = z.object({
+  value: z.string(),
+  confidence: z.number().min(0).max(1).nullable().optional(),
+});
+export type OcrField = z.infer<typeof ocrFieldSchema>;
+
+export const ocrFieldsSchema = z.object({
+  nameZh: ocrFieldSchema.optional(),
+  nameEn: ocrFieldSchema.optional(),
+  namePhonetic: ocrFieldSchema.optional(),
+  jobTitleZh: ocrFieldSchema.optional(),
+  jobTitleEn: ocrFieldSchema.optional(),
+  department: ocrFieldSchema.optional(),
+  companyZh: ocrFieldSchema.optional(),
+  companyEn: ocrFieldSchema.optional(),
+  companyWebsite: ocrFieldSchema.optional(),
+  phones: z
+    .array(
+      z.object({
+        label: z.enum(["mobile", "office", "home", "fax", "other"]).default("other"),
+        value: z.string(),
+        confidence: z.number().min(0).max(1).nullable().optional(),
+      }),
+    )
+    .default([]),
+  emails: z
+    .array(
+      z.object({
+        label: z.enum(["work", "personal", "other"]).default("work"),
+        value: z.string(),
+        confidence: z.number().min(0).max(1).nullable().optional(),
+      }),
+    )
+    .default([]),
+  addresses: z
+    .array(
+      z.object({
+        line1: z.string().optional(),
+        city: z.string().optional(),
+        region: z.string().optional(),
+        country: z.string().optional(),
+        postalCode: z.string().optional(),
+        confidence: z.number().min(0).max(1).nullable().optional(),
+      }),
+    )
+    .default([]),
+  social: z
+    .object({
+      lineId: ocrFieldSchema.optional(),
+      wechatId: ocrFieldSchema.optional(),
+      linkedinUrl: ocrFieldSchema.optional(),
+      twitterHandle: ocrFieldSchema.optional(),
+      websiteUrl: ocrFieldSchema.optional(),
+    })
+    .default({}),
+});
+export type OcrFields = z.infer<typeof ocrFieldsSchema>;
+
+export const LOW_CONFIDENCE_THRESHOLD = 0.7;
+
+export function isLowConfidence(f: OcrField | undefined): boolean {
+  if (!f) return false;
+  if (f.confidence === null || f.confidence === undefined) return false;
+  return f.confidence < LOW_CONFIDENCE_THRESHOLD;
+}

--- a/src/lib/storage/card-images.ts
+++ b/src/lib/storage/card-images.ts
@@ -1,0 +1,104 @@
+import "server-only";
+
+import sharp from "sharp";
+
+import { getAdminStorage } from "@/lib/firebase/server";
+
+/**
+ * Card-image storage pipeline — accepts a raw uploaded image buffer,
+ * compresses to WebP (quality 82, max 2000px long edge), uploads to
+ * users/{uid}/card-images/{uuid}.webp, and returns the path plus a
+ * short-lived signed URL the OCR provider can fetch.
+ *
+ * Filename contract (UUID v4 + .webp) matches the Storage Rules regex
+ * so unauthorized paths are rejected server-side.
+ */
+
+export interface UploadOptions {
+  uid: string;
+  fileBuffer: Buffer;
+  originalName?: string;
+  mimeType: string;
+}
+
+export interface UploadResult {
+  path: string; // storage path, e.g. users/{uid}/card-images/{uuid}.webp
+  bucket: string;
+  signedUrl: string; // ~15 min expiry
+  width: number;
+  height: number;
+  bytes: number;
+}
+
+const SIGNED_URL_EXPIRY_MS = 15 * 60 * 1000; // 15 minutes
+const MAX_DIMENSION = 2000;
+const WEBP_QUALITY = 82;
+
+export async function uploadCardImage(opts: UploadOptions): Promise<UploadResult> {
+  if (!opts.mimeType.startsWith("image/")) {
+    throw new Error(`Unsupported content type: ${opts.mimeType}`);
+  }
+
+  // Resize + encode to WebP.
+  const pipeline = sharp(opts.fileBuffer, { failOn: "error" })
+    .rotate() // EXIF-aware orientation
+    .resize({
+      width: MAX_DIMENSION,
+      height: MAX_DIMENSION,
+      fit: "inside",
+      withoutEnlargement: true,
+    })
+    .webp({ quality: WEBP_QUALITY });
+  const { data: webp, info } = await pipeline.toBuffer({ resolveWithObject: true });
+
+  const uuid = crypto.randomUUID();
+  const path = `users/${opts.uid}/card-images/${uuid}.webp`;
+  const bucket = getAdminStorage().bucket();
+  const file = bucket.file(path);
+  await file.save(webp, {
+    contentType: "image/webp",
+    metadata: {
+      cacheControl: "private, max-age=3600",
+      metadata: {
+        uploadedBy: opts.uid,
+        originalName: opts.originalName ?? "",
+      },
+    },
+    resumable: false,
+  });
+
+  const [signedUrl] = await file.getSignedUrl({
+    action: "read",
+    expires: Date.now() + SIGNED_URL_EXPIRY_MS,
+    version: "v4",
+  });
+
+  return {
+    path,
+    bucket: bucket.name,
+    signedUrl,
+    width: info.width,
+    height: info.height,
+    bytes: webp.byteLength,
+  };
+}
+
+/** Mint a fresh signed URL for a previously uploaded image. */
+export async function signedUrlFor(path: string): Promise<string> {
+  const bucket = getAdminStorage().bucket();
+  const [url] = await bucket.file(path).getSignedUrl({
+    action: "read",
+    expires: Date.now() + SIGNED_URL_EXPIRY_MS,
+    version: "v4",
+  });
+  return url;
+}
+
+/** Delete an uploaded image. Safe to call for missing paths. */
+export async function deleteCardImage(path: string): Promise<void> {
+  const bucket = getAdminStorage().bucket();
+  await bucket
+    .file(path)
+    .delete({ ignoreNotFound: true })
+    .catch(() => {});
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,16 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import { SESSION_COOKIE_NAME } from "@/lib/firebase/shared";
 
-const PUBLIC_PATHS = new Set<string>(["/login", "/unauthorized", "/api/health"]);
+const PUBLIC_PATHS = new Set<string>([
+  "/login",
+  "/unauthorized",
+  "/api/health",
+  // PWA metadata — must be reachable without a session so the browser can
+  // install the app from the login page.
+  "/manifest.webmanifest",
+  "/icon",
+  "/apple-icon",
+]);
 
 function isPublic(pathname: string): boolean {
   if (PUBLIC_PATHS.has(pathname)) return true;


### PR DESCRIPTION
## Summary

Closes #21

Phase 3 ships the three pieces that turn the skeleton into a daily-usable tool:

- **OCR pipeline** — MiniMax M2.7 vision chat (primary) with deterministic stub (fallback for dev / E2E). Clean provider contract so GPT-4o or local models drop in without touching callers.
- **Scan flow** — upload → sharp-compressed WebP + signed URL (15 min) → OCR → RHF review form with low-confidence visual markers, smart templates (\`在 X 認識的，聊到 ___\`), and voice input for \`whyRemember\`.
- **PWA** — manifest + dynamic 512/180 PNG icons via \`ImageResponse\`, theme color, standalone display, public pre-auth reachability. Installable on Mac mini via Tailscale Serve.

## Phase breakdown

### P3A — OCR contract + providers (commit ccdfefb)
- \`src/lib/ocr/types.ts\` — \`OcrProvider\`, \`OcrFields\` (Zod), \`OcrResult\` envelope, \`LOW_CONFIDENCE_THRESHOLD = 0.7\`, \`isLowConfidence\` helper
- \`src/lib/ocr/prompts.ts\` — Chinese-English business-card system prompt demanding strict JSON output
- \`src/lib/ocr/post-process.ts\` — idempotent normalization: drop empty values, phone re-labeling by pattern (09XX → mobile, 行動/公司/fax hints), email trim, malformed email detection
- \`src/lib/ocr/minimax.ts\` — MiniMax chat-completion impl via \`/v1/chat/completions\` with \`image_url\`; handles \`\`\`json fences, 30s timeout, error taxonomy (unsupported / rate-limit / network / invalid-response / unknown)
- \`src/lib/ocr/stub.ts\` — deterministic fake returning Alice Chen card for E2E / dev
- \`src/lib/ocr/index.ts\` — \`getOcrProvider()\` resolves from \`OCR_PROVIDER\` env or \`MINIMAX_API_KEY\` presence

### P3B + P3C — Upload pipeline, review form, voice (commit 5ba589f)
- \`src/lib/storage/card-images.ts\` — sharp → WebP (q82, max 2000px, EXIF-aware rotate), signed URLs (15 min), path \`users/{uid}/card-images/{uuid}.webp\`
- \`src/app/(app)/cards/scan/actions.ts\` — \`scanCardAction\` safe-action: base64 → upload → OCR → returns \`ok/failed\` envelope
- \`src/components/scan/ScanFlow.tsx\` — phase state machine: \`idle → uploading → review → ocr-failed\`
- \`src/components/scan/CardFormPrefilled.tsx\` — RHF form pre-filled from \`OcrFields\`; low-confidence fields get a yellow underline; template suggestions; VoiceCapture integrated for \`whyRemember\`
- \`src/components/capture/VoiceCapture.tsx\` — Web Speech API client component with \`useSyncExternalStore\` for SSR-safe feature detection (avoids \`setState\`-in-effect), language cycling (zh-TW / zh-CN / en-US), graceful unsupported fallback

### P3D — PWA (commit c5a688d)
- \`src/app/manifest.ts\` — webmanifest: name, start_url \`/\`, display \`standalone\`, hex theme color matched to \`oklch\` ink / paper palette
- \`src/app/icon.tsx\` / \`src/app/apple-icon.tsx\` — \`ImageResponse\` dynamic 512 / 180 PNG icons (Satori; oklch not supported so uses matched hex)
- \`src/app/layout.tsx\` — \`viewport\` export with light / dark \`themeColor\`, manifest link, \`appleWebApp\` capable
- Scope bound client imports: \`OcrFields\` + \`isLowConfidence\` now import from \`@/lib/ocr/types\` directly so the client bundle no longer pulls \`server-only\` minimax provider

### P3E — Tests + middleware (commit fd82e44)
- \`src/lib/ocr/__tests__/provider-selection.test.ts\` — 5 cases covering all four decision paths in \`getOcrProvider()\`
- \`e2e/pwa.spec.ts\` — asserts \`/manifest.webmanifest\` returns installable-shaped JSON, \`/icon\` + \`/apple-icon\` return real PNG bytes
- \`src/middleware.ts\` — expose \`/manifest.webmanifest\`, \`/icon\`, \`/apple-icon\` without session so browser can install from \`/login\`

## Test plan

- [x] \`pnpm lint\` — clean
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` — 100 passed | 15 skipped (9 files) including 24 OCR UT
- [x] \`pnpm build\` — all routes compile; \`/icon\`, \`/apple-icon\`, \`/manifest.webmanifest\` prerendered as static
- [ ] CI: existing \`e2e-crud\` job continues to pass
- [ ] Manual (after merge + local): upload a real card, verify MiniMax extraction + low-confidence highlights + voice capture
- [ ] Manual (post-deploy): install prompt fires on iOS Safari + Chrome Android via Tailscale

## Notes

- \`OCR_PROVIDER=stub\` overrides even if \`MINIMAX_API_KEY\` is set — use this for CI and local dev so we never ping MiniMax during tests.
- \`MINIMAX_API_KEY\` is still the primary resolver; if unset we fall through to stub (never 500s in dev).
- \`icon.tsx\` and \`apple-icon.tsx\` use hex colors instead of oklch because Satori (the SVG-to-PNG renderer) doesn't parse \`oklch()\`.