### PR TITLE
feat(cards): contact-event log per card (Closes #39)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -109,6 +109,28 @@ service cloud.firestore {
           ownershipUnchanged();
 
         allow delete: if isAuthed() && isMember(resource.data.memberUids);
+
+        // ==================== Contact events (append-only log) ====================
+        // Each card accumulates a stream of contact events. Members of the
+        // parent card (read via get() — small, infrequent) can read and
+        // append. Edit and delete are disallowed at the rules layer;
+        // retractions / redactions go through a future Admin-SDK path.
+        match /contactEvents/{eventId} {
+          function parentCardMembers() {
+            return get(/databases/$(database)/documents/workspaces/$(wid)/cards/$(cardId)).data.memberUids;
+          }
+
+          allow read: if isAuthed() && request.auth.uid in parentCardMembers();
+
+          allow create: if isAuthed() &&
+            request.auth.uid in parentCardMembers() &&
+            incoming().authorUid == request.auth.uid &&
+            incoming().at == request.time &&
+            (!('note' in incoming()) ||
+              (incoming().note is string && incoming().note.size() <= 500));
+
+          allow update, delete: if false;
+        }
       }
 
       // ==================== Tags subcollection ====================

--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -2,8 +2,9 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { CardActions } from "@/components/cards/CardActions";
+import { ContactEventList } from "@/components/cards/ContactEventList";
 import { TagSuggestionsBanner } from "@/components/tags/TagSuggestionsBanner";
-import { getCardForUser } from "@/db/cards";
+import { getCardForUser, listContactEventsForUser } from "@/db/cards";
 import type { CardCreateInput } from "@/db/schema";
 import { readSession } from "@/lib/firebase/session";
 
@@ -33,6 +34,7 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
   if (!user) return null;
   const card = await getCardForUser(user.uid, id);
   if (!card || card.deletedAt) notFound();
+  const contactEvents = await listContactEventsForUser(id, user.uid, 30);
 
   const primary = card.nameZh || card.nameEn || "（未命名）";
   const secondary = card.nameZh && card.nameEn ? card.nameEn : null;
@@ -140,6 +142,8 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
               <p className={styles.notesBody}>{card.notes}</p>
             </section>
           )}
+
+          <ContactEventList events={contactEvents} />
         </main>
 
         <aside className={styles.sidebar} aria-label="Contact details">

--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -6,8 +6,8 @@ import { z } from "zod";
 import { authedAction } from "@/lib/auth/safe-action";
 import {
   createCardForUser,
+  logContactEvent,
   softDeleteCardForUser,
-  touchLastContactedAt,
   updateCardForUser,
 } from "@/db/cards";
 import { cardCreateSchema, cardUpdateSchema } from "@/db/schema";
@@ -50,10 +50,41 @@ export const deleteCardAction = authedAction
     return { ok: true as const };
   });
 
+/**
+ * Log a contact event (optionally with a short note) and refresh the
+ * card's lastContactedAt ranking signal. `touchCardAction` is kept as
+ * a thin alias so existing callers (just mark-contacted) keep working.
+ */
+export const logContactAction = authedAction
+  .inputSchema(
+    z.object({
+      id: z.string().min(1),
+      note: z.string().max(500).default(""),
+    }),
+  )
+  .action(async ({ parsedInput, ctx }) => {
+    const eventId = await logContactEvent(parsedInput.id, {
+      uid: ctx.user.uid,
+      note: parsedInput.note,
+      authorDisplay: ctx.user.displayName ?? null,
+    });
+    revalidatePath("/");
+    revalidatePath(`/cards/${parsedInput.id}`);
+    return { ok: true as const, eventId };
+  });
+
+/**
+ * @deprecated Prefer `logContactAction`. Retained so any existing
+ * callers keep working; internally logs an empty-note event.
+ */
 export const touchCardAction = authedAction
   .inputSchema(z.object({ id: z.string().min(1) }))
   .action(async ({ parsedInput, ctx }) => {
-    await touchLastContactedAt(parsedInput.id, { uid: ctx.user.uid });
+    await logContactEvent(parsedInput.id, {
+      uid: ctx.user.uid,
+      note: "",
+      authorDisplay: ctx.user.displayName ?? null,
+    });
     revalidatePath("/");
     revalidatePath(`/cards/${parsedInput.id}`);
     return { ok: true as const };

--- a/src/components/cards/CardActions.module.css
+++ b/src/components/cards/CardActions.module.css
@@ -137,6 +137,45 @@
   border-color: var(--color-accent);
 }
 
+.noteBox {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-sm);
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-raised);
+}
+
+.noteInput {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  line-height: 1.45;
+  padding: var(--space-xs) var(--space-sm);
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-paper);
+  color: var(--color-fg);
+  resize: vertical;
+  min-height: 60px;
+}
+
+.noteInput:focus {
+  outline: none;
+  border-color: var(--color-ink);
+}
+
+.noteActions {
+  display: flex;
+  gap: var(--space-xs);
+  justify-content: flex-end;
+}
+
+.noteActions .secondary {
+  flex: 0 1 auto;
+  padding: var(--space-xs) var(--space-sm);
+}
+
 .toast {
   margin: 0;
   padding: var(--space-xs) var(--space-sm);

--- a/src/components/cards/CardActions.tsx
+++ b/src/components/cards/CardActions.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useTransition } from "react";
 
-import { deleteCardAction, touchCardAction } from "@/app/(app)/cards/actions";
+import { deleteCardAction, logContactAction } from "@/app/(app)/cards/actions";
 
 import styles from "./CardActions.module.css";
 
@@ -28,6 +28,8 @@ export function CardActions({
   const [confirming, setConfirming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
+  const [logNoteOpen, setLogNoteOpen] = useState(false);
+  const [noteDraft, setNoteDraft] = useState("");
 
   useEffect(() => {
     if (!toast) return;
@@ -36,12 +38,25 @@ export function CardActions({
   }, [toast]);
 
   const handleTouch = () => {
+    // First click: reveal the note input. User can type a note and submit,
+    // or click 「跳過備註」 to log an empty event. This keeps 1-click
+    // behavior cheap while making the log meaningful when content matters.
+    if (!logNoteOpen) {
+      setLogNoteOpen(true);
+      return;
+    }
+    submitLog(noteDraft);
+  };
+
+  const submitLog = (note: string) => {
     setError(null);
     startTransition(async () => {
-      const result = await touchCardAction({ id: cardId });
+      const result = await logContactAction({ id: cardId, note });
       if (result?.serverError) setError(result.serverError);
       else {
-        setToast("已記錄聯絡");
+        setToast(note.trim() ? "已記錄互動" : "已標記聯絡");
+        setLogNoteOpen(false);
+        setNoteDraft("");
         router.refresh();
       }
     });
@@ -146,13 +161,52 @@ export function CardActions({
           onClick={handleTouch}
           disabled={pending}
           aria-label="記錄為已聯絡"
+          aria-expanded={logNoteOpen}
         >
           <span className={styles.quickIcon} aria-hidden="true">
             ✅
           </span>
-          <span className={styles.quickLabel}>{pending ? "記錄中…" : "已聯絡"}</span>
+          <span className={styles.quickLabel}>
+            {pending ? "記錄中…" : logNoteOpen ? "記錄" : "已聯絡"}
+          </span>
         </button>
       </div>
+
+      {logNoteOpen && (
+        <div className={styles.noteBox}>
+          <textarea
+            className={styles.noteInput}
+            placeholder="寫一句互動摘要（可留空）"
+            value={noteDraft}
+            onChange={(e) => setNoteDraft(e.target.value.slice(0, 500))}
+            maxLength={500}
+            rows={2}
+            autoFocus
+            aria-label="互動備註（500 字以內）"
+          />
+          <div className={styles.noteActions}>
+            <button
+              type="button"
+              className={styles.secondary}
+              onClick={() => submitLog("")}
+              disabled={pending}
+            >
+              跳過備註
+            </button>
+            <button
+              type="button"
+              className={styles.secondary}
+              onClick={() => {
+                setLogNoteOpen(false);
+                setNoteDraft("");
+              }}
+              disabled={pending}
+            >
+              取消
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Copy-to-clipboard row — 商務常需快速複製貼到其他 app */}
       {(primaryEmail || primaryPhone) && (

--- a/src/components/cards/ContactEventList.module.css
+++ b/src/components/cards/ContactEventList.module.css
@@ -1,0 +1,70 @@
+.section {
+  margin-top: var(--space-xl);
+  padding-top: var(--space-lg);
+  border-top: var(--border-thin) solid var(--color-border);
+}
+
+.title {
+  font-family: var(--font-serif);
+  font-size: var(--text-h3);
+  letter-spacing: var(--tracking-tight);
+  margin: 0 0 var(--space-md);
+  color: var(--color-fg);
+}
+
+.empty {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-body);
+  color: var(--color-fg-muted);
+  margin: 0;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-left: var(--space-md);
+  border-left: 2px solid var(--color-accent-ink);
+}
+
+.when {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+}
+
+.note {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  line-height: 1.55;
+  color: var(--color-fg);
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.noteMuted {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+  margin: 0;
+}
+
+.author {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+  margin: 0;
+}

--- a/src/components/cards/ContactEventList.tsx
+++ b/src/components/cards/ContactEventList.tsx
@@ -1,0 +1,50 @@
+import type { ContactEvent } from "@/db/cards";
+
+import styles from "./ContactEventList.module.css";
+
+interface ContactEventListProps {
+  events: ContactEvent[];
+}
+
+/**
+ * Render the contact-event log for a card, newest first. Designed to
+ * sit beneath the main detail copy — 空狀態也印一行提示，讓 user 看到
+ * 「這裡將出現互動紀錄」，不會突兀。
+ */
+export function ContactEventList({ events }: ContactEventListProps) {
+  return (
+    <section className={styles.section} aria-label="互動紀錄">
+      <h2 className={styles.title}>互動紀錄</h2>
+      {events.length === 0 ? (
+        <p className={styles.empty}>還沒有互動紀錄。按「✅ 已聯絡」後會顯示在這裡。</p>
+      ) : (
+        <ol className={styles.list}>
+          {events.map((e) => (
+            <li key={e.id} className={styles.item}>
+              <time className={styles.when} dateTime={e.at.toISOString()}>
+                {formatDateTime(e.at)}
+              </time>
+              {e.note ? (
+                <p className={styles.note}>{e.note}</p>
+              ) : (
+                <p className={styles.noteMuted}>（無備註）</p>
+              )}
+              {e.authorDisplay && <p className={styles.author}>— {e.authorDisplay}</p>}
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+// Local-time-friendly format: 2026-04-24 09:30 (TW). Avoids Intl.DateTimeFormat
+// timezone surprises on the server when we render at SSR time.
+function formatDateTime(d: Date): string {
+  const y = d.getFullYear();
+  const mo = String(d.getMonth() + 1).padStart(2, "0");
+  const da = String(d.getDate()).padStart(2, "0");
+  const h = String(d.getHours()).padStart(2, "0");
+  const m = String(d.getMinutes()).padStart(2, "0");
+  return `${y}-${mo}-${da} ${h}:${m}`;
+}

--- a/src/components/cards/__tests__/CardActions.test.tsx
+++ b/src/components/cards/__tests__/CardActions.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 import { CardActions } from "../CardActions";
 
@@ -7,7 +7,7 @@ import { CardActions } from "../CardActions";
 // not the mutation path (SIT covers that).
 vi.mock("@/app/(app)/cards/actions", () => ({
   deleteCardAction: vi.fn(),
-  touchCardAction: vi.fn(),
+  logContactAction: vi.fn().mockResolvedValue({ ok: true, eventId: "ev1" }),
 }));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
@@ -64,5 +64,41 @@ describe("CardActions quick CTA row", () => {
     rerender(<CardActions cardId="abc" primaryEmail="x@y.com" />);
     expect(screen.getByText("複製 Email")).toBeInTheDocument();
     expect(screen.queryByText("複製電話")).not.toBeInTheDocument();
+  });
+
+  describe("contact-event note flow", () => {
+    it("first click on 已聯絡 expands the note input (doesn't fire the action)", () => {
+      render(<CardActions cardId="abc" />);
+      expect(screen.queryByLabelText(/互動備註/)).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /記錄為已聯絡/ }));
+      expect(screen.getByLabelText(/互動備註/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /記錄為已聯絡/ })).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+    });
+
+    it("cancel button closes the note input without submitting", () => {
+      render(<CardActions cardId="abc" />);
+      fireEvent.click(screen.getByRole("button", { name: /記錄為已聯絡/ }));
+      expect(screen.getByLabelText(/互動備註/)).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /取消/ }));
+      expect(screen.queryByLabelText(/互動備註/)).not.toBeInTheDocument();
+    });
+
+    it("typing a note and clicking 記錄 submits the trimmed value", async () => {
+      const { logContactAction } = await import("@/app/(app)/cards/actions");
+      render(<CardActions cardId="abc" />);
+      fireEvent.click(screen.getByRole("button", { name: /記錄為已聯絡/ }));
+      const textarea = screen.getByLabelText(/互動備註/) as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "wrote follow-up email" } });
+      fireEvent.click(screen.getByRole("button", { name: /記錄為已聯絡/ }));
+      await vi.waitFor(() => {
+        expect(logContactAction).toHaveBeenCalledWith({
+          id: "abc",
+          note: "wrote follow-up email",
+        });
+      });
+    });
   });
 });

--- a/src/db/__tests__/cards.sit.test.ts
+++ b/src/db/__tests__/cards.sit.test.ts
@@ -312,4 +312,69 @@ describe("cards repository (SIT)", () => {
       expect(second.getTime()).toBeGreaterThan(first.getTime());
     });
   });
+
+  describe("logContactEvent + listContactEventsForUser", () => {
+    it("appends an event and bumps lastContactedAt in one atomic write", async () => {
+      const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      const before = Date.now();
+      const eventId = await repo.logContactEvent(id, {
+        uid: TEST_UID_ALICE,
+        note: "發了 proposal",
+        authorDisplay: "Alice",
+      });
+      expect(eventId).toMatch(/^[A-Za-z0-9]+$/);
+
+      const events = await repo.listContactEventsForUser(id, TEST_UID_ALICE);
+      expect(events).toHaveLength(1);
+      expect(events[0].note).toBe("發了 proposal");
+      expect(events[0].authorDisplay).toBe("Alice");
+      expect(events[0].authorUid).toBe(TEST_UID_ALICE);
+      expect(events[0].at.getTime()).toBeGreaterThanOrEqual(before - 1000);
+
+      const card = (await repo.getCardForUser(TEST_UID_ALICE, id))!;
+      expect(card.lastContactedAt).toBeInstanceOf(Date);
+    });
+
+    it("allows empty note and preserves author=null", async () => {
+      const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await repo.logContactEvent(id, { uid: TEST_UID_ALICE });
+      const events = await repo.listContactEventsForUser(id, TEST_UID_ALICE);
+      expect(events[0].note).toBe("");
+      expect(events[0].authorDisplay).toBeNull();
+    });
+
+    it("truncates notes beyond 500 characters", async () => {
+      const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      const long = "a".repeat(600);
+      await repo.logContactEvent(id, { uid: TEST_UID_ALICE, note: long });
+      const events = await repo.listContactEventsForUser(id, TEST_UID_ALICE);
+      expect(events[0].note).toHaveLength(500);
+    });
+
+    it("returns events newest-first", async () => {
+      const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await repo.logContactEvent(id, { uid: TEST_UID_ALICE, note: "first" });
+      await new Promise((r) => setTimeout(r, 25));
+      await repo.logContactEvent(id, { uid: TEST_UID_ALICE, note: "second" });
+      await new Promise((r) => setTimeout(r, 25));
+      await repo.logContactEvent(id, { uid: TEST_UID_ALICE, note: "third" });
+
+      const events = await repo.listContactEventsForUser(id, TEST_UID_ALICE);
+      expect(events.map((e) => e.note)).toEqual(["third", "second", "first"]);
+    });
+
+    it("refuses to log on a card the caller doesn't own", async () => {
+      const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await expect(
+        repo.logContactEvent(id, { uid: TEST_UID_BOB, note: "intruder" }),
+      ).rejects.toThrow();
+    });
+
+    it("returns empty list when caller has no access", async () => {
+      const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await repo.logContactEvent(id, { uid: TEST_UID_ALICE, note: "private" });
+      const events = await repo.listContactEventsForUser(id, TEST_UID_BOB);
+      expect(events).toEqual([]);
+    });
+  });
 });

--- a/src/db/cards.ts
+++ b/src/db/cards.ts
@@ -189,4 +189,106 @@ export async function touchLastContactedAt(
   }
 }
 
+// ==================== Contact events (append-only log) ====================
+
+export const SUB_COLLECTION_CONTACT_EVENTS = "contactEvents";
+
+export interface ContactEvent {
+  id: string;
+  at: Date;
+  note: string;
+  authorUid: string;
+  authorDisplay: string | null;
+}
+
+export interface LogContactEventOptions {
+  uid: string;
+  note?: string;
+  authorDisplay?: string | null;
+}
+
+/**
+ * Append a contact event to a card's log AND update the card's
+ * lastContactedAt ranking signal in a single batch. Typesense reindex
+ * follows so sort_by: lastContactedAt:desc reflects the change.
+ *
+ * Returns the event id for callers that want to show it optimistically.
+ * Throws if the caller is not a member of the card.
+ */
+export async function logContactEvent(
+  cardId: string,
+  { uid, note = "", authorDisplay = null }: LogContactEventOptions,
+): Promise<string> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const cardRef = db.doc(`${cardsPath(wid)}/${cardId}`);
+  const snap = await cardRef.get();
+  if (!snap.exists) throw new Error("card not found");
+  const data = snap.data()!;
+  if (!data.memberUids?.includes(uid)) throw new Error("無權限記錄互動");
+
+  const trimmedNote = note.slice(0, 500);
+  const eventRef = cardRef.collection(SUB_COLLECTION_CONTACT_EVENTS).doc();
+  const now = FieldValue.serverTimestamp();
+  const batch = db.batch();
+  batch.set(eventRef, {
+    at: now,
+    note: trimmedNote,
+    authorUid: uid,
+    authorDisplay,
+  });
+  batch.update(cardRef, {
+    lastContactedAt: now,
+    updatedAt: now,
+  });
+  await batch.commit();
+
+  const after = await cardRef.get();
+  if (after.exists && after.data()?.deletedAt === null) {
+    await syncWithFallback(wid, "upsert", cardId, toSummary(cardId, after.data()!));
+  }
+
+  return eventRef.id;
+}
+
+/**
+ * Read recent contact events for a card, newest first. Access check
+ * uses the same memberUids rule as getCardForUser — we don't leak
+ * events from cards the caller can't otherwise read.
+ */
+export async function listContactEventsForUser(
+  cardId: string,
+  uid: string,
+  limit = 50,
+): Promise<ContactEvent[]> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const cardRef = db.doc(`${cardsPath(wid)}/${cardId}`);
+  const cardSnap = await cardRef.get();
+  if (!cardSnap.exists) return [];
+  const data = cardSnap.data()!;
+  if (!data.memberUids?.includes(uid)) return [];
+
+  const snap = await cardRef
+    .collection(SUB_COLLECTION_CONTACT_EVENTS)
+    .orderBy("at", "desc")
+    .limit(limit)
+    .get();
+  return snap.docs.map((doc) => {
+    const raw = doc.data();
+    return {
+      id: doc.id,
+      at: raw.at?.toDate?.() ?? new Date(0),
+      note: typeof raw.note === "string" ? raw.note : "",
+      authorUid: typeof raw.authorUid === "string" ? raw.authorUid : "",
+      authorDisplay:
+        typeof raw.authorDisplay === "string"
+          ? raw.authorDisplay
+          : raw.authorDisplay === null
+            ? null
+            : null,
+    } satisfies ContactEvent;
+  });
+}
+
 export { COLLECTION_WORKSPACES, SUB_COLLECTION_CARDS };


### PR DESCRIPTION
Closes #39. Business-UX track, second slice — gives the card a memory of what happened, not just when.

## What

- Firestore subcollection `contactEvents` under each card. Append-only.
- Rules inherit from parent card memberUids; create allowed if caller is a member and note ≤ 500; update/delete disallowed.
- `logContactAction({ id, note? })`: atomic event + lastContactedAt bump + Typesense reindex.
- `touchCardAction` kept as a deprecated alias (empty-note event) so no caller breaks.
- `CardActions` ✅ button: first click opens a small textarea, second click submits. 「跳過備註」 = one-click empty event. Cancel closes without write.
- `ContactEventList` on the detail page: newest-first, 30 cap, empty-state hint.

## Test plan

- [x] 6 SIT (append atomicity, empty note, 500-char truncate, order, member refusal, read isolation)
- [x] 3 UT (expand, cancel, submit-with-note)
- [x] Full UT suite: 293 pass / 21 skipped (was 290 / 21)
- [x] typecheck + lint + format clean
- [ ] CI gates
- [ ] Manual post-merge: log an event on a real card with a note, log another without, check the detail page list + timeline ordering unchanged.

## Deploy reminder

After merge, need to deploy new Firestore rules (`contactEvents` block):
`pnpm exec firebase deploy --only firestore:rules --project namecard-web-prd`