### PR TITLE
chore(env): sync .env.production.example with actual prod env keys (Closes #34)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -44,10 +44,28 @@ SESSION_COOKIE_SECRET=
 # ------------------------------------------------------------
 # OCR
 # ------------------------------------------------------------
+# Primary provider: minimax | openai
 OCR_PROVIDER=minimax
+
+# MiniMax (primary)
 MINIMAX_API_KEY=
 MINIMAX_MODEL=MiniMax-M2.7
 MINIMAX_BASE_URL=https://api.minimax.chat/v1
+
+# OpenAI (optional fallback; leave blank if you only use MiniMax)
+OPENAI_API_KEY=
+OPENAI_OCR_MODEL=gpt-4o
+
+# Per-user daily OCR cap (anti-cost-blowup). Defaults to 50 if omitted.
+OCR_DAILY_LIMIT_PER_USER=50
+
+# ------------------------------------------------------------
+# Monitoring / Alerts (optional — leave blank to disable)
+# ------------------------------------------------------------
+# Used by UptimeRobot → Telegram Bot webhook for downtime alerts.
+# Create a bot via @BotFather, then get the chat id via @userinfobot.
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
 
 # ------------------------------------------------------------
 # Typesense (production — loopback, Docker)


### PR DESCRIPTION
Closes #34.

## Change

\`.env.production.example\` was missing 5 keys that exist in \`.env.production\` on the Mac mini and in the dev-side \`.env.example\`:

- \`OCR_DAILY_LIMIT_PER_USER\` (per-user OCR rate cap — defaults 50 if omitted)
- \`OPENAI_API_KEY\` (optional fallback OCR provider)
- \`OPENAI_OCR_MODEL\` (default \`gpt-4o\`)
- \`TELEGRAM_BOT_TOKEN\` (optional — downtime alerts)
- \`TELEGRAM_CHAT_ID\` (optional — downtime alerts)

Grouped Telegram keys under a new \"Monitoring / Alerts\" section; OpenAI under the existing OCR section.

## Why it matters

Future rebuild (new Mac mini, disk restore, DR drill) follows RUNBOOK §2 step 3 which says \"copy \`.env.production.example\` → \`.env.production\` and fill in\". Any missing template key would silently disable the feature — OpenAI fallback wouldn't fire, Telegram alerts wouldn't page. Now both templates agree.

## Deliberately not in scope

- \`NODE_ENV\` + \`PORT\`: set by \`ecosystem.config.cjs#env_production\`, intentionally not duplicated in the template.
- Collapsing \`.env.example\` + \`.env.production.example\` into a single source: worth doing later but not this PR.

## Test plan

- [x] \`diff <(keys .env.production) <(keys .env.production.example)\` now shows only \`NODE_ENV\` + \`PORT\` (ecosystem-managed) — no real drift.
- [x] \`pnpm format\` clean.
- [x] \`pnpm lint\` clean (0 errors, 2 pre-existing warnings unchanged).
- No code changed; verify-deploy.sh / runtime behavior unaffected.