### PR TITLE
Phase 7: Mac mini deployment — PM2 + Tailscale sub-path + Typesense prod

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,70 @@
+# ============================================================
+# namecard-web — Production Environment Template
+# ============================================================
+# 1. Copy this file to .env.production
+#    cp .env.production.example .env.production
+# 2. Fill in every blank value.
+# 3. NEVER commit .env.production — it is gitignored.
+# ============================================================
+
+# ------------------------------------------------------------
+# Firebase Admin SDK (server-only)
+# ------------------------------------------------------------
+# Path to the service account JSON downloaded from Firebase Console →
+# Project Settings → Service Accounts → Generate new private key.
+# Recommended location: ~/.config/namecard/service-account.json
+# (outside the repo, not world-readable)
+GOOGLE_APPLICATION_CREDENTIALS=/Users/openclaw/.config/namecard/service-account.json
+FIREBASE_ADMIN_PROJECT_ID=namecard-web-prd
+
+# ------------------------------------------------------------
+# Firebase Web SDK (public / client-side)
+# ------------------------------------------------------------
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=namecard-web-prd.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=namecard-web-prd
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=namecard-web-prd.appspot.com
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
+NEXT_PUBLIC_FIREBASE_APP_ID=
+
+# ------------------------------------------------------------
+# Auth whitelist
+# ------------------------------------------------------------
+# Comma-separated list of Google-account emails permitted to sign in.
+# Example: ALLOWED_EMAILS=alice@example.com,bob@example.com
+ALLOWED_EMAILS=
+
+# ------------------------------------------------------------
+# Session cookie secret
+# ------------------------------------------------------------
+# 32+ random characters; generate with:
+#   openssl rand -base64 32
+SESSION_COOKIE_SECRET=
+
+# ------------------------------------------------------------
+# OCR
+# ------------------------------------------------------------
+OCR_PROVIDER=minimax
+MINIMAX_API_KEY=
+MINIMAX_MODEL=MiniMax-M2.7
+MINIMAX_BASE_URL=https://api.minimax.chat/v1
+
+# ------------------------------------------------------------
+# Typesense (production — loopback, Docker)
+# ------------------------------------------------------------
+TYPESENSE_HOST=127.0.0.1
+TYPESENSE_PORT=8108
+TYPESENSE_PROTOCOL=http
+# Generate with: openssl rand -hex 32
+TYPESENSE_API_KEY=
+
+# ------------------------------------------------------------
+# Sub-path routing (Tailscale Serve)
+# ------------------------------------------------------------
+# Must match the --set-path value used in `tailscale serve`.
+NAMECARD_BASE_PATH=/namecard-web
+
+# ------------------------------------------------------------
+# Next.js / telemetry
+# ------------------------------------------------------------
+NEXT_TELEMETRY_DISABLED=1

--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,9 @@ storybook-static/
 *.tgz
 *.rar
 *.7z
+
+# ==================== Phase 7 production artifacts ====================
+# Real secrets — never commit
+.env.production
+# Typesense production data volume (bind-mount)
+.typesense-data-prod/

--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ src/
 - [ ] Phase 6：Workspace 邀請 UI
 - [ ] Phase 7：部署 + 監控 + RUNBOOK
 
+## 🚢 部署
+
+生產環境部署至 Mac mini M4，透過 PM2 + Tailscale Serve 提供服務。
+
+- 目標 URL：`https://mac-mini.tailde842d.ts.net/namecard-web/`
+- 詳細部署流程、排查指南、備份與災難還原：[RUNBOOK.md](./RUNBOOK.md)
+
 ## 📜 License
 
 MIT — 見 [LICENSE](./LICENSE)

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -29,7 +29,7 @@ Tailscale MagicDNS (HTTPS)
   tailscale serve (TLS termination + path routing)
         │
         ▼
-  localhost:3013  ← PM2: namecard-web (Next.js)
+  localhost:3014  ← PM2: namecard-web (Next.js)
         │
         ├── Firebase Admin SDK → Firestore / Auth / Storage (namecard-web-prd)
         └── localhost:8108    ← Docker: namecard-typesense
@@ -37,7 +37,7 @@ Tailscale MagicDNS (HTTPS)
 
 | 元件       | 管理工具                      | Port                     |
 | ---------- | ----------------------------- | ------------------------ |
-| Next.js    | PM2 (`namecard-web`)          | 3013                     |
+| Next.js    | PM2 (`namecard-web`)          | 3014                     |
 | Typesense  | Docker (`namecard-typesense`) | 127.0.0.1:8108           |
 | TLS + 路由 | Tailscale Serve               | 443 (public via tailnet) |
 | Firebase   | Google Cloud (外部)           | —                        |
@@ -88,7 +88,7 @@ pm2 startup launchd
 # → 依照輸出的指令貼上執行（通常需要 sudo）
 
 # 8. 設定 Tailscale Serve 路由
-tailscale serve --bg --set-path=/namecard-web http://localhost:3013
+tailscale serve --bg --set-path=/namecard-web http://localhost:3014
 
 # 9. 健康檢查
 scripts/verify-deploy.sh
@@ -133,7 +133,7 @@ scripts/verify-deploy.sh
 
 1. PM2 `namecard-web` 狀態為 online
 2. Docker `namecard-typesense` container 正在執行
-3. `http://localhost:3013/namecard-web/api/health` 回應 HTTP 200
+3. `http://localhost:3014/namecard-web/api/health` 回應 HTTP 200
 4. `tailscale serve status` 包含 `/namecard-web` 路由
 5. `http://127.0.0.1:8108/health` 回應 `{"ok":true}`
 
@@ -151,7 +151,7 @@ pm2 logs namecard-web --lines 100
 
 | 症狀                                       | 排查                                                   |
 | ------------------------------------------ | ------------------------------------------------------ |
-| `PORT 3013 already in use`                 | `lsof -i :3013` 找出佔用 PID → `kill <PID>`            |
+| `PORT 3014 already in use`                 | `lsof -i :3014` 找出佔用 PID → `kill <PID>`            |
 | `GOOGLE_APPLICATION_CREDENTIALS not found` | 確認 `.env.production` 中路徑正確且檔案存在            |
 | `SESSION_COOKIE_SECRET too short`          | 確認 secret ≥ 32 字元                                  |
 | `basePath` 資源 404                        | 確認 build 時有設定 `NAMECARD_BASE_PATH=/namecard-web` |
@@ -173,7 +173,7 @@ docker compose -f docker-compose.prod.yml \
 tailscale serve status
 
 # 重新設定
-tailscale serve --bg --set-path=/namecard-web http://localhost:3013
+tailscale serve --bg --set-path=/namecard-web http://localhost:3014
 
 # 驗證
 curl -s https://mac-mini.tailde842d.ts.net/namecard-web/api/health
@@ -272,7 +272,7 @@ pm2 save
 pm2 startup launchd
 
 # 8. Tailscale Serve
-tailscale serve --bg --set-path=/namecard-web http://localhost:3013
+tailscale serve --bg --set-path=/namecard-web http://localhost:3014
 
 # 9. 驗證
 scripts/verify-deploy.sh
@@ -318,7 +318,7 @@ docker exec -it namecard-typesense sh    # 進入 container shell
 
 ```bash
 tailscale serve status                  # 查看 serve 設定
-tailscale serve --bg --set-path=/namecard-web http://localhost:3013
+tailscale serve --bg --set-path=/namecard-web http://localhost:3014
 tailscale serve --https=443 off         # 移除所有 serve（謹慎使用）
 ```
 
@@ -334,7 +334,7 @@ npx firebase deploy --only storage
 ```bash
 scripts/verify-deploy.sh
 # 或手動
-curl -s http://localhost:3013/namecard-web/api/health
+curl -s http://localhost:3014/namecard-web/api/health
 curl -s http://127.0.0.1:8108/health
 pm2 list
 docker ps | grep namecard

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -88,7 +88,13 @@ pm2 startup launchd
 # → 依照輸出的指令貼上執行（通常需要 sudo）
 
 # 8. 設定 Tailscale Serve 路由
-tailscale serve --bg --set-path=/namecard-web http://localhost:3014
+#
+# 重要：upstream URL 必須包含 /namecard-web 路徑。
+# Tailscale Serve 會將傳入的 /namecard-web 前綴剝除後再轉發；
+# 若 upstream 不帶此路徑，Next.js（basePath: "/namecard-web"）
+# 只會收到裸路徑並回傳 404。帶上路徑後，剝除前綴與 basePath 對齊，
+# 確保 Next.js 正確回應所有請求。
+tailscale serve --bg --set-path=/namecard-web http://localhost:3014/namecard-web
 
 # 9. 健康檢查
 scripts/verify-deploy.sh
@@ -173,7 +179,7 @@ docker compose -f docker-compose.prod.yml \
 tailscale serve status
 
 # 重新設定
-tailscale serve --bg --set-path=/namecard-web http://localhost:3014
+tailscale serve --bg --set-path=/namecard-web http://localhost:3014/namecard-web
 
 # 驗證
 curl -s https://mac-mini.tailde842d.ts.net/namecard-web/api/health
@@ -272,7 +278,7 @@ pm2 save
 pm2 startup launchd
 
 # 8. Tailscale Serve
-tailscale serve --bg --set-path=/namecard-web http://localhost:3014
+tailscale serve --bg --set-path=/namecard-web http://localhost:3014/namecard-web
 
 # 9. 驗證
 scripts/verify-deploy.sh
@@ -318,7 +324,7 @@ docker exec -it namecard-typesense sh    # 進入 container shell
 
 ```bash
 tailscale serve status                  # 查看 serve 設定
-tailscale serve --bg --set-path=/namecard-web http://localhost:3014
+tailscale serve --bg --set-path=/namecard-web http://localhost:3014/namecard-web
 tailscale serve --https=443 off         # 移除所有 serve（謹慎使用）
 ```
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,341 @@
+# namecard-web 運維手冊 (RUNBOOK)
+
+> 目標 URL：**https://mac-mini.tailde842d.ts.net/namecard-web/**
+> 機器：Mac mini M4（macOS Darwin 25.x）
+> 管理帳號：openclaw
+
+---
+
+## 目錄
+
+1. [服務架構總覽](#1-服務架構總覽)
+2. [首次部署（First-time Deploy）](#2-首次部署)
+3. [常規部署（git pull → rebuild → reload）](#3-常規部署)
+4. [健康檢查](#4-健康檢查)
+5. [常見問題排查](#5-常見問題排查)
+6. [備份與還原](#6-備份與還原)
+7. [災難還原（RTO < 2h）](#7-災難還原)
+8. [常用指令速查](#8-常用指令速查)
+
+---
+
+## 1. 服務架構總覽
+
+```
+Tailscale MagicDNS (HTTPS)
+  └── mac-mini.tailde842d.ts.net/namecard-web/*
+        │
+        ▼
+  tailscale serve (TLS termination + path routing)
+        │
+        ▼
+  localhost:3013  ← PM2: namecard-web (Next.js)
+        │
+        ├── Firebase Admin SDK → Firestore / Auth / Storage (namecard-web-prd)
+        └── localhost:8108    ← Docker: namecard-typesense
+```
+
+| 元件       | 管理工具                      | Port                     |
+| ---------- | ----------------------------- | ------------------------ |
+| Next.js    | PM2 (`namecard-web`)          | 3013                     |
+| Typesense  | Docker (`namecard-typesense`) | 127.0.0.1:8108           |
+| TLS + 路由 | Tailscale Serve               | 443 (public via tailnet) |
+| Firebase   | Google Cloud (外部)           | —                        |
+
+---
+
+## 2. 首次部署
+
+### 前置條件確認
+
+- [ ] `node --version` ≥ 22
+- [ ] `pnpm --version` ≥ 10
+- [ ] `pm2 --version` ≥ 6
+- [ ] `docker info` 正常（Docker daemon 已啟動）
+- [ ] `/usr/local/bin/tailscale status` 已連線至 tailnet
+- [ ] Firebase service account JSON 已放至 `~/.config/namecard/service-account.json`
+- [ ] `.env.production` 已從 `.env.production.example` 複製並填寫完整
+
+### 步驟
+
+```bash
+# 1. Clone（若尚未 clone）
+git clone https://github.com/cct08311github/namecard-web.git \
+  /Users/openclaw/.openclaw/shared/projects/namecard-web
+cd /Users/openclaw/.openclaw/shared/projects/namecard-web
+
+# 2. 安裝依賴
+pnpm install
+
+# 3. 建立 production env（第一次需手動填入）
+cp .env.production.example .env.production
+# → 開啟 .env.production，填入所有空值（見 .env.production.example 說明）
+
+# 4. 啟動 Typesense container
+docker compose -f docker-compose.prod.yml \
+  --env-file .env.production up -d
+
+# 5. 建置 Next.js
+NAMECARD_BASE_PATH=/namecard-web pnpm build
+
+# 6. 啟動 PM2（載入 .env.production 環境變數）
+set -a; source .env.production; set +a
+pm2 start ecosystem.config.cjs --env production
+pm2 save
+
+# 7. 確保 PM2 跟隨系統啟動（只需執行一次）
+pm2 startup launchd
+# → 依照輸出的指令貼上執行（通常需要 sudo）
+
+# 8. 設定 Tailscale Serve 路由
+tailscale serve --bg --set-path=/namecard-web http://localhost:3013
+
+# 9. 健康檢查
+scripts/verify-deploy.sh
+```
+
+---
+
+## 3. 常規部署
+
+每次 `git pull` 後執行以下步驟（已有 PM2 管理、Tailscale Serve 已設定）：
+
+```bash
+cd /Users/openclaw/.openclaw/shared/projects/namecard-web
+
+# 1. 拉取最新程式碼
+git pull origin main
+
+# 2. 更新依賴（package.json 有變動時）
+pnpm install
+
+# 3. 重新建置
+NAMECARD_BASE_PATH=/namecard-web pnpm build
+
+# 4. 零停機重載（PM2 fork mode）
+pm2 reload namecard-web
+
+# 5. 驗證
+scripts/verify-deploy.sh
+```
+
+---
+
+## 4. 健康檢查
+
+執行一鍵檢查腳本：
+
+```bash
+scripts/verify-deploy.sh
+```
+
+腳本會依序確認：
+
+1. PM2 `namecard-web` 狀態為 online
+2. Docker `namecard-typesense` container 正在執行
+3. `http://localhost:3013/namecard-web/api/health` 回應 HTTP 200
+4. `tailscale serve status` 包含 `/namecard-web` 路由
+5. `http://127.0.0.1:8108/health` 回應 `{"ok":true}`
+
+---
+
+## 5. 常見問題排查
+
+### Next.js 啟動失敗
+
+```bash
+pm2 logs namecard-web --lines 100
+```
+
+常見原因：
+
+| 症狀                                       | 排查                                                   |
+| ------------------------------------------ | ------------------------------------------------------ |
+| `PORT 3013 already in use`                 | `lsof -i :3013` 找出佔用 PID → `kill <PID>`            |
+| `GOOGLE_APPLICATION_CREDENTIALS not found` | 確認 `.env.production` 中路徑正確且檔案存在            |
+| `SESSION_COOKIE_SECRET too short`          | 確認 secret ≥ 32 字元                                  |
+| `basePath` 資源 404                        | 確認 build 時有設定 `NAMECARD_BASE_PATH=/namecard-web` |
+
+### Typesense container 停止
+
+```bash
+docker logs namecard-typesense --tail 50
+docker compose -f docker-compose.prod.yml \
+  --env-file .env.production up -d
+```
+
+常見原因：`TYPESENSE_API_KEY` 未設定、`.typesense-data-prod/` 權限問題（`chmod 755 .typesense-data-prod`）。
+
+### Tailscale Serve 路由不存在
+
+```bash
+# 查看現有 serve 設定
+tailscale serve status
+
+# 重新設定
+tailscale serve --bg --set-path=/namecard-web http://localhost:3013
+
+# 驗證
+curl -s https://mac-mini.tailde842d.ts.net/namecard-web/api/health
+```
+
+### Session Cookie 失效（用戶被踢出）
+
+Firebase session cookie 預設有效期為 14 天。若大量用戶同時失效，確認：
+
+- `SESSION_COOKIE_SECRET` 未被意外變更
+- Firebase Auth 服務狀態：https://status.firebase.google.com/
+
+### Firestore 認證失敗（Admin SDK）
+
+```bash
+# 測試 service account 是否有效
+gcloud auth activate-service-account \
+  --key-file ~/.config/namecard/service-account.json
+gcloud firestore operations list \
+  --project=namecard-web-prd
+```
+
+若 service account 金鑰過期，至 Firebase Console → Project Settings → Service Accounts 重新產生。
+
+---
+
+## 6. 備份與還原
+
+### 備份位置
+
+- **Firestore**：GCS bucket `gs://namecard-backup-namecard-web-prd/firestore/<timestamp>/`
+- **Storage**：Firebase Storage 已啟用 Object Versioning（不需另外備份）
+
+### 手動觸發備份
+
+```bash
+scripts/backup-firestore.sh
+```
+
+> ⚠️ 首次使用前需先依 `scripts/backup-firestore.sh` 頂端 TODO 完成 GCS bucket 設定。
+
+### 排程備份（launchd）
+
+每日 02:00 自動執行（plist 範例待建立）。
+
+### 從備份還原 Firestore
+
+```bash
+# 列出可用備份
+gsutil ls gs://namecard-backup-namecard-web-prd/firestore/
+
+# 還原指定快照（會覆蓋現有資料，操作前確認）
+gcloud firestore import gs://namecard-backup-namecard-web-prd/firestore/<timestamp>/ \
+  --project=namecard-web-prd
+```
+
+---
+
+## 7. 災難還原
+
+目標：**RTO < 2 小時**
+
+### 情境：Mac mini 需重建（新機或系統重裝）
+
+```bash
+# 1. 從 1Password 取回以下機密：
+#    - ~/.config/namecard/service-account.json
+#    - .env.production 內容
+
+# 2. 安裝必要工具
+brew install node pnpm
+npm install -g pm2@latest
+
+# 3. Clone 程式碼
+git clone https://github.com/cct08311github/namecard-web.git \
+  /Users/openclaw/.openclaw/shared/projects/namecard-web
+cd /Users/openclaw/.openclaw/shared/projects/namecard-web
+
+# 4. 還原 service account + env
+mkdir -p ~/.config/namecard
+# → 從 1Password 貼上 service-account.json
+# → 從 1Password 貼上 .env.production
+
+# 5. 安裝依賴 + 建置
+pnpm install
+NAMECARD_BASE_PATH=/namecard-web pnpm build
+
+# 6. 啟動 Typesense
+docker compose -f docker-compose.prod.yml \
+  --env-file .env.production up -d
+
+# 7. 啟動 PM2
+set -a; source .env.production; set +a
+pm2 start ecosystem.config.cjs --env production
+pm2 save
+pm2 startup launchd
+
+# 8. Tailscale Serve
+tailscale serve --bg --set-path=/namecard-web http://localhost:3013
+
+# 9. 驗證
+scripts/verify-deploy.sh
+```
+
+### 機密存放（1Password）
+
+| 項目                  | 1Password Vault | 備注                     |
+| --------------------- | --------------- | ------------------------ |
+| service-account.json  | namecard-web    | Firebase Admin SDK 金鑰  |
+| .env.production       | namecard-web    | 所有 production 環境變數 |
+| SESSION_COOKIE_SECRET | namecard-web    | 32+ 字元隨機值           |
+| TYPESENSE_API_KEY     | namecard-web    | Typesense admin key      |
+
+---
+
+## 8. 常用指令速查
+
+### PM2
+
+```bash
+pm2 list                          # 查看所有 process 狀態
+pm2 logs namecard-web             # 即時 log（Ctrl-C 離開）
+pm2 logs namecard-web --lines 200 # 最後 200 行 log
+pm2 reload namecard-web           # 零停機重啟（production 改版用）
+pm2 restart namecard-web          # 強制重啟
+pm2 stop namecard-web             # 停止
+pm2 delete namecard-web           # 從 PM2 移除
+pm2 save                          # 儲存 process 列表（供 startup 使用）
+```
+
+### Docker / Typesense
+
+```bash
+docker compose -f docker-compose.prod.yml \
+  --env-file .env.production up -d      # 啟動 Typesense
+docker compose -f docker-compose.prod.yml down   # 停止（保留資料）
+docker logs namecard-typesense -f        # 即時 log
+docker exec -it namecard-typesense sh    # 進入 container shell
+```
+
+### Tailscale
+
+```bash
+tailscale serve status                  # 查看 serve 設定
+tailscale serve --bg --set-path=/namecard-web http://localhost:3013
+tailscale serve --https=443 off         # 移除所有 serve（謹慎使用）
+```
+
+### Firebase
+
+```bash
+npx firebase deploy --only firestore:rules,firestore:indexes
+npx firebase deploy --only storage
+```
+
+### 快速驗證
+
+```bash
+scripts/verify-deploy.sh
+# 或手動
+curl -s http://localhost:3013/namecard-web/api/health
+curl -s http://127.0.0.1:8108/health
+pm2 list
+docker ps | grep namecard
+```

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,34 @@
+# Production Typesense for namecard-web.
+#
+# Usage:
+#   docker compose -f docker-compose.prod.yml up -d
+#   docker compose -f docker-compose.prod.yml down
+#   docker compose -f docker-compose.prod.yml logs -f typesense
+#
+# Requirements:
+#   TYPESENSE_API_KEY must be set in .env.production (or exported in shell).
+#   docker compose automatically reads .env files — either pass --env-file .env.production
+#   or export TYPESENSE_API_KEY before calling docker compose.
+#
+# Port binding: 127.0.0.1:8108 only — Typesense is NOT publicly reachable.
+# The Next.js server (also on localhost) connects to http://127.0.0.1:8108.
+
+services:
+  typesense:
+    image: typesense/typesense:28.0
+    container_name: namecard-typesense
+    restart: unless-stopped
+    ports:
+      # Bind to loopback only — do not expose to LAN or tailnet.
+      - "127.0.0.1:8108:8108"
+    volumes:
+      # Named bind-mount keeps data outside the container; survives `docker compose down`.
+      - ./.typesense-data-prod:/data
+    command: >-
+      --data-dir /data
+      --api-key=${TYPESENSE_API_KEY}
+      --listen-port 8108
+      --enable-cors
+    # No container-internal healthcheck — the Typesense 28.0 image ships with curl,
+    # but we rely on scripts/verify-deploy.sh for external readiness probing to keep
+    # this compose file simple and avoid HEALTHCHECK restart loops on cold start.

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -32,7 +32,7 @@ module.exports = {
       autorestart: true,
       env_production: {
         NODE_ENV: "production",
-        PORT: "3013",
+        PORT: "3014",
         NAMECARD_BASE_PATH: "/namecard-web",
         // All secrets must be provided in .env.production (see .env.production.example).
         // PM2 does NOT auto-load .env files; source them before starting or use

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,49 @@
+/**
+ * PM2 process manifest for namecard-web.
+ *
+ * Start:
+ *   pm2 start ecosystem.config.cjs --env production
+ *
+ * Reload after deploy (zero-downtime):
+ *   pm2 reload namecard-web
+ *
+ * Save PM2 process list + enable launchd startup:
+ *   pm2 save && pm2 startup launchd   (owner: openclaw)
+ *
+ * Logs:
+ *   pm2 logs namecard-web
+ *   tail -f ~/.pm2/logs/namecard-web-out.log
+ *   tail -f ~/.pm2/logs/namecard-web-error.log
+ */
+module.exports = {
+  apps: [
+    {
+      name: "namecard-web",
+      script: "pnpm",
+      args: "start",
+      cwd: "/Users/openclaw/.openclaw/shared/projects/namecard-web",
+      // pnpm is itself a Node script; set interpreter to "none" so PM2 doesn't
+      // try to wrap it with another node invocation.
+      interpreter: "none",
+      instances: 1,
+      exec_mode: "fork",
+      max_memory_restart: "500M",
+      watch: false,
+      autorestart: true,
+      env_production: {
+        NODE_ENV: "production",
+        PORT: "3013",
+        NAMECARD_BASE_PATH: "/namecard-web",
+        // All secrets must be provided in .env.production (see .env.production.example).
+        // PM2 does NOT auto-load .env files; source them before starting or use
+        // the dotenv trick: add `node -r dotenv/config` to args if needed.
+        // Recommended: pipe via `pm2 start ... --env-file .env.production` (PM2 v5+)
+        // or export vars in the shell before `pm2 start`.
+      },
+      error_file: "/Users/openclaw/.pm2/logs/namecard-web-error.log",
+      out_file: "/Users/openclaw/.pm2/logs/namecard-web-out.log",
+      merge_logs: true,
+      log_date_format: "YYYY-MM-DD HH:mm:ss Z",
+    },
+  ],
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // basePath is empty in dev; set NAMECARD_BASE_PATH=/namecard-web in production
+  // so all internal links, assets, and middleware routes are prefixed automatically.
+  basePath: process.env.NAMECARD_BASE_PATH ?? "",
 };
 
 export default nextConfig;

--- a/scripts/backup-firestore.sh
+++ b/scripts/backup-firestore.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# ============================================================
+# scripts/backup-firestore.sh
+# 每日 Firestore + Storage 匯出到 GCS bucket
+#
+# 需求：
+#   - gcloud CLI 已安裝且以 owner 身份認證（gcloud auth login）
+#   - GCS bucket: namecard-backup-${PROJECT_ID}
+#     建立指令：
+#       gsutil mb -l asia-east1 gs://namecard-backup-namecard-web-prd
+#       gsutil lifecycle set scripts/gcs-lifecycle-30d.json gs://namecard-backup-namecard-web-prd
+#   - bucket 需設定 30-day 自動清理 lifecycle（見 scripts/gcs-lifecycle-30d.json）
+#
+# 建議呼叫方式（launchd plist 每日 02:00 執行）：
+#   參考 docs/deployment/com.namecard.backup.plist.example
+#
+# 用法：
+#   scripts/backup-firestore.sh
+#
+# TODO（Phase 7 手動步驟）：
+#   1. 在 Google Cloud Console 建立 GCS bucket
+#   2. 設定 30-day lifecycle policy
+#   3. 授予 service account storage.objectCreator 權限
+#   4. 取消下方 TODO 區塊的 exit 0，填入正式 gsutil 指令
+# ============================================================
+
+set -euo pipefail
+
+PROJECT_ID="${FIREBASE_ADMIN_PROJECT_ID:-namecard-web-prd}"
+BUCKET="gs://namecard-backup-${PROJECT_ID}"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+EXPORT_PATH="${BUCKET}/firestore/${TIMESTAMP}"
+
+echo "[backup-firestore] $(date '+%Y-%m-%d %H:%M:%S') 開始備份..."
+echo "[backup-firestore] Project: ${PROJECT_ID}"
+echo "[backup-firestore] Destination: ${EXPORT_PATH}"
+
+# ---- TODO: 啟用以下指令（需先完成 GCS bucket 設定）-----------
+# gcloud firestore export "${EXPORT_PATH}" \
+#   --project="${PROJECT_ID}" \
+#   --async
+# echo "[backup-firestore] Firestore 匯出已排入佇列：${EXPORT_PATH}"
+# ---------------------------------------------------------------
+
+echo ""
+echo "[backup-firestore] ⚠️  尚未設定 GCS bucket — 跳過實際備份"
+echo "[backup-firestore] 請依 scripts/backup-firestore.sh 頂端的 TODO 步驟完成設定後"
+echo "[backup-firestore] 再取消 gcloud firestore export 指令的注解"
+echo ""
+
+exit 0

--- a/scripts/verify-deploy.sh
+++ b/scripts/verify-deploy.sh
@@ -6,7 +6,7 @@
 # 檢查項目：
 #   1. PM2 process "namecard-web" 狀態為 online
 #   2. Docker container "namecard-typesense" 正在執行
-#   3. Next.js localhost:3013/namecard-web/api/health 回應 200
+#   3. Next.js localhost:3014/namecard-web/api/health 回應 200
 #   4. tailscale serve status 包含 /namecard-web 路由
 #   5. Typesense http://127.0.0.1:8108/health 回應 {"ok":true}
 #
@@ -56,9 +56,9 @@ else
 fi
 
 # ---- 3. Next.js health endpoint -----------------------------
-info "[3/5] Next.js http://localhost:3013/namecard-web/api/health ..."
+info "[3/5] Next.js http://localhost:3014/namecard-web/api/health ..."
 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
-  "http://localhost:3013/namecard-web/api/health" 2>/dev/null || echo "000")
+  "http://localhost:3014/namecard-web/api/health" 2>/dev/null || echo "000")
 if [ "$HTTP_CODE" = "200" ]; then
   pass "Next.js health endpoint returned 200"
 else
@@ -70,7 +70,7 @@ info "[4/5] Tailscale Serve /namecard-web route ..."
 if /usr/local/bin/tailscale serve status 2>/dev/null | grep -q "/namecard-web"; then
   pass "Tailscale Serve includes /namecard-web"
 else
-  fail "Tailscale Serve does NOT include /namecard-web (run: tailscale serve --bg --set-path=/namecard-web http://localhost:3013)"
+  fail "Tailscale Serve does NOT include /namecard-web (run: tailscale serve --bg --set-path=/namecard-web http://localhost:3014)"
 fi
 
 # ---- 5. Typesense health ------------------------------------

--- a/scripts/verify-deploy.sh
+++ b/scripts/verify-deploy.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# ============================================================
+# scripts/verify-deploy.sh
+# namecard-web 部署健康檢查
+#
+# 檢查項目：
+#   1. PM2 process "namecard-web" 狀態為 online
+#   2. Docker container "namecard-typesense" 正在執行
+#   3. Next.js localhost:3013/namecard-web/api/health 回應 200
+#   4. tailscale serve status 包含 /namecard-web 路由
+#   5. Typesense http://127.0.0.1:8108/health 回應 {"ok":true}
+#
+# 用法：
+#   scripts/verify-deploy.sh
+#
+# 結束碼：
+#   0 — 全部通過
+#   1 — 至少一項失敗
+# ============================================================
+
+set -euo pipefail
+
+# ---- 顏色輸出 -----------------------------------------------
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+pass() { echo -e "${GREEN}✓${NC} $*"; }
+fail() { echo -e "${RED}✗${NC} $*"; FAILED=1; }
+info() { echo -e "${YELLOW}→${NC} $*"; }
+
+FAILED=0
+
+echo ""
+echo "=================================================="
+echo " namecard-web 部署健康檢查"
+echo "=================================================="
+echo ""
+
+# ---- 1. PM2 process online ----------------------------------
+info "[1/5] PM2 process namecard-web ..."
+if pm2 list --no-color 2>/dev/null | grep -q "namecard-web.*online"; then
+  pass "PM2 namecard-web is online"
+else
+  fail "PM2 namecard-web is NOT online (run: pm2 start ecosystem.config.cjs --env production)"
+fi
+
+# ---- 2. Docker container running ----------------------------
+info "[2/5] Docker container namecard-typesense ..."
+CONTAINER_STATUS=$(docker inspect --format='{{.State.Status}}' namecard-typesense 2>/dev/null || echo "missing")
+if [ "$CONTAINER_STATUS" = "running" ]; then
+  pass "Docker namecard-typesense is running"
+else
+  fail "Docker namecard-typesense status: ${CONTAINER_STATUS} (run: docker compose -f docker-compose.prod.yml up -d)"
+fi
+
+# ---- 3. Next.js health endpoint -----------------------------
+info "[3/5] Next.js http://localhost:3013/namecard-web/api/health ..."
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
+  "http://localhost:3013/namecard-web/api/health" 2>/dev/null || echo "000")
+if [ "$HTTP_CODE" = "200" ]; then
+  pass "Next.js health endpoint returned 200"
+else
+  fail "Next.js health endpoint returned HTTP ${HTTP_CODE} (expected 200)"
+fi
+
+# ---- 4. Tailscale Serve path --------------------------------
+info "[4/5] Tailscale Serve /namecard-web route ..."
+if /usr/local/bin/tailscale serve status 2>/dev/null | grep -q "/namecard-web"; then
+  pass "Tailscale Serve includes /namecard-web"
+else
+  fail "Tailscale Serve does NOT include /namecard-web (run: tailscale serve --bg --set-path=/namecard-web http://localhost:3013)"
+fi
+
+# ---- 5. Typesense health ------------------------------------
+info "[5/5] Typesense http://127.0.0.1:8108/health ..."
+TS_BODY=$(curl -s --max-time 5 "http://127.0.0.1:8108/health" 2>/dev/null || echo "")
+if echo "$TS_BODY" | grep -q '"ok":true'; then
+  pass "Typesense healthy: ${TS_BODY}"
+else
+  fail "Typesense unhealthy — got: '${TS_BODY}'"
+fi
+
+# ---- 結果 ---------------------------------------------------
+echo ""
+echo "=================================================="
+if [ "$FAILED" -eq 0 ]; then
+  echo -e "${GREEN}全部通過 — namecard-web 運行正常${NC}"
+  echo " 外部存取：https://mac-mini.tailde842d.ts.net/namecard-web/"
+else
+  echo -e "${RED}部分檢查失敗 — 請依上方提示排查${NC}"
+fi
+echo "=================================================="
+echo ""
+
+exit "$FAILED"

--- a/scripts/verify-deploy.sh
+++ b/scripts/verify-deploy.sh
@@ -70,7 +70,7 @@ info "[4/5] Tailscale Serve /namecard-web route ..."
 if /usr/local/bin/tailscale serve status 2>/dev/null | grep -q "/namecard-web"; then
   pass "Tailscale Serve includes /namecard-web"
 else
-  fail "Tailscale Serve does NOT include /namecard-web (run: tailscale serve --bg --set-path=/namecard-web http://localhost:3014)"
+  fail "Tailscale Serve does NOT include /namecard-web (run: tailscale serve --bg --set-path=/namecard-web http://localhost:3014/namecard-web)"
 fi
 
 # ---- 5. Typesense health ------------------------------------


### PR DESCRIPTION
## Summary

Closes #9

Phase 7 deployment scaffolding for Mac mini M4. Target URL: `https://mac-mini.tailde842d.ts.net/namecard-web/`

## Architecture decisions

- **Sub-path routing** via Next.js `basePath` (env-configurable) + Tailscale Serve path routing. No Nginx needed.
- **Port 3013** for Next.js (avoids existing serves at :3011 / :3012 / :18789).
- **Typesense** via Docker Compose, bound to `127.0.0.1` only (tailnet-internal server-to-server).
- **Firebase** production project `namecard-web-prd`. Service account at `~/.config/namecard/service-account.json`.
- **No Nginx** — Tailscale Serve handles TLS + path routing natively.

## Files

- `next.config.ts` — `basePath: process.env.NAMECARD_BASE_PATH ?? ""` (dev=empty, prod=`/namecard-web`)
- `ecosystem.config.cjs` — PM2 manifest, port 3013, 500M memory limit, fork mode
- `docker-compose.prod.yml` — Typesense 28.0, `restart: unless-stopped`, bound to 127.0.0.1
- `.env.production.example` — template for all prod env vars
- `scripts/verify-deploy.sh` — 5-point health check (PM2 / Docker / Next health / Tailscale serve / Typesense)
- `scripts/backup-firestore.sh` — daily Firestore export skeleton (gcloud commands commented, user fills in after GCS bucket setup)
- `RUNBOOK.md` — zh-TW operational runbook (first deploy / regular deploy / troubleshooting / DR RTO <2h)
- `.gitignore` — exclude `.env.production` + `.typesense-data-prod/`
- `README.md` — new 🚢 部署 section

## Test plan

- [x] `pnpm typecheck` — clean (except pre-existing stale `.next/types/` cache)
- [x] `pnpm lint` — clean
- [x] `pnpm build` (default) — succeeds, basePath empty
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — succeeds, all 15 routes generated with basePath
- [ ] CI: existing gates should stay green (no runtime code change except basePath)
- [ ] Manual after merge: run RUNBOOK's "First-time deploy" on Mac mini

## Manual follow-ups (Phase 7 acceptance criteria)

- [ ] Populate `.env.production` from template (Firebase + MiniMax + session secret)
- [ ] Run deploy sequence per RUNBOOK
- [ ] `scripts/verify-deploy.sh` all-green
- [ ] Set up GCS backup bucket + 30-day lifecycle; fill in `scripts/backup-firestore.sh`
- [ ] Create launchd plist for daily backup
- [ ] UptimeRobot HTTPS probe + Telegram Bot alert
- [ ] Google Cloud Budget $10/月 alert
- [ ] Store service-account.json + API keys in 1Password
- [ ] DR drill

## Relates

- Supersedes manual Phase 7 runbook planning from issue #9
- Dependabot follow-up remains at #26 (unrelated)