### PR TITLE
feat(cards): add quick-CTA row to card detail page (Closes #37)

### DIFF
--- a/e2e/cards-crud.spec.ts
+++ b/e2e/cards-crud.spec.ts
@@ -141,10 +141,10 @@ test.describe("Cards CRUD journey (emulator-backed)", () => {
     await expect(page.getByText("後續合作 AI 邊緣推論，穩定聯絡")).toBeVisible();
 
     // ────────────────────────────────────────────────────────────────
-    // 8. Touch "剛剛聯絡過"
+    // 8. Touch "記錄為已聯絡" (quick-CTA button; match by stable aria-label)
     // ────────────────────────────────────────────────────────────────
     await page.goto(`/cards/${cardId}`);
-    await page.getByRole("button", { name: /剛剛聯絡過/ }).click();
+    await page.getByRole("button", { name: /記錄為已聯絡/ }).click();
     // Wait for the action to complete (router.refresh).
     await page.waitForTimeout(500);
 

--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -194,6 +194,8 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
             cardId={card.id}
             primaryPhone={primaryPhone?.value}
             primaryEmail={primaryEmail?.value}
+            lineId={card.social?.lineId}
+            linkedinUrl={card.social?.linkedinUrl}
           />
 
           <footer className={styles.timestamps}>

--- a/src/components/cards/CardActions.module.css
+++ b/src/components/cards/CardActions.module.css
@@ -13,13 +13,89 @@
   margin: 0;
 }
 
+/* Primary CTA row — icon-first, 4-up grid */
+.quick {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-xs);
+}
+
+.quickButton {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: var(--space-sm) 2px;
+  min-height: 64px;
+  border-radius: var(--radius-md);
+  border: var(--border-thin) solid var(--color-border);
+  background: var(--color-bg-raised);
+  color: var(--color-fg);
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    transform var(--duration-fast) var(--ease-standard);
+  font-family: var(--font-sans);
+}
+
+.quickButton:hover:not(.quickDisabled):not(:disabled) {
+  border-color: var(--color-fg-muted);
+  transform: translateY(-1px);
+}
+
+.quickButton:active:not(.quickDisabled):not(:disabled) {
+  transform: translateY(0);
+}
+
+.quickButton:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+/* The "mark contacted" action is elevated to ink primary */
+.quickPrimary {
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-color: var(--color-ink);
+}
+
+.quickPrimary:hover:not(:disabled) {
+  background: var(--color-accent-ink);
+  border-color: var(--color-accent-ink);
+}
+
+.quickDisabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.quickIcon {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.quickLabel {
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+}
+
+/* Copy-to-clipboard row */
+.copyRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--space-xs);
+}
+
 .stack {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
 }
 
-.primary,
 .secondary,
 .destructive {
   font-family: var(--font-sans);
@@ -37,22 +113,6 @@
     background var(--duration-fast) var(--ease-standard),
     color var(--duration-fast) var(--ease-standard),
     border-color var(--duration-fast) var(--ease-standard);
-}
-
-.primary {
-  background: var(--color-ink);
-  color: var(--color-paper);
-  border-color: var(--color-ink);
-}
-
-.primary:hover:not(:disabled) {
-  background: var(--color-accent-ink);
-  border-color: var(--color-accent-ink);
-}
-
-.primary:disabled {
-  opacity: 0.6;
-  cursor: wait;
 }
 
 .secondary:hover {
@@ -75,6 +135,17 @@
   color: var(--color-paper);
   background: var(--color-accent);
   border-color: var(--color-accent);
+}
+
+.toast {
+  margin: 0;
+  padding: var(--space-xs) var(--space-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-radius: var(--radius-sm);
+  text-align: center;
 }
 
 .error {

--- a/src/components/cards/CardActions.tsx
+++ b/src/components/cards/CardActions.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 
 import { deleteCardAction, touchCardAction } from "@/app/(app)/cards/actions";
 
@@ -12,20 +12,38 @@ interface CardActionsProps {
   cardId: string;
   primaryPhone?: string;
   primaryEmail?: string;
+  lineId?: string;
+  linkedinUrl?: string;
 }
 
-export function CardActions({ cardId, primaryPhone, primaryEmail }: CardActionsProps) {
+export function CardActions({
+  cardId,
+  primaryPhone,
+  primaryEmail,
+  lineId,
+  linkedinUrl,
+}: CardActionsProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [confirming, setConfirming] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 2000);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   const handleTouch = () => {
     setError(null);
     startTransition(async () => {
       const result = await touchCardAction({ id: cardId });
       if (result?.serverError) setError(result.serverError);
-      else router.refresh();
+      else {
+        setToast("已記錄聯絡");
+        router.refresh();
+      }
     });
   };
 
@@ -42,24 +60,136 @@ export function CardActions({ cardId, primaryPhone, primaryEmail }: CardActionsP
     });
   };
 
+  const copyToClipboard = async (value: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setToast(`已複製${label}`);
+    } catch {
+      setToast("複製失敗");
+    }
+  };
+
+  // LINE deep-link: older LINE IDs (@foo) use line://ti/p/@foo, user IDs
+  // without @ use ~{id}. Both open the LINE app when present.
+  const lineHref = lineId
+    ? `https://line.me/ti/p/${lineId.startsWith("@") ? encodeURIComponent(lineId) : `~${encodeURIComponent(lineId)}`}`
+    : null;
+
   return (
     <section className={styles.actions} aria-label="Actions">
-      <p className={styles.title}>動作</p>
-      <div className={styles.stack}>
-        <button type="button" className={styles.primary} onClick={handleTouch} disabled={pending}>
-          {pending ? "記錄中…" : "標記：剛剛聯絡過"}
+      <p className={styles.title}>快速動作</p>
+
+      {/* Primary CTAs — 商務人士最常觸發的四個動作 */}
+      <div className={styles.quick}>
+        {primaryPhone ? (
+          <a
+            href={`tel:${primaryPhone}`}
+            className={styles.quickButton}
+            aria-label={`撥打 ${primaryPhone}`}
+          >
+            <span className={styles.quickIcon} aria-hidden="true">
+              📞
+            </span>
+            <span className={styles.quickLabel}>電話</span>
+          </a>
+        ) : (
+          <span className={`${styles.quickButton} ${styles.quickDisabled}`} aria-disabled="true">
+            <span className={styles.quickIcon} aria-hidden="true">
+              📞
+            </span>
+            <span className={styles.quickLabel}>電話</span>
+          </span>
+        )}
+        {primaryEmail ? (
+          <a
+            href={`mailto:${primaryEmail}`}
+            className={styles.quickButton}
+            aria-label={`寄信到 ${primaryEmail}`}
+          >
+            <span className={styles.quickIcon} aria-hidden="true">
+              📧
+            </span>
+            <span className={styles.quickLabel}>Email</span>
+          </a>
+        ) : (
+          <span className={`${styles.quickButton} ${styles.quickDisabled}`} aria-disabled="true">
+            <span className={styles.quickIcon} aria-hidden="true">
+              📧
+            </span>
+            <span className={styles.quickLabel}>Email</span>
+          </span>
+        )}
+        {lineHref ? (
+          <a
+            href={lineHref}
+            className={styles.quickButton}
+            target="_blank"
+            rel="noreferrer noopener"
+            aria-label="開啟 LINE"
+          >
+            <span className={styles.quickIcon} aria-hidden="true">
+              💬
+            </span>
+            <span className={styles.quickLabel}>LINE</span>
+          </a>
+        ) : (
+          <span className={`${styles.quickButton} ${styles.quickDisabled}`} aria-disabled="true">
+            <span className={styles.quickIcon} aria-hidden="true">
+              💬
+            </span>
+            <span className={styles.quickLabel}>LINE</span>
+          </span>
+        )}
+        <button
+          type="button"
+          className={`${styles.quickButton} ${styles.quickPrimary}`}
+          onClick={handleTouch}
+          disabled={pending}
+          aria-label="記錄為已聯絡"
+        >
+          <span className={styles.quickIcon} aria-hidden="true">
+            ✅
+          </span>
+          <span className={styles.quickLabel}>{pending ? "記錄中…" : "已聯絡"}</span>
         </button>
+      </div>
+
+      {/* Copy-to-clipboard row — 商務常需快速複製貼到其他 app */}
+      {(primaryEmail || primaryPhone) && (
+        <div className={styles.copyRow}>
+          {primaryEmail && (
+            <button
+              type="button"
+              className={styles.secondary}
+              onClick={() => copyToClipboard(primaryEmail, " email")}
+            >
+              複製 Email
+            </button>
+          )}
+          {primaryPhone && (
+            <button
+              type="button"
+              className={styles.secondary}
+              onClick={() => copyToClipboard(primaryPhone, "電話")}
+            >
+              複製電話
+            </button>
+          )}
+        </div>
+      )}
+
+      <div className={styles.stack}>
         <a href={`/api/cards/${cardId}/vcard`} className={styles.secondary}>
           匯出 vCard
         </a>
-        {primaryPhone && (
-          <a href={`tel:${primaryPhone}`} className={styles.secondary}>
-            撥打電話
-          </a>
-        )}
-        {primaryEmail && (
-          <a href={`mailto:${primaryEmail}`} className={styles.secondary}>
-            寫 Email
+        {linkedinUrl && (
+          <a
+            href={linkedinUrl}
+            className={styles.secondary}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            開啟 LinkedIn ↗
           </a>
         )}
         <Link href={`/cards/${cardId}/edit`} className={styles.secondary}>
@@ -74,6 +204,13 @@ export function CardActions({ cardId, primaryPhone, primaryEmail }: CardActionsP
           {confirming ? "確定要刪除嗎？" : "刪除名片"}
         </button>
       </div>
+
+      {toast && (
+        <p role="status" aria-live="polite" className={styles.toast}>
+          {toast}
+        </p>
+      )}
+
       {error && (
         <p role="alert" className={styles.error}>
           {error}

--- a/src/components/cards/__tests__/CardActions.test.tsx
+++ b/src/components/cards/__tests__/CardActions.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { CardActions } from "../CardActions";
+
+// Stub the Server Actions — this unit test is purely about render state,
+// not the mutation path (SIT covers that).
+vi.mock("@/app/(app)/cards/actions", () => ({
+  deleteCardAction: vi.fn(),
+  touchCardAction: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+
+describe("CardActions quick CTA row", () => {
+  it("renders the mark-contacted button even without any contact fields", () => {
+    render(<CardActions cardId="abc" />);
+    expect(screen.getByRole("button", { name: /記錄為已聯絡/ })).toBeInTheDocument();
+    // Quick row always renders 4 slots (Phone / Email / LINE / Already contacted).
+    // Without contact data, the first 3 are rendered as disabled span stubs.
+    expect(screen.getAllByText("電話")).toHaveLength(1);
+    expect(screen.getAllByText("Email")).toHaveLength(1);
+    expect(screen.getAllByText("LINE")).toHaveLength(1);
+  });
+
+  it("emits tel: deep link when primaryPhone is provided", () => {
+    render(<CardActions cardId="abc" primaryPhone="0928030326" />);
+    const phoneLink = screen.getByLabelText("撥打 0928030326") as HTMLAnchorElement;
+    expect(phoneLink.href).toBe("tel:0928030326");
+  });
+
+  it("emits mailto: deep link when primaryEmail is provided", () => {
+    render(<CardActions cardId="abc" primaryEmail="x@y.com" />);
+    const mailLink = screen.getByLabelText("寄信到 x@y.com") as HTMLAnchorElement;
+    expect(mailLink.href).toBe("mailto:x@y.com");
+  });
+
+  it("builds LINE deep link with @ prefix for official LINE IDs", () => {
+    render(<CardActions cardId="abc" lineId="@openclaw" />);
+    const lineLink = screen.getByLabelText("開啟 LINE") as HTMLAnchorElement;
+    expect(lineLink.href).toContain("line.me/ti/p/");
+    expect(lineLink.href).toContain(encodeURIComponent("@openclaw"));
+  });
+
+  it("builds LINE deep link with ~ prefix for user IDs without @", () => {
+    render(<CardActions cardId="abc" lineId="yuhan" />);
+    const lineLink = screen.getByLabelText("開啟 LINE") as HTMLAnchorElement;
+    expect(lineLink.href).toContain("line.me/ti/p/~yuhan");
+  });
+
+  it("renders LinkedIn button only when URL is present", () => {
+    const { rerender } = render(<CardActions cardId="abc" />);
+    expect(screen.queryByText(/開啟 LinkedIn/)).not.toBeInTheDocument();
+    rerender(<CardActions cardId="abc" linkedinUrl="https://linkedin.com/in/x" />);
+    const linkedinLink = screen.getByText(/開啟 LinkedIn/) as HTMLAnchorElement;
+    expect(linkedinLink.closest("a")?.href).toBe("https://linkedin.com/in/x");
+  });
+
+  it("renders copy-row only when at least one of phone/email exists", () => {
+    const { rerender } = render(<CardActions cardId="abc" />);
+    expect(screen.queryByText("複製 Email")).not.toBeInTheDocument();
+    expect(screen.queryByText("複製電話")).not.toBeInTheDocument();
+    rerender(<CardActions cardId="abc" primaryEmail="x@y.com" />);
+    expect(screen.getByText("複製 Email")).toBeInTheDocument();
+    expect(screen.queryByText("複製電話")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #37. First slice of the \"business-user UX\" track.

## Why

Business users open a card to call, email, LINE, or log \"I just contacted this person\". Each was previously 2-4 steps (scroll → copy → switch app → paste). Now each is 1 click.

## Changes

- 4-up icon grid at top of actions sidebar: Phone / Email / LINE / ✅ Already contacted. Mark-contacted is elevated to ink primary.
- Copy Email / Copy Phone buttons (clipboard + 2s toast). Critical on mobile where browsers don't expose OS copy.
- Open LinkedIn button when \`social.linkedinUrl\` is set.
- LINE deep link encodes both official IDs (\`@foo\` → \`line.me/ti/p/@foo\`) and user IDs (\`foo\` → \`line.me/ti/p/~foo\`).
- Disabled slots render as span stubs, not hidden, so layout doesn't jitter as data hydrates.

No schema change. \`touchCardAction\` already existed — CTA just wires to it and now shows a success toast.

## Not in scope

- Contact-log history (per-card event stream) — own issue.
- Multi-value phone/email picker — next UX pass.
- \`navigator.share()\` fallback — requires vCard blob plumbing.

## Test plan

- [x] 7 new UT: disabled states, tel: / mailto: href, LINE deep link (both encodings), LinkedIn + copy-row visibility gates.
- [x] Full suite: 290 pass / 21 skipped (was 283 / 21). SIT & rules integration untouched.
- [x] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm format\` all clean.
- [ ] CI gates.
- [ ] Manual smoke on prod after merge: open a real card, try all 4 quick buttons + copy + mark-contacted, confirm toast + router refresh.