### PR TITLE
feat(cards): pin important contacts (Closes #41)

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -200,6 +200,7 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
             primaryEmail={primaryEmail?.value}
             lineId={card.social?.lineId}
             linkedinUrl={card.social?.linkedinUrl}
+            isPinned={card.isPinned}
           />
 
           <footer className={styles.timestamps}>

--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -7,6 +7,7 @@ import { authedAction } from "@/lib/auth/safe-action";
 import {
   createCardForUser,
   logContactEvent,
+  setCardPinned,
   softDeleteCardForUser,
   updateCardForUser,
 } from "@/db/cards";
@@ -71,6 +72,20 @@ export const logContactAction = authedAction
     revalidatePath("/");
     revalidatePath(`/cards/${parsedInput.id}`);
     return { ok: true as const, eventId };
+  });
+
+/**
+ * Flip a card's pin state. Pinned cards appear in the Timeline's
+ * Pinned section at the top and are excluded from 「最近沒聯絡」.
+ */
+export const toggleCardPinAction = authedAction
+  .inputSchema(z.object({ id: z.string().min(1), pinned: z.boolean() }))
+  .action(async ({ parsedInput, ctx }) => {
+    await setCardPinned(parsedInput.id, ctx.user.uid, parsedInput.pinned);
+    revalidatePath("/");
+    revalidatePath("/cards");
+    revalidatePath(`/cards/${parsedInput.id}`);
+    return { ok: true as const, pinned: parsedInput.pinned };
   });
 
 /**

--- a/src/components/cards/CardActions.tsx
+++ b/src/components/cards/CardActions.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useTransition } from "react";
 
-import { deleteCardAction, logContactAction } from "@/app/(app)/cards/actions";
+import { deleteCardAction, logContactAction, toggleCardPinAction } from "@/app/(app)/cards/actions";
 
 import styles from "./CardActions.module.css";
 
@@ -14,6 +14,7 @@ interface CardActionsProps {
   primaryEmail?: string;
   lineId?: string;
   linkedinUrl?: string;
+  isPinned?: boolean;
 }
 
 export function CardActions({
@@ -22,6 +23,7 @@ export function CardActions({
   primaryEmail,
   lineId,
   linkedinUrl,
+  isPinned = false,
 }: CardActionsProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
@@ -72,6 +74,18 @@ export function CardActions({
       const result = await deleteCardAction({ id: cardId });
       if (result?.serverError) setError(result.serverError);
       else router.push("/cards");
+    });
+  };
+
+  const handleTogglePin = () => {
+    setError(null);
+    startTransition(async () => {
+      const result = await toggleCardPinAction({ id: cardId, pinned: !isPinned });
+      if (result?.serverError) setError(result.serverError);
+      else {
+        setToast(isPinned ? "已取消置頂" : "已加入重要聯絡人");
+        router.refresh();
+      }
     });
   };
 
@@ -233,6 +247,15 @@ export function CardActions({
       )}
 
       <div className={styles.stack}>
+        <button
+          type="button"
+          className={styles.secondary}
+          onClick={handleTogglePin}
+          disabled={pending}
+          aria-pressed={isPinned}
+        >
+          {isPinned ? "📍 已置頂（取消）" : "📌 設為重要聯絡人"}
+        </button>
         <a href={`/api/cards/${cardId}/vcard`} className={styles.secondary}>
           匯出 vCard
         </a>

--- a/src/components/cards/__tests__/CardActions.test.tsx
+++ b/src/components/cards/__tests__/CardActions.test.tsx
@@ -8,6 +8,7 @@ import { CardActions } from "../CardActions";
 vi.mock("@/app/(app)/cards/actions", () => ({
   deleteCardAction: vi.fn(),
   logContactAction: vi.fn().mockResolvedValue({ ok: true, eventId: "ev1" }),
+  toggleCardPinAction: vi.fn().mockResolvedValue({ ok: true, pinned: true }),
 }));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
@@ -98,6 +99,26 @@ describe("CardActions quick CTA row", () => {
           id: "abc",
           note: "wrote follow-up email",
         });
+      });
+    });
+  });
+
+  describe("pin toggle", () => {
+    it("shows 設為重要聯絡人 when unpinned and 已置頂 when pinned", () => {
+      const { rerender } = render(<CardActions cardId="abc" />);
+      expect(screen.getByText(/設為重要聯絡人/)).toBeInTheDocument();
+      rerender(<CardActions cardId="abc" isPinned />);
+      expect(screen.getByText(/已置頂/)).toBeInTheDocument();
+    });
+
+    it("fires toggleCardPinAction with opposite pinned value", async () => {
+      const { toggleCardPinAction } = await import("@/app/(app)/cards/actions");
+      const mocked = vi.mocked(toggleCardPinAction);
+      mocked.mockClear();
+      render(<CardActions cardId="abc" isPinned={false} />);
+      fireEvent.click(screen.getByText(/設為重要聯絡人/));
+      await vi.waitFor(() => {
+        expect(mocked).toHaveBeenCalledWith({ id: "abc", pinned: true });
       });
     });
   });

--- a/src/db/__tests__/cards.sit.test.ts
+++ b/src/db/__tests__/cards.sit.test.ts
@@ -313,6 +313,21 @@ describe("cards repository (SIT)", () => {
     });
   });
 
+  describe("setCardPinned", () => {
+    it("flips isPinned on and off", async () => {
+      const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await repo.setCardPinned(id, TEST_UID_ALICE, true);
+      expect((await repo.getCardForUser(TEST_UID_ALICE, id))!.isPinned).toBe(true);
+      await repo.setCardPinned(id, TEST_UID_ALICE, false);
+      expect((await repo.getCardForUser(TEST_UID_ALICE, id))!.isPinned).toBe(false);
+    });
+
+    it("refuses to pin a card the caller doesn't own", async () => {
+      const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await expect(repo.setCardPinned(id, TEST_UID_BOB, true)).rejects.toThrow();
+    });
+  });
+
   describe("logContactEvent + listContactEventsForUser", () => {
     it("appends an event and bumps lastContactedAt in one atomic write", async () => {
       const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });

--- a/src/db/cards-data.ts
+++ b/src/db/cards-data.ts
@@ -43,6 +43,7 @@ export function toSummaryFromData(id: string, data: FirebaseFirestore.DocumentDa
     social: data.social ?? {},
     frontImagePath: data.frontImagePath,
     backImagePath: data.backImagePath,
+    isPinned: data.isPinned === true,
     createdAt: tsToDate(data.createdAt),
     updatedAt: tsToDate(data.updatedAt),
     lastContactedAt: tsToDate(data.lastContactedAt),

--- a/src/db/cards.ts
+++ b/src/db/cards.ts
@@ -46,6 +46,12 @@ export interface CardSummary {
   social?: Record<string, string | undefined>;
   frontImagePath?: string;
   backImagePath?: string;
+  /**
+   * Optional for backwards compat with card docs predating the pin
+   * feature. Consumers should treat undefined as false (categorize,
+   * CardActions already do).
+   */
+  isPinned?: boolean;
   createdAt: Date | null;
   updatedAt: Date | null;
   lastContactedAt: Date | null;
@@ -187,6 +193,27 @@ export async function touchLastContactedAt(
   if (after.exists && after.data()?.deletedAt === null) {
     await syncWithFallback(wid, "upsert", cardId, toSummary(cardId, after.data()!));
   }
+}
+
+/**
+ * Toggle the pin flag on a card. Pinned cards surface in the Timeline
+ * "Pinned" section at the top and are excluded from "uncontacted"
+ * so core contacts aren't shame-nudged. Pin state does not affect
+ * Typesense ranking (pinned is a UI concern, not a search signal),
+ * so this write intentionally skips the reindex.
+ */
+export async function setCardPinned(cardId: string, uid: string, pinned: boolean): Promise<void> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${cardsPath(wid)}/${cardId}`);
+  const snap = await ref.get();
+  if (!snap.exists) throw new Error("card not found");
+  const data = snap.data()!;
+  if (!data.memberUids?.includes(uid)) throw new Error("無權限修改此名片");
+  await ref.update({
+    isPinned: pinned,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
 }
 
 // ==================== Contact events (append-only log) ====================

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -105,6 +105,10 @@ const cardBaseShape = {
   // Tags (denormalized — tagIds for query, tagNames for display)
   tagIds: z.array(z.string().max(80)).max(30).default([]),
   tagNames: z.array(z.string().max(60)).max(30).default([]),
+
+  // Pin — surfaced in Pinned section at the top of the timeline.
+  // Optional for backwards-compat with existing card docs.
+  isPinned: z.boolean().optional(),
 };
 
 /** Payload shape when creating a card (client → server). */

--- a/src/lib/import/__tests__/dedupe.test.ts
+++ b/src/lib/import/__tests__/dedupe.test.ts
@@ -23,6 +23,7 @@ function aExistingCard(overrides: Partial<CardSummary> = {}): CardSummary {
     tagNames: [],
     phones: [],
     emails: [{ label: "work", value: "david@test.example" }],
+    isPinned: false,
     createdAt: null,
     updatedAt: null,
     lastContactedAt: null,

--- a/src/lib/search/__tests__/sync.test.ts
+++ b/src/lib/search/__tests__/sync.test.ts
@@ -15,6 +15,7 @@ function makeCard(overrides: Partial<CardSummary> = {}): CardSummary {
     tagNames: [],
     phones: [],
     emails: [],
+    isPinned: false,
     createdAt: new Date("2026-04-01T00:00:00Z"),
     updatedAt: new Date("2026-04-01T00:00:00Z"),
     lastContactedAt: null,

--- a/src/lib/tags/__tests__/suggest-llm.test.ts
+++ b/src/lib/tags/__tests__/suggest-llm.test.ts
@@ -16,6 +16,7 @@ function makeCard(overrides: Partial<CardCreateInput> = {}): CardCreateInput {
     whyRemember: "met at conference",
     nameEn: "Alice Chen",
     companyEn: "ACME Corp",
+    isPinned: false,
     ...overrides,
   };
 }

--- a/src/lib/tags/__tests__/suggest-rules.test.ts
+++ b/src/lib/tags/__tests__/suggest-rules.test.ts
@@ -14,6 +14,7 @@ function makeCard(overrides: Partial<CardCreateInput> = {}): CardCreateInput {
     tagIds: [],
     tagNames: [],
     whyRemember: "test",
+    isPinned: false,
     ...overrides,
   };
 }

--- a/src/lib/tags/__tests__/suggest.test.ts
+++ b/src/lib/tags/__tests__/suggest.test.ts
@@ -22,6 +22,7 @@ function makeCard(overrides: Partial<CardCreateInput> = {}): CardCreateInput {
     tagIds: [],
     tagNames: [],
     whyRemember: "test",
+    isPinned: false,
     ...overrides,
   };
 }

--- a/src/lib/timeline/__tests__/categorize.test.ts
+++ b/src/lib/timeline/__tests__/categorize.test.ts
@@ -19,6 +19,7 @@ function card(overrides: Partial<CardSummary> = {}): CardSummary {
     phones: [],
     emails: [],
     social: {},
+    isPinned: false,
     createdAt: new Date("2026-01-01T00:00:00Z"),
     updatedAt: new Date("2026-01-01T00:00:00Z"),
     lastContactedAt: null,
@@ -28,21 +29,55 @@ function card(overrides: Partial<CardSummary> = {}): CardSummary {
 }
 
 describe("categorizeTimeline", () => {
-  it("returns 3 sections in fixed order", () => {
+  it("returns 4 sections in fixed order (pinned first)", () => {
     const sections = categorizeTimeline([], { now: NOW });
-    expect(sections.map((s) => s.id)).toEqual(["newly-added", "met-this-month", "uncontacted"]);
+    expect(sections.map((s) => s.id)).toEqual([
+      "pinned",
+      "newly-added",
+      "met-this-month",
+      "uncontacted",
+    ]);
+  });
+
+  it("puts pinned cards in the pinned section and excludes them from uncontacted", () => {
+    const staleAndPinned = card({
+      id: "p",
+      isPinned: true,
+      createdAt: new Date("2020-01-01T00:00:00Z"),
+      lastContactedAt: new Date("2020-01-01T00:00:00Z"),
+    });
+    const staleUnpinned = card({
+      id: "u",
+      isPinned: false,
+      createdAt: new Date("2020-01-01T00:00:00Z"),
+      lastContactedAt: new Date("2020-01-01T00:00:00Z"),
+    });
+    const sections = categorizeTimeline([staleAndPinned, staleUnpinned], { now: NOW });
+    const pinned = sections.find((s) => s.id === "pinned")!;
+    const uncontacted = sections.find((s) => s.id === "uncontacted")!;
+    expect(pinned.cards.map((c) => c.id)).toEqual(["p"]);
+    expect(uncontacted.cards.map((c) => c.id)).toEqual(["u"]);
+  });
+
+  it("pinned section is not capped (bypasses maxPerSection)", () => {
+    const many = Array.from({ length: 12 }, (_, i) =>
+      card({ id: `p${i}`, isPinned: true, updatedAt: new Date(2026, 3, 20 - i) }),
+    );
+    const sections = categorizeTimeline(many, { now: NOW, maxPerSection: 5 });
+    const pinned = sections.find((s) => s.id === "pinned")!;
+    expect(pinned.cards).toHaveLength(12);
   });
 
   it("classifies firstMetDate in current month as met-this-month", () => {
     const c = card({ firstMetDate: "2026-04-10" });
-    const [, met] = categorizeTimeline([c], { now: NOW });
+    const [, , met] = categorizeTimeline([c], { now: NOW });
     expect(met.cards).toHaveLength(1);
     expect(met.cards[0]).toBe(c);
   });
 
   it("classifies firstMetDate last month as NOT met-this-month", () => {
     const c = card({ firstMetDate: "2026-03-10" });
-    const [newly, met, uncontacted] = categorizeTimeline([c], { now: NOW });
+    const [, newly, met, uncontacted] = categorizeTimeline([c], { now: NOW });
     expect(met.cards).toHaveLength(0);
     // createdAt is 2026-01-01 so not newly-added; last contact null → uncontacted
     expect(newly.cards).toHaveLength(0);
@@ -54,7 +89,7 @@ describe("categorizeTimeline", () => {
       id: "new",
       createdAt: new Date("2026-04-15T00:00:00Z"),
     });
-    const [newly] = categorizeTimeline([c], { now: NOW });
+    const [, newly] = categorizeTimeline([c], { now: NOW });
     expect(newly.cards.map((card) => card.id)).toContain("new");
   });
 
@@ -64,7 +99,7 @@ describe("categorizeTimeline", () => {
       createdAt: new Date("2025-01-01T00:00:00Z"),
       lastContactedAt: new Date("2026-02-01T00:00:00Z"), // > 30 days before NOW
     });
-    const [, , uncontacted] = categorizeTimeline([c], { now: NOW });
+    const [, , , uncontacted] = categorizeTimeline([c], { now: NOW });
     expect(uncontacted.cards.map((card) => card.id)).toContain("stale");
   });
 
@@ -74,7 +109,7 @@ describe("categorizeTimeline", () => {
       createdAt: new Date("2025-01-01T00:00:00Z"),
       lastContactedAt: new Date("2026-04-15T00:00:00Z"), // 3 days before NOW
     });
-    const [newly, met, uncontacted] = categorizeTimeline([c], { now: NOW });
+    const [, newly, met, uncontacted] = categorizeTimeline([c], { now: NOW });
     expect([...newly.cards, ...met.cards, ...uncontacted.cards]).toHaveLength(0);
   });
 
@@ -102,7 +137,7 @@ describe("categorizeTimeline", () => {
       id: "newer",
       createdAt: new Date("2026-04-17T00:00:00Z"),
     });
-    const [newly] = categorizeTimeline([older, newer], { now: NOW });
+    const [, newly] = categorizeTimeline([older, newer], { now: NOW });
     expect(newly.cards.map((c) => c.id)).toEqual(["newer", "older"]);
   });
 
@@ -117,7 +152,7 @@ describe("categorizeTimeline", () => {
       createdAt: new Date("2025-01-01T00:00:00Z"),
       lastContactedAt: new Date("2026-01-01T00:00:00Z"),
     });
-    const [, , uncontacted] = categorizeTimeline([b, a], { now: NOW });
+    const [, , , uncontacted] = categorizeTimeline([b, a], { now: NOW });
     expect(uncontacted.cards.map((c) => c.id)).toEqual(["a", "b"]);
   });
 
@@ -151,7 +186,7 @@ describe("categorizeTimeline", () => {
       firstMetDate: "04/10/2026" as unknown as string,
       createdAt: new Date("2025-01-01T00:00:00Z"),
     });
-    const [, met, uncontacted] = categorizeTimeline([c], { now: NOW });
+    const [, , met, uncontacted] = categorizeTimeline([c], { now: NOW });
     expect(met.cards).toHaveLength(0);
     expect(uncontacted.cards).toHaveLength(1);
   });
@@ -159,7 +194,7 @@ describe("categorizeTimeline", () => {
   it("sorts met-this-month by firstMetDate desc", () => {
     const early = card({ id: "early", firstMetDate: "2026-04-03" });
     const late = card({ id: "late", firstMetDate: "2026-04-17" });
-    const [, met] = categorizeTimeline([early, late], { now: NOW });
+    const [, , met] = categorizeTimeline([early, late], { now: NOW });
     expect(met.cards.map((c) => c.id)).toEqual(["late", "early"]);
   });
 
@@ -167,7 +202,7 @@ describe("categorizeTimeline", () => {
     const good = card({ id: "good", firstMetDate: "2026-04-15" });
     // broken date never enters met-this-month, but guard the sort fallback
     // via a card with firstMetDate set to a valid current-month date only once.
-    const [, met] = categorizeTimeline([good], { now: NOW });
+    const [, , met] = categorizeTimeline([good], { now: NOW });
     expect(met.cards).toHaveLength(1);
   });
 
@@ -181,8 +216,10 @@ describe("categorizeTimeline", () => {
 
   it("uses default uncontactedDays/newlyAddedDays/maxPerSection when omitted", () => {
     const sections = categorizeTimeline([], { now: NOW });
-    expect(sections[0].description).toMatch(/7 天/);
-    expect(sections[2].description).toMatch(/30 天/);
+    const newly = sections.find((s) => s.id === "newly-added")!;
+    const uncontacted = sections.find((s) => s.id === "uncontacted")!;
+    expect(newly.description).toMatch(/7 天/);
+    expect(uncontacted.description).toMatch(/30 天/);
   });
 
   it("respects custom uncontactedDays override", () => {

--- a/src/lib/timeline/categorize.ts
+++ b/src/lib/timeline/categorize.ts
@@ -1,7 +1,7 @@
 import type { CardSummary } from "@/db/cards";
 
 export interface TimelineSection {
-  id: "uncontacted" | "met-this-month" | "newly-added";
+  id: "pinned" | "uncontacted" | "met-this-month" | "newly-added";
   title: string;
   description: string;
   cards: CardSummary[];
@@ -30,14 +30,20 @@ function parseFirstMetDate(raw: string | undefined): Date | null {
 }
 
 /**
- * Categorize cards into the 3 timeline sections.
+ * Categorize cards into the 4 timeline sections.
+ * Priority: pinned > met-this-month > newly-added > uncontacted.
+ * A pinned card shows only in the Pinned section — it's
+ * intentionally never duplicated as "最近沒聯絡" because core
+ * contacts shouldn't be shame-nudged.
+ *
  * Rules:
- *  - met-this-month: firstMetDate within the given "now" month (exclusive of archive).
+ *  - pinned: card.isPinned === true
+ *  - met-this-month: firstMetDate within the given "now" month.
  *  - newly-added: createdAt within newlyAddedDays (default 7). Excluded from uncontacted.
  *  - uncontacted:
  *      - lastContactedAt older than uncontactedDays (default 30), OR
  *      - lastContactedAt is null AND createdAt older than uncontactedDays
- *      - excludes cards already in met-this-month or newly-added
+ *      - excludes cards already pinned / met-this-month / newly-added
  *  - Each section capped by maxPerSection (default 5), sorted deterministically.
  */
 export function categorizeTimeline(
@@ -46,12 +52,17 @@ export function categorizeTimeline(
 ): TimelineSection[] {
   const { now, uncontactedDays = 30, newlyAddedDays = 7, maxPerSection = 5 } = options;
 
+  const pinned: CardSummary[] = [];
   const metThisMonth: CardSummary[] = [];
   const newlyAdded: CardSummary[] = [];
   const uncontacted: CardSummary[] = [];
 
   for (const card of cards) {
     if (card.deletedAt) continue;
+    if (card.isPinned) {
+      pinned.push(card);
+      continue;
+    }
     const firstMet = parseFirstMetDate(card.firstMetDate);
     const createdAt = card.createdAt;
     const lastContactedAt = card.lastContactedAt;
@@ -90,7 +101,21 @@ export function categorizeTimeline(
     return ta - tb;
   });
 
+  // Pinned sorted by most-recently-touched so the top row feels alive.
+  pinned.sort((a, b) => {
+    const ta = a.updatedAt?.getTime() ?? a.createdAt?.getTime() ?? 0;
+    const tb = b.updatedAt?.getTime() ?? b.createdAt?.getTime() ?? 0;
+    return tb - ta;
+  });
+
   return [
+    {
+      id: "pinned",
+      title: "重要聯絡人",
+      description: "核心圈，永遠放在最上方。",
+      // Pinned intentionally not capped — user curates this list themselves.
+      cards: pinned,
+    },
     {
       id: "newly-added",
       title: "新建立",

--- a/src/lib/vcard/__tests__/export.test.ts
+++ b/src/lib/vcard/__tests__/export.test.ts
@@ -28,6 +28,7 @@ function makeCard(overrides: Partial<CardSummary> = {}): CardSummary {
     social: {},
     frontImagePath: undefined,
     backImagePath: undefined,
+    isPinned: false,
     createdAt: new Date("2026-04-01T00:00:00Z"),
     updatedAt: new Date("2026-04-01T00:00:00Z"),
     lastContactedAt: null,

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -33,6 +33,7 @@ export function aCard(overrides: Partial<CardCreateInput> = {}): CardCreateInput
     tagNames: [],
     frontImagePath: undefined,
     backImagePath: undefined,
+    isPinned: false,
     ocrProvider: undefined,
     ocrConfidence: undefined,
     ocrRawJson: undefined,


### PR DESCRIPTION
Closes #41. Third business-UX slice — core contacts never get shame-nudged.

## What

- `isPinned?: boolean` added to card schema (optional, no migration needed for pre-existing docs).
- New Pinned section at the top of the timeline home. Pinned cards are excluded from 「最近沒聯絡」.
- Pin toggle button in CardActions.
- Pin does not affect Typesense ranking — it's a UI concern only, so setCardPinned skips reindex for speed.

## Tests

- Full UT suite: 297 pass / 21 skipped (was 293)
- 2 new SIT: toggle flip + non-member refusal
- 2 new UT for pin toggle
- Existing categorize destructures shifted by 1 to account for pinned being index 0

## Deploy

No rules change this time. After merge:
1. `pnpm build` with basePath
2. `pm2 reload namecard-web --update-env`
3. Any pre-existing card doc without isPinned renders as unpinned (design decision — opt-in pin, not opt-out).