### PR TITLE
ops: close Phase 7 loose ends — env auto-load, Typesense bootstrap, 7-point verify (Closes #31, #32)

### DIFF
--- a/.claude/skills/namecard-web-deploy/SKILL.md
+++ b/.claude/skills/namecard-web-deploy/SKILL.md
@@ -44,11 +44,12 @@ description: Mac mini M4 deployment operations for namecard-web — use when dep
 2. `pnpm install --prod=false`（build 需要 dev dep）
 3. `NAMECARD_BASE_PATH=/namecard-web pnpm build`
 4. `docker compose -f docker-compose.prod.yml up -d`（Typesense）
-5. `pm2 start ecosystem.config.cjs --env production`
-6. `pm2 save` — **不能漏**
-7. 補 Tailscale serve 映射到 `tailscale-serve-setup.sh`（見上面「開機自恢復鏈」），跑一次驗證
-8. Firebase Console 加 authorized domain（見 pitfall #3）
-9. 跑驗證流程（見下）
+5. `pnpm search:bootstrap`（建 `cards` collection — 見 pitfall #7）
+6. `pm2 start ecosystem.config.cjs --env production`（config 會 parse `.env.production` 自動注入 secrets — 見 pitfall #8）
+7. `pm2 save` — **不能漏**，否則重開後 resurrect 會缺東西
+8. 補 Tailscale serve 映射到 `tailscale-serve-setup.sh`（見上面「開機自恢復鏈」），跑一次驗證
+9. Firebase Console 加 authorized domain（見 pitfall #3）
+10. 跑驗證：`bash scripts/verify-deploy.sh`（7 點全綠）
 
 ### 重開機後系統恢復
 
@@ -102,13 +103,17 @@ curl -skL -o /dev/null -w "public %{http_code}\n" https://mac-mini.tailde842d.ts
 pm2 logs namecard-web --lines 40 --nostream --err | tail -20
 ```
 
-### 驗證清單（完整五點健檢）
+### 驗證清單（完整七點健檢）
 
 直接跑現成腳本：
 
 ```bash
-bash scripts/verify-deploy.sh    # 5-point: PM2 / Docker / Next health / Tailscale serve / Typesense
+bash scripts/verify-deploy.sh
+# 7-point: PM2 / Docker / Next health / Tailscale serve / Typesense /
+#          cards collection bootstrapped / PM2 process has secret env
 ```
+
+第 6 點抓 pitfall #7（collection 沒 bootstrap），第 7 點抓 pitfall #8（env 沒進 PM2 process）— 這兩種都是會讓 app 靜默 degrade 的狀況。
 
 ## Pitfalls（踩過的坑，按優先順序）
 
@@ -180,7 +185,53 @@ pnpm exec firebase deploy --only firestore:indexes --project namecard-web-prd
 - 每次 `firestore.indexes.json` 改動後 deploy，用 `firestore_list_indexes` MCP 確認 state=READY
 - 清掉舊 COLLECTION-scope 殘留：`firebase deploy ... --force`（會刪除 JSON 中未列的 index）
 
-### 7. `pnpm build` 的 "multiple lockfiles" warning
+### 7. Typesense `cards` collection 未 bootstrap
+
+**症狀**: search UI 顯示「搜尋服務暫時無法連線，請稍後再試或用名片冊瀏覽」，但 `docker ps` 看 namecard-typesense 是 Up、`/health` 200、`.env.production` 的 `TYPESENSE_API_KEY` 正確。
+**根因**: Typesense container 啟動時是空的，必須由 app / script 先建立 schema 才能使用。App 的 search path 沒自動 bootstrap（只在 search 失敗時顯示 graceful degradation），所以首次部署漏跑 `pnpm search:bootstrap` 會無限 degrade。
+**解法**:
+
+```bash
+pnpm search:bootstrap   # idempotent — 會回「already exists」或「created」
+```
+
+若該筆首次被 upsert 時 collection 還沒建，寫入失敗會進 `workspaces/{uid}/searchSyncFailures/` queue；之後編輯該名片會觸發 re-sync，或等 `reconcileFailures(uid)` drain queue。
+
+**預防**:
+
+- 首次部署流程一定要跑 `pnpm search:bootstrap`
+- `scripts/verify-deploy.sh` 檢查第 6 點會 curl `collections/cards` 確認 HTTP 200
+- `scripts/typesense-bootstrap.ts` 用自包 fetch（不經 `src/lib/search/bootstrap.ts` 模組鏈），避免 Node 25 `--experimental-strip-types` 對無副檔名相對 import 的報錯
+
+### 8. Next.js 16 production runtime 不自動讀 `.env.production`
+
+**症狀**: `searchCardsAction` 回 `degraded: true` 但 stderr 完全乾淨（沒 `[search] query failed`）；或 Server Action 靜默失敗。`/login` 仍能 work（因為 `NEXT_PUBLIC_*` 是 build-time inline 到 client bundle）。
+**根因**: 與 Next 13/14 + Webpack 行為不同，Next.js 16 + Turbopack 的 `next start` runtime 在我們這個 setup 下**不會**自動 load `.env.production` 到 server-side `process.env`。而 PM2 本身也不 auto-load dotenv。Server Action 裡 `process.env.TYPESENSE_HOST` 讀到 undefined，`search-actions.ts:43-50` 的 `typesenseConfigured()` 回 false，直接走 degraded 路徑不報錯。
+**診斷**:
+
+```bash
+PID=$(pm2 jlist | python3 -c "import json,sys;d=json.load(sys.stdin);print(next(x['pid'] for x in d if x['name']=='namecard-web'))")
+ps eww -o command= -p $PID | tr ' ' '\n' | awk -F= 'NF==2 && ($1 ~ /TYPESENSE|FIREBASE|MINIMAX|GOOGLE|SESSION|ALLOWED/){print $1"="(length($2)>0?"***":"(empty)")}' | sort -u
+# 若缺 TYPESENSE_API_KEY / GOOGLE_APPLICATION_CREDENTIALS / SESSION_COOKIE_SECRET 等，就是這問題
+```
+
+**解法**: `ecosystem.config.cjs` 在 config eval 時直接 parse `.env.production` 並合進 `env_production`：
+
+```js
+function parseDotenv(path) { /* 見檔案實作 */ }
+const dotenvProd = parseDotenv(path.join(__dirname, ".env.production"));
+module.exports = { apps: [{ ..., env_production: { ...dotenvProd, PORT, NAMECARD_BASE_PATH }, ... }] };
+```
+
+這樣 `pm2 start ecosystem.config.cjs --env production` 一次就對，不需要操作者記得先 `source .env.production`。
+
+**預防**:
+
+- 改完 `.env.production` 後跑 `pm2 start ecosystem.config.cjs --env production && pm2 save`（ecosystem re-parse 新 env；`save` 更新 dump.pm2 供 resurrect 用）
+- `scripts/verify-deploy.sh` 第 7 點 spot-check `ps eww` 看 `TYPESENSE_API_KEY` + `GOOGLE_APPLICATION_CREDENTIALS` 是否進 process
+- `dump.pm2` 含明文 secret snapshot（可接受的單人部署 trade-off；若多人使用要改走 wrapper script + LaunchAgent 每次重讀）
+
+### 9. `pnpm build` 的 "multiple lockfiles" warning
 
 **症狀**: build log 出現 `Next.js inferred your workspace root ... selected .../package-lock.json`。
 **影響**: 無害（不影響 runtime），只影響 standalone output 的 file tracing — 我們沒用 standalone，可忽略。真要消掉：在 `next.config.ts` 加 `outputFileTracingRoot: __dirname`。

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -75,19 +75,25 @@ cp .env.production.example .env.production
 docker compose -f docker-compose.prod.yml \
   --env-file .env.production up -d
 
-# 5. 建置 Next.js
+# 5. Bootstrap Typesense `cards` collection（idempotent — 空 collection 必做）
+#    若漏跑，app 搜尋頁會顯示「搜尋服務暫時無法連線」而無 stderr 錯誤。
+pnpm search:bootstrap
+
+# 6. 建置 Next.js
 NAMECARD_BASE_PATH=/namecard-web pnpm build
 
-# 6. 啟動 PM2（載入 .env.production 環境變數）
-set -a; source .env.production; set +a
+# 7. 啟動 PM2
+#    ecosystem.config.cjs 會在 config eval 時 parse .env.production
+#    並合入 env_production — 不需要手動 source 就能把 secrets 傳進 Node 進程。
+#    （Next.js 16 + Turbopack 的 `next start` 不會自動 load .env.production。）
 pm2 start ecosystem.config.cjs --env production
 pm2 save
 
-# 7. 確保 PM2 跟隨系統啟動（只需執行一次）
+# 8. 確保 PM2 跟隨系統啟動（只需執行一次）
 pm2 startup launchd
 # → 依照輸出的指令貼上執行（通常需要 sudo）
 
-# 8. 設定 Tailscale Serve 路由
+# 9. 設定 Tailscale Serve 路由
 #
 # 重要：upstream URL 必須包含 /namecard-web 路徑。
 # Tailscale Serve 會將傳入的 /namecard-web 前綴剝除後再轉發；
@@ -95,8 +101,11 @@ pm2 startup launchd
 # 只會收到裸路徑並回傳 404。帶上路徑後，剝除前綴與 basePath 對齊，
 # 確保 Next.js 正確回應所有請求。
 tailscale serve --bg --set-path=/namecard-web http://localhost:3014/namecard-web
+#
+# 同時把此映射加進 ~/.openclaw/bin/tailscale-serve-setup.sh 的 PATH_MAPPINGS，
+# 否則 Mac mini 重開後 LaunchAgent 不會恢復這條路由。
 
-# 9. 健康檢查
+# 10. 健康檢查（7 點全綠才算部署成功）
 scripts/verify-deploy.sh
 ```
 
@@ -123,6 +132,19 @@ pm2 reload namecard-web
 
 # 5. 驗證
 scripts/verify-deploy.sh
+```
+
+**改到 `.env.production` 時**：要重啟才會注入新 env（`pm2 reload` 不重讀 ecosystem config）：
+
+```bash
+pm2 start ecosystem.config.cjs --env production   # 會覆蓋既有 process 並 re-parse .env.production
+pm2 save                                           # 更新 dump.pm2，重開後 resurrect 會帶新 env
+```
+
+**改到 `firestore.indexes.json` 或 `firestore.rules` 時**：CI 只跑 emulator 測試，prod 要手動部署：
+
+```bash
+pnpm exec firebase deploy --only firestore:indexes,firestore:rules,storage --project namecard-web-prd
 ```
 
 ---

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -14,14 +14,54 @@
  *   pm2 logs namecard-web
  *   tail -f ~/.pm2/logs/namecard-web-out.log
  *   tail -f ~/.pm2/logs/namecard-web-error.log
+ *
+ * Env: .env.production is parsed below and merged into env_production.
+ * Next.js 16 + Turbopack does not reliably load .env.production at
+ * runtime the way Next 13/14 did under Webpack, and PM2 does not
+ * auto-load dotenv — so we parse the file here at config eval time.
+ * After editing .env.production, re-run `pm2 start ecosystem.config.cjs
+ * --env production && pm2 save` to refresh the dump.pm2 env snapshot
+ * used by `pm2 resurrect` on reboot.
  */
+/* eslint-disable @typescript-eslint/no-require-imports --
+ * PM2 config is CommonJS by design — PM2 loads it via require() and
+ * only supports CJS. Using require() here is correct, not accidental.
+ */
+const fs = require("node:fs");
+const path = require("node:path");
+
+function parseDotenv(filepath) {
+  const env = {};
+  if (!fs.existsSync(filepath)) return env;
+  const content = fs.readFileSync(filepath, "utf8");
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (key) env[key] = value;
+  }
+  return env;
+}
+
+const PROJECT_DIR = "/Users/openclaw/.openclaw/shared/projects/namecard-web";
+const dotenvProd = parseDotenv(path.join(PROJECT_DIR, ".env.production"));
+
 module.exports = {
   apps: [
     {
       name: "namecard-web",
       script: "pnpm",
       args: "start",
-      cwd: "/Users/openclaw/.openclaw/shared/projects/namecard-web",
+      cwd: PROJECT_DIR,
       // pnpm is itself a Node script; set interpreter to "none" so PM2 doesn't
       // try to wrap it with another node invocation.
       interpreter: "none",
@@ -31,14 +71,11 @@ module.exports = {
       watch: false,
       autorestart: true,
       env_production: {
+        // Secrets first so explicit fields below can override if needed.
+        ...dotenvProd,
         NODE_ENV: "production",
         PORT: "3014",
         NAMECARD_BASE_PATH: "/namecard-web",
-        // All secrets must be provided in .env.production (see .env.production.example).
-        // PM2 does NOT auto-load .env files; source them before starting or use
-        // the dotenv trick: add `node -r dotenv/config` to args if needed.
-        // Recommended: pipe via `pm2 start ... --env-file .env.production` (PM2 v5+)
-        // or export vars in the shell before `pm2 start`.
       },
       error_file: "/Users/openclaw/.pm2/logs/namecard-web-error.log",
       out_file: "/Users/openclaw/.pm2/logs/namecard-web-out.log",

--- a/scripts/typesense-bootstrap.ts
+++ b/scripts/typesense-bootstrap.ts
@@ -1,24 +1,88 @@
 #!/usr/bin/env -S node --experimental-strip-types
 /**
- * Dev CLI: bootstrap the Typesense `cards` collection against the local
- * Docker instance. Safe to rerun — idempotent. Invoked via
- * `pnpm search:bootstrap`.
+ * Dev / prod CLI: bootstrap the Typesense `cards` collection against
+ * the configured Typesense instance. Safe to rerun — idempotent.
+ * Invoked via `pnpm search:bootstrap`.
  *
- * Uses Node 22's native loadEnvFile so we don't pull in dotenv just for
- * a dev script. Silent if the env file is missing (matches Next's DX).
+ * Env resolution order (merge, first non-empty wins):
+ *   .env.local → .env → .env.production
+ * Dev contributors with a populated `.env.local` always win — they
+ * stay pointed at Docker dev. On the Mac mini deploy box only
+ * `.env.production` is populated, so it fills in the gaps. The
+ * merge skips empty values so a stub `.env.local` with `KEY=` doesn't
+ * shadow a real value in `.env.production`.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
-for (const file of [".env.local", ".env"]) {
-  if (existsSync(file)) process.loadEnvFile(file);
+function mergeEnvFile(filepath: string): void {
+  if (!existsSync(filepath)) return;
+  const content = readFileSync(filepath, "utf8");
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    // Only set if the key is missing or currently empty — skip explicit
+    // empty stubs so they don't block values in later files.
+    if (key && value && !process.env[key]) {
+      process.env[key] = value;
+    }
+  }
 }
 
-const { ensureCardsCollection } = await import("../src/lib/search/bootstrap.ts");
-
-const result = await ensureCardsCollection();
-if (result === "created") {
-  console.log("[typesense] created `cards` collection");
-} else {
-  console.log("[typesense] `cards` collection already exists");
+for (const file of [".env.local", ".env", ".env.production"]) {
+  mergeEnvFile(file);
 }
+
+// Self-contained REST implementation — intentionally avoids importing
+// src/lib/search/bootstrap.ts (which depends on `server-only` + relative
+// imports without .ts extensions, incompatible with Node 25's ESM loader
+// under --experimental-strip-types). The schema itself is pure data and
+// imports only `type`s from the typesense package, so it loads cleanly.
+const { CARDS_COLLECTION_NAME, cardsCollectionSchema } =
+  await import("../src/lib/search/schema.ts");
+
+const host = process.env.TYPESENSE_HOST ?? "localhost";
+const port = process.env.TYPESENSE_PORT ?? "8108";
+const protocol = process.env.TYPESENSE_PROTOCOL ?? "http";
+const apiKey = process.env.TYPESENSE_API_KEY;
+
+if (!apiKey) {
+  console.error(
+    "[typesense] TYPESENSE_API_KEY is not set — add it to .env.local (dev) or .env.production (prod).",
+  );
+  process.exit(1);
+}
+
+const baseUrl = `${protocol}://${host}:${port}`;
+const headers = { "X-TYPESENSE-API-KEY": apiKey, "Content-Type": "application/json" };
+
+const probe = await fetch(`${baseUrl}/collections/${CARDS_COLLECTION_NAME}`, { headers });
+if (probe.ok) {
+  console.log(`[typesense] \`${CARDS_COLLECTION_NAME}\` collection already exists`);
+  process.exit(0);
+}
+if (probe.status !== 404) {
+  console.error(`[typesense] probe failed: HTTP ${probe.status} — ${await probe.text()}`);
+  process.exit(1);
+}
+
+const create = await fetch(`${baseUrl}/collections`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify(cardsCollectionSchema),
+});
+if (!create.ok) {
+  console.error(`[typesense] create failed: HTTP ${create.status} — ${await create.text()}`);
+  process.exit(1);
+}
+console.log(`[typesense] created \`${CARDS_COLLECTION_NAME}\` collection`);

--- a/scripts/verify-deploy.sh
+++ b/scripts/verify-deploy.sh
@@ -9,6 +9,8 @@
 #   3. Next.js localhost:3014/namecard-web/api/health 回應 200
 #   4. tailscale serve status 包含 /namecard-web 路由
 #   5. Typesense http://127.0.0.1:8108/health 回應 {"ok":true}
+#   6. Typesense `cards` collection 已建立（bootstrap 過）
+#   7. PM2 process 實際有拿到 .env.production 的關鍵 secret
 #
 # 用法：
 #   scripts/verify-deploy.sh
@@ -39,7 +41,7 @@ echo "=================================================="
 echo ""
 
 # ---- 1. PM2 process online ----------------------------------
-info "[1/5] PM2 process namecard-web ..."
+info "[1/7] PM2 process namecard-web ..."
 if pm2 list --no-color 2>/dev/null | grep -q "namecard-web.*online"; then
   pass "PM2 namecard-web is online"
 else
@@ -47,7 +49,7 @@ else
 fi
 
 # ---- 2. Docker container running ----------------------------
-info "[2/5] Docker container namecard-typesense ..."
+info "[2/7] Docker container namecard-typesense ..."
 CONTAINER_STATUS=$(docker inspect --format='{{.State.Status}}' namecard-typesense 2>/dev/null || echo "missing")
 if [ "$CONTAINER_STATUS" = "running" ]; then
   pass "Docker namecard-typesense is running"
@@ -56,7 +58,7 @@ else
 fi
 
 # ---- 3. Next.js health endpoint -----------------------------
-info "[3/5] Next.js http://localhost:3014/namecard-web/api/health ..."
+info "[3/7] Next.js http://localhost:3014/namecard-web/api/health ..."
 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
   "http://localhost:3014/namecard-web/api/health" 2>/dev/null || echo "000")
 if [ "$HTTP_CODE" = "200" ]; then
@@ -66,7 +68,7 @@ else
 fi
 
 # ---- 4. Tailscale Serve path --------------------------------
-info "[4/5] Tailscale Serve /namecard-web route ..."
+info "[4/7] Tailscale Serve /namecard-web route ..."
 if /usr/local/bin/tailscale serve status 2>/dev/null | grep -q "/namecard-web"; then
   pass "Tailscale Serve includes /namecard-web"
 else
@@ -74,12 +76,65 @@ else
 fi
 
 # ---- 5. Typesense health ------------------------------------
-info "[5/5] Typesense http://127.0.0.1:8108/health ..."
+info "[5/7] Typesense http://127.0.0.1:8108/health ..."
 TS_BODY=$(curl -s --max-time 5 "http://127.0.0.1:8108/health" 2>/dev/null || echo "")
 if echo "$TS_BODY" | grep -q '"ok":true'; then
   pass "Typesense healthy: ${TS_BODY}"
 else
   fail "Typesense unhealthy — got: '${TS_BODY}'"
+fi
+
+# ---- 6. Typesense cards collection --------------------------
+info "[6/7] Typesense \`cards\` collection bootstrapped ..."
+# Load TYPESENSE_API_KEY from .env.production if not already in shell.
+if [ -z "${TYPESENSE_API_KEY:-}" ] && [ -f ".env.production" ]; then
+  TYPESENSE_API_KEY=$(grep '^TYPESENSE_API_KEY=' .env.production | cut -d= -f2- | tr -d "'\"")
+fi
+if [ -z "${TYPESENSE_API_KEY:-}" ]; then
+  fail "Cannot read TYPESENSE_API_KEY — skip collection check"
+else
+  COLL_HTTP=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
+    -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
+    "http://127.0.0.1:8108/collections/cards" 2>/dev/null || echo "000")
+  if [ "$COLL_HTTP" = "200" ]; then
+    pass "Typesense \`cards\` collection exists"
+  else
+    fail "Typesense \`cards\` collection missing (HTTP ${COLL_HTTP}) — run: pnpm search:bootstrap"
+  fi
+fi
+
+# ---- 7. PM2 process has env from .env.production ------------
+info "[7/7] PM2 process inherits secrets from .env.production ..."
+# ps eww shows the Node process's environ. We spot-check two critical
+# keys. If either is missing, the app degrades silently (e.g. search
+# returns degraded:true with no stderr, Firebase Admin SDK auth fails).
+PM2_PID=$(pm2 jlist 2>/dev/null | python3 -c "
+import json, sys
+try:
+    ps = json.load(sys.stdin)
+    p = next((x for x in ps if x['name'] == 'namecard-web' and x['pm2_env']['status'] == 'online'), None)
+    print(p['pid'] if p else '')
+except Exception:
+    print('')
+" 2>/dev/null)
+
+if [ -z "$PM2_PID" ]; then
+  fail "Cannot locate namecard-web PID — skip env check"
+else
+  # macOS ps eww prints space-separated KEY=VALUE pairs after the command.
+  # We look for presence of the key name before the = sign.
+  PROCESS_ENV=$(ps eww -o command= -p "$PM2_PID" 2>/dev/null || echo "")
+  missing=""
+  for key in TYPESENSE_API_KEY GOOGLE_APPLICATION_CREDENTIALS; do
+    if ! echo "$PROCESS_ENV" | tr ' ' '\n' | grep -q "^${key}="; then
+      missing="${missing} ${key}"
+    fi
+  done
+  if [ -z "$missing" ]; then
+    pass "PM2 process has TYPESENSE_API_KEY + GOOGLE_APPLICATION_CREDENTIALS"
+  else
+    fail "PM2 process missing env:${missing} (restart: pm2 start ecosystem.config.cjs --env production && pm2 save)"
+  fi
 fi
 
 # ---- 結果 ---------------------------------------------------


### PR DESCRIPTION
Closes #31 and #32 in one PR — both are deploy-hygiene follow-ups from the same Phase 7 rollout and share the affected files (verify script, skill, RUNBOOK).

## Changes

### 1. \`ecosystem.config.cjs\` now auto-loads \`.env.production\`

Root cause of the silent Typesense / Firebase-Admin degradation after Phase 7 deploy: Next.js 16 + Turbopack doesn't auto-load \`.env.production\` into the server runtime (unlike Next 13/14 + Webpack), and PM2 does not auto-load dotenv. Server Actions reading \`process.env.TYPESENSE_HOST\` saw \`undefined\` → \`typesenseConfigured()\` returned false → \`{ degraded: true }\` with no stderr log.

Fixed by inlining a tiny dotenv parser in the CJS config file and merging parsed values into \`env_production\`. \`pm2 start ecosystem.config.cjs --env production\` now carries every secret without operators needing to remember \`source .env.production\` first.

One small ESLint caveat: the CJS file legitimately needs \`require()\`, so an explicit \`eslint-disable @typescript-eslint/no-require-imports\` with rationale sits at the top of the file (not at the rule config — following the repo's \"don't weaken rules, justify suppressions\" stance).

### 2. \`scripts/typesense-bootstrap.ts\` rewritten for Node 25

Old version broke on Node 25's ESM loader with \`ERR_MODULE_NOT_FOUND\` because \`src/lib/search/bootstrap.ts\` has extensionless relative imports (\`./client\`, \`./schema\`). Rather than touch those for downstream compatibility, the script now imports only the pure-data \`schema.ts\` and hits Typesense REST directly. Also changed env resolution to merge-first-non-empty across \`.env.local\` / \`.env\` / \`.env.production\` so a stub \`KEY=\` in \`.env.local\` doesn't shadow a real value in \`.env.production\` on the deploy box.

### 3. \`scripts/verify-deploy.sh\` expanded 5 → 7 checks

- \`[6/7] Typesense cards collection bootstrapped\` — curl \`/collections/cards\` with API key, catches pitfall #7 (Typesense collection not bootstrapped → silent search degradation).
- \`[7/7] PM2 process inherits secrets\` — \`ps eww\` spot-check for \`TYPESENSE_API_KEY\` + \`GOOGLE_APPLICATION_CREDENTIALS\` on the live process, catches pitfall #8 (env didn't propagate into PM2 process).

### 4. Docs synced

- \`.claude/skills/namecard-web-deploy/SKILL.md\`: added pitfalls #7 (Typesense bootstrap) and #8 (Next.js 16 env loading). Renumbered subsequent pitfalls (was 7, now 9 is the lockfile warning).
- \`RUNBOOK.md\`: first-time-deploy gets \`pnpm search:bootstrap\`. Regular-deploy section notes when to re-start PM2 (env edits) vs firebase deploy (schema edits).

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean (0 errors, 2 pre-existing warnings unchanged)
- [x] \`pnpm test\` 283 pass / 21 skipped (SIT emulator skip)
- [x] \`pnpm format\` clean after prettier auto-fix
- [x] \`pnpm search:bootstrap\` now works on Node 25 — output \`[typesense] cards collection already exists\`
- [x] \`scripts/verify-deploy.sh\` — 7/7 passes
- [ ] CI gates

## Deliberately not in scope

- Did **not** run \`pnpm build\` locally to avoid overwriting the live PM2 \`.next/\` (pitfall #1). CI will build-verify.
- Did **not** \`pm2 start ecosystem.config.cjs --env production\` on the live process — that's the operator's job after merge (it will briefly cycle the live service, and the env parser needs a real test on cold start). Current PM2 process is still running with env that was manually propagated during #32 triage, so the site stays up until the next reboot or intentional pm2 start.