### PR TITLE
fix: resolve axios SSRF advisories (partial fix for #26)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
       "protobufjs",
       "re2",
       "@vercel/speed-insights"
-    ]
+    ],
+    "overrides": {
+      "axios@<1.15.0": "^1.15.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  axios@<1.15.0: ^1.15.0
+
 importers:
 
   .:
@@ -1910,8 +1913,8 @@ packages:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
     engines: {node: '>=4'}
 
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -4470,6 +4473,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -7394,11 +7401,11 @@ snapshots:
 
   axe-core@4.11.3: {}
 
-  axios@1.13.5:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -10337,6 +10344,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   punycode@2.3.1: {}
 
   pupa@2.1.1:
@@ -11220,7 +11229,7 @@ snapshots:
   typesense@3.0.5(@babel/runtime@7.29.2):
     dependencies:
       '@babel/runtime': 7.29.2
-      axios: 1.13.5
+      axios: 1.15.0
       loglevel: 1.9.2
       tslib: 2.8.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Partial fix for #26 — addresses the 2 moderate axios advisories.

## Changes

- `package.json`: add `pnpm.overrides` entry forcing `axios@<1.15.0` → `^1.15.0`
- `pnpm-lock.yaml`: regenerated — axios 1.13.5 → 1.15.0

## Advisories resolved

- [axios SSRF via NO_PROXY hostname normalization bypass](https://github.com/advisories/GHSA-4hjh-wcwx-xvwj) (moderate) → patched in 1.15.0
- [axios cloud metadata exfil via header injection chain](https://github.com/advisories/GHSA-jr5f-v2jv-69x6) (moderate) → patched in 1.15.0

## Advisory documented as wontfix

- `@tootallnate/once@2.0.0` (low severity, "Incorrect Control Flow Scoping")
  - Transitive under `firebase-admin@13.8.0 → @google-cloud/storage@7.19.0 → teeny-request@9.0.0 → http-proxy-agent@5.0.0 → @tootallnate/once@2.0.0`
  - Patched version `@tootallnate/once@3.0.1` has breaking API changes — removed the default-exported function in favor of Promise-based `events.once` in Node 14+. Forcing it would break `http-proxy-agent@5.0.0`.
  - Upstream remediation requires `@google-cloud/storage` to bump `teeny-request` from `^9.0.0` to `^10.1.2` (which drops `http-proxy-agent@5` → `@7`). Not in our control.
  - Vulnerable code path only activates when `HTTP_PROXY` env is set. Our Mac mini deployment does not use an HTTP proxy — tailnet routes directly. Risk surface is effectively zero for this deployment.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no new warnings (2 pre-existing React Hook Form warnings unchanged)
- [x] `pnpm test` — 283 pass / 21 skipped (SIT skipped without emulator)
- [x] `pnpm build` — clean production build
- [ ] CI gates (Build, Firestore Rules, SIT, E2E)

## Follow-up

Keep #26 open after merge with the wontfix rationale above, or close as "resolved with documented exception". Will revisit when `@google-cloud/storage` upstream upgrades teeny-request.