### PR TITLE
feat(cards): list/gallery 視覺完整性 — pin icon + N-days-stale badge (Closes #43)

### DIFF
--- a/src/components/cards/CardGallery.module.css
+++ b/src/components/cards/CardGallery.module.css
@@ -113,7 +113,9 @@
 
 .cardFooter {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-sm);
 }
 
 .eventTag {
@@ -122,4 +124,17 @@
   letter-spacing: var(--tracking-wider);
   text-transform: uppercase;
   color: var(--color-accent-ink);
+}
+
+.pinBadge {
+  font-size: 0.75em;
+  margin-right: 0.1rem;
+}
+
+.staleBadge {
+  font-family: var(--font-sans);
+  font-size: 0.6875rem;
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-accent);
+  font-weight: 500;
 }

--- a/src/components/cards/CardGallery.tsx
+++ b/src/components/cards/CardGallery.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import type { CardSummary } from "@/db/cards";
+import { daysSinceContact, shouldShowStaleBadge } from "@/lib/timeline/staleness";
 
 import styles from "./CardGallery.module.css";
 
@@ -34,11 +35,14 @@ function tiltFor(id: string): number {
 }
 
 export function CardGallery({ cards }: CardGalleryProps) {
+  const now = new Date();
   return (
     <ul className={styles.grid}>
       {cards.map((card, index) => {
         const tilt = tiltFor(card.id);
         const isFeatured = index % 7 === 0 && cards.length > 6;
+        const stale = shouldShowStaleBadge(card, now);
+        const days = stale ? daysSinceContact(card, now) : null;
         return (
           <li
             key={card.id}
@@ -48,7 +52,14 @@ export function CardGallery({ cards }: CardGalleryProps) {
             <Link href={`/cards/${card.id}`} className={styles.link}>
               <article className={styles.card}>
                 <header className={styles.cardHeader}>
-                  <h2 className={styles.name}>{primaryName(card)}</h2>
+                  <h2 className={styles.name}>
+                    {card.isPinned && (
+                      <span className={styles.pinBadge} aria-label="重要聯絡人" title="重要聯絡人">
+                        📍{" "}
+                      </span>
+                    )}
+                    {primaryName(card)}
+                  </h2>
                   {secondaryName(card) && <p className={styles.nameEn}>{secondaryName(card)}</p>}
                   {role(card) && <p className={styles.role}>{role(card)}</p>}
                   {company(card) && <p className={styles.company}>{company(card)}</p>}
@@ -62,6 +73,9 @@ export function CardGallery({ cards }: CardGalleryProps) {
                   ) : card.firstMetDate ? (
                     <span className={styles.eventTag}>{card.firstMetDate}</span>
                   ) : null}
+                  {stale && days !== null && (
+                    <span className={styles.staleBadge}>{days} 天沒聯絡</span>
+                  )}
                 </footer>
               </article>
             </Link>

--- a/src/components/cards/CardList.tsx
+++ b/src/components/cards/CardList.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import type { CardSummary } from "@/db/cards";
+import { daysSinceContact, shouldShowStaleBadge } from "@/lib/timeline/staleness";
 
 import styles from "./CardList.module.css";
 
@@ -21,26 +22,41 @@ function role(card: CardSummary): string | null {
 }
 
 export function CardList({ cards }: CardListProps) {
+  // Compute now once per render so staleness is stable across the list and
+  // doesn't diverge between items rendered a few ms apart.
+  const now = new Date();
   return (
     <ol className={styles.list}>
-      {cards.map((card) => (
-        <li key={card.id} className={styles.row}>
-          <Link href={`/cards/${card.id}`} className={styles.link}>
-            <div className={styles.primary}>
-              <span className={styles.name}>{primaryName(card)}</span>
-              {role(card) && <span className={styles.role}>{role(card)}</span>}
-              {company(card) && <span className={styles.company}>{company(card)}</span>}
-            </div>
-            <p className={styles.why}>{card.whyRemember}</p>
-            <div className={styles.meta}>
-              {card.firstMetEventTag && (
-                <span className={styles.event}>@ {card.firstMetEventTag}</span>
-              )}
-              {card.firstMetDate && <span className={styles.date}>{card.firstMetDate}</span>}
-            </div>
-          </Link>
-        </li>
-      ))}
+      {cards.map((card) => {
+        const stale = shouldShowStaleBadge(card, now);
+        const days = stale ? daysSinceContact(card, now) : null;
+        return (
+          <li key={card.id} className={styles.row}>
+            <Link href={`/cards/${card.id}`} className={styles.link}>
+              <div className={styles.primary}>
+                {card.isPinned && (
+                  <span className={styles.pinBadge} aria-label="重要聯絡人" title="重要聯絡人">
+                    📍
+                  </span>
+                )}
+                <span className={styles.name}>{primaryName(card)}</span>
+                {role(card) && <span className={styles.role}>{role(card)}</span>}
+                {company(card) && <span className={styles.company}>{company(card)}</span>}
+              </div>
+              <p className={styles.why}>{card.whyRemember}</p>
+              <div className={styles.meta}>
+                {card.firstMetEventTag && (
+                  <span className={styles.event}>@ {card.firstMetEventTag}</span>
+                )}
+                {card.firstMetDate && <span className={styles.date}>{card.firstMetDate}</span>}
+                {stale && days !== null && (
+                  <span className={styles.staleBadge}>{days} 天沒聯絡</span>
+                )}
+              </div>
+            </Link>
+          </li>
+        );
+      })}
     </ol>
   );
 }

--- a/src/lib/timeline/__tests__/staleness.test.ts
+++ b/src/lib/timeline/__tests__/staleness.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import { daysSinceContact, shouldShowStaleBadge } from "../staleness";
+
+const NOW = new Date("2026-04-24T00:00:00Z");
+
+function mk(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "c1",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    social: {},
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe("daysSinceContact", () => {
+  it("uses lastContactedAt when present", () => {
+    const c = mk({ lastContactedAt: new Date("2026-04-10T00:00:00Z") });
+    expect(daysSinceContact(c, NOW)).toBe(14);
+  });
+
+  it("falls back to createdAt when lastContactedAt is null", () => {
+    const c = mk({ createdAt: new Date("2026-03-25T00:00:00Z") });
+    expect(daysSinceContact(c, NOW)).toBe(30);
+  });
+
+  it("returns null when both are missing", () => {
+    expect(daysSinceContact(mk(), NOW)).toBeNull();
+  });
+
+  it("clamps negative values to 0 (future contact dates)", () => {
+    const c = mk({ lastContactedAt: new Date("2026-05-01T00:00:00Z") });
+    expect(daysSinceContact(c, NOW)).toBe(0);
+  });
+});
+
+describe("shouldShowStaleBadge", () => {
+  it("is true when days ≥ default threshold (30)", () => {
+    const c = mk({ lastContactedAt: new Date("2026-03-24T00:00:00Z") });
+    expect(shouldShowStaleBadge(c, NOW)).toBe(true);
+  });
+
+  it("is false just below threshold", () => {
+    const c = mk({ lastContactedAt: new Date("2026-03-26T00:00:00Z") });
+    expect(shouldShowStaleBadge(c, NOW)).toBe(false);
+  });
+
+  it("respects a custom threshold", () => {
+    const c = mk({ lastContactedAt: new Date("2026-04-20T00:00:00Z") });
+    expect(shouldShowStaleBadge(c, NOW, 3)).toBe(true);
+    expect(shouldShowStaleBadge(c, NOW, 5)).toBe(false);
+  });
+
+  it("never shows the badge on a pinned card", () => {
+    const c = mk({
+      isPinned: true,
+      lastContactedAt: new Date("2025-01-01T00:00:00Z"),
+    });
+    expect(shouldShowStaleBadge(c, NOW)).toBe(false);
+  });
+
+  it("is false when both timestamps are missing (no signal)", () => {
+    expect(shouldShowStaleBadge(mk(), NOW)).toBe(false);
+  });
+});

--- a/src/lib/timeline/staleness.ts
+++ b/src/lib/timeline/staleness.ts
@@ -1,0 +1,26 @@
+import type { CardSummary } from "@/db/cards";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Days since the user last logged contact with this card. Falls back to
+ * createdAt when lastContactedAt is null. Returns null when both are
+ * missing (can't compute staleness).
+ */
+export function daysSinceContact(card: CardSummary, now: Date): number | null {
+  const last = card.lastContactedAt ?? card.createdAt;
+  if (!last) return null;
+  const ms = now.getTime() - last.getTime();
+  return Math.max(0, Math.floor(ms / MS_PER_DAY));
+}
+
+/**
+ * Whether to surface a 「N 天沒聯絡」 badge on the list/gallery.
+ * Pinned cards are intentionally exempt — core contacts shouldn't
+ * show a pestering badge. Threshold defaults to 30 days.
+ */
+export function shouldShowStaleBadge(card: CardSummary, now: Date, thresholdDays = 30): boolean {
+  if (card.isPinned) return false;
+  const days = daysSinceContact(card, now);
+  return days !== null && days >= thresholdDays;
+}


### PR DESCRIPTION
Closes #43. Close the visual gap between timeline home and list/gallery views.

## Changes

- New `src/lib/timeline/staleness.ts` — 2 pure fns (`daysSinceContact`, `shouldShowStaleBadge`).
- `CardList` + `CardGallery`: 📍 pin badge when `isPinned`, `N 天沒聯絡` accent label when stale.
- Pinned cards are exempt from stale badge by design (no shame-nudge on core contacts).

## Tests

- 10 new UT in `staleness.test.ts`: pin exemption, custom threshold, null fallbacks, negative clamp.
- Full suite: 306 pass / 21 skipped (was 297 / 21).
- typecheck + lint + format clean.

## Deploy

Pure UI — no rules/schema. After merge:
- `pnpm build` with basePath
- `pm2 reload namecard-web --update-env`