### PR TITLE
feat(cards): OCR rescan panel on card edit — upload a fresh photo to fill blanks (Closes #45)

### DIFF
--- a/src/app/(app)/cards/[id]/edit/page.tsx
+++ b/src/app/(app)/cards/[id]/edit/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 
 import { CardForm } from "@/components/cards/CardForm";
+import { OcrRescanPanel } from "@/components/scan/OcrRescanPanel";
 import { getCardForUser } from "@/db/cards";
 import { readSession } from "@/lib/firebase/session";
 
@@ -54,6 +55,22 @@ export default async function EditCardPage({ params }: EditPageProps) {
           更新<em>{card.nameZh || card.nameEn || "這張名片"}</em>
         </h1>
       </header>
+      <OcrRescanPanel
+        cardId={id}
+        current={{
+          nameZh: card.nameZh,
+          nameEn: card.nameEn,
+          namePhonetic: card.namePhonetic,
+          jobTitleZh: card.jobTitleZh,
+          jobTitleEn: card.jobTitleEn,
+          department: card.department,
+          companyZh: card.companyZh,
+          companyEn: card.companyEn,
+          phones: card.phones,
+          emails: card.emails,
+          social: card.social ?? {},
+        }}
+      />
       <CardForm mode="edit" cardId={id} defaults={defaults} />
     </article>
   );

--- a/src/components/scan/OcrRescanPanel.module.css
+++ b/src/components/scan/OcrRescanPanel.module.css
@@ -1,0 +1,215 @@
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-bg-raised);
+  border: var(--border-thin) dashed var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-fg);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.trigger:hover {
+  background: var(--color-accent-soft);
+  border-color: var(--color-accent-ink);
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-raised);
+  margin-bottom: var(--space-lg);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.title {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+}
+
+.close {
+  background: transparent;
+  border: none;
+  color: var(--color-fg-muted);
+  font-size: var(--text-body);
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.close:hover {
+  color: var(--color-fg);
+}
+
+.fileLabel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  padding: var(--space-xl) var(--space-md);
+  border: var(--border-thin) dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: border-color var(--duration-fast) var(--ease-standard);
+}
+
+.fileLabel:hover {
+  border-color: var(--color-accent-ink);
+}
+
+.fileInput {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.fileCta {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-fg);
+}
+
+.hint {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+}
+
+.uploadingBox,
+.review,
+.failed {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.preview {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-sm);
+  border: var(--border-thin) solid var(--color-border);
+}
+
+.uploading {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-fg-muted);
+  margin: 0;
+}
+
+.summary {
+  width: 100%;
+}
+
+.summaryTitle {
+  margin: 0 0 var(--space-xs);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-fg-muted);
+}
+
+.fieldList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fieldList li {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: var(--space-sm);
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-fg);
+}
+
+.fieldLabel {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+}
+
+.applyRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-sm);
+  width: 100%;
+}
+
+.primary,
+.secondary {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  text-align: center;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  border: var(--border-thin) solid var(--color-border);
+}
+
+.primary {
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-color: var(--color-ink);
+}
+
+.primary:hover:not(:disabled) {
+  background: var(--color-accent-ink);
+  border-color: var(--color-accent-ink);
+}
+
+.primary:disabled,
+.secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.secondary {
+  background: var(--color-bg-raised);
+  color: var(--color-fg);
+}
+
+.secondary:hover:not(:disabled) {
+  border-color: var(--color-fg-muted);
+}
+
+.error {
+  color: var(--color-accent);
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  margin: var(--space-xs) 0 0;
+}

--- a/src/components/scan/OcrRescanPanel.tsx
+++ b/src/components/scan/OcrRescanPanel.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { updateCardAction } from "@/app/(app)/cards/actions";
+import { scanCardAction } from "@/app/(app)/cards/scan/actions";
+import type { CardUpdateInput } from "@/db/schema";
+import { countAffectedFields, mergeOcrIntoExisting, type MergeStrategy } from "@/lib/ocr/merge";
+import type { OcrFields } from "@/lib/ocr/types";
+
+import styles from "./OcrRescanPanel.module.css";
+
+interface OcrRescanPanelProps {
+  cardId: string;
+  /**
+   * Current (pre-edit) card field snapshot. We only need the fields
+   * that can be OCR-filled, in the same shape updateCardAction accepts.
+   */
+  current: Partial<CardUpdateInput>;
+}
+
+type Phase =
+  | { kind: "idle" }
+  | { kind: "uploading"; previewUrl: string }
+  | {
+      kind: "review";
+      previewUrl: string;
+      fields: OcrFields;
+    }
+  | { kind: "ocr-failed"; previewUrl: string; message: string }
+  | { kind: "applying" };
+
+/**
+ * Disclosure panel on the edit page that lets you upload a fresh
+ * photo of a namecard and pull detected fields into the existing
+ * record. Two apply modes:
+ *   - 只補空欄位 (default / safer) — never overwrites your typing
+ *   - 全部覆蓋 — destructive, OCR wins
+ */
+export function OcrRescanPanel({ cardId, current }: OcrRescanPanelProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [phase, setPhase] = useState<Phase>({ kind: "idle" });
+  const [error, setError] = useState<string | null>(null);
+  const [applying, startApply] = useTransition();
+
+  async function handleFile(file: File) {
+    setError(null);
+    const previewUrl = URL.createObjectURL(file);
+    setPhase({ kind: "uploading", previewUrl });
+
+    const fileBase64 = await blobToBase64(file);
+    const result = await scanCardAction({
+      fileBase64,
+      mimeType: file.type || "image/jpeg",
+      originalName: file.name,
+    });
+
+    if (result?.serverError) {
+      setPhase({ kind: "ocr-failed", previewUrl, message: result.serverError });
+      return;
+    }
+    if (result?.validationErrors) {
+      setPhase({
+        kind: "ocr-failed",
+        previewUrl,
+        message: "上傳格式不符（>10MB 或非圖片）",
+      });
+      return;
+    }
+
+    const data = result?.data;
+    if (!data || !data.ok) {
+      setPhase({
+        kind: "ocr-failed",
+        previewUrl,
+        message: "OCR 解析失敗，請換一張清晰的圖片再試。",
+      });
+      return;
+    }
+
+    setPhase({ kind: "review", previewUrl, fields: data.fields });
+  }
+
+  function handleApply(strategy: MergeStrategy) {
+    if (phase.kind !== "review") return;
+    const patch = mergeOcrIntoExisting(current, phase.fields, strategy);
+    if (Object.keys(patch).length === 0) {
+      setError("OCR 沒有可以填入的新欄位。");
+      return;
+    }
+    setPhase({ kind: "applying" });
+    setError(null);
+    startApply(async () => {
+      const result = await updateCardAction({ id: cardId, input: patch });
+      if (result?.serverError) {
+        setError(result.serverError);
+        setPhase({
+          kind: "review",
+          previewUrl: phaseWithPreview(phase),
+          fields: phase.fields,
+        });
+        return;
+      }
+      // Success: collapse + refresh so the edit form mounts with new values.
+      setOpen(false);
+      setPhase({ kind: "idle" });
+      router.refresh();
+    });
+  }
+
+  if (!open) {
+    return (
+      <button type="button" className={styles.trigger} onClick={() => setOpen(true)}>
+        📷 從照片重新解析欄位
+      </button>
+    );
+  }
+
+  return (
+    <section className={styles.panel} aria-label="OCR 重新解析">
+      <header className={styles.header}>
+        <p className={styles.title}>📷 從照片重新解析欄位</p>
+        <button
+          type="button"
+          className={styles.close}
+          onClick={() => {
+            setOpen(false);
+            setPhase({ kind: "idle" });
+            setError(null);
+          }}
+          aria-label="關閉"
+        >
+          ✕
+        </button>
+      </header>
+
+      {phase.kind === "idle" && (
+        <label className={styles.fileLabel}>
+          <input
+            type="file"
+            accept="image/*"
+            capture="environment"
+            className={styles.fileInput}
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) void handleFile(f);
+            }}
+          />
+          <span className={styles.fileCta}>選擇或拍攝名片照片</span>
+          <span className={styles.hint}>最大 10MB · 會存到 Firebase Storage 並呼叫 OCR</span>
+        </label>
+      )}
+
+      {phase.kind === "uploading" && (
+        <div className={styles.uploadingBox}>
+          <Image
+            src={phase.previewUrl}
+            alt="預覽"
+            className={styles.preview}
+            width={320}
+            height={200}
+            unoptimized
+          />
+          <p className={styles.uploading}>解析中…</p>
+        </div>
+      )}
+
+      {phase.kind === "review" && (
+        <ReviewBody
+          previewUrl={phase.previewUrl}
+          current={current}
+          fields={phase.fields}
+          onApply={handleApply}
+          disabled={applying}
+        />
+      )}
+
+      {phase.kind === "applying" && <p className={styles.uploading}>更新中…</p>}
+
+      {phase.kind === "ocr-failed" && (
+        <div className={styles.failed}>
+          <Image
+            src={phase.previewUrl}
+            alt="預覽"
+            className={styles.preview}
+            width={320}
+            height={200}
+            unoptimized
+          />
+          <p className={styles.error}>{phase.message}</p>
+          <button
+            type="button"
+            className={styles.secondary}
+            onClick={() => setPhase({ kind: "idle" })}
+          >
+            重試
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <p role="alert" className={styles.error}>
+          {error}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function ReviewBody({
+  previewUrl,
+  current,
+  fields,
+  onApply,
+  disabled,
+}: {
+  previewUrl: string;
+  current: Partial<CardUpdateInput>;
+  fields: OcrFields;
+  onApply: (strategy: MergeStrategy) => void;
+  disabled: boolean;
+}) {
+  const fillEmptyCount = countAffectedFields(current, fields, "fill-empty");
+  const overwriteCount = countAffectedFields(current, fields, "overwrite");
+
+  return (
+    <div className={styles.review}>
+      <Image
+        src={previewUrl}
+        alt="名片預覽"
+        className={styles.preview}
+        width={320}
+        height={200}
+        unoptimized
+      />
+      <div className={styles.summary}>
+        <p className={styles.summaryTitle}>OCR 解析結果</p>
+        <ul className={styles.fieldList}>
+          {fieldPreviewRow("姓名(中)", fields.nameZh?.value)}
+          {fieldPreviewRow("姓名(英)", fields.nameEn?.value)}
+          {fieldPreviewRow("職稱", fields.jobTitleZh?.value || fields.jobTitleEn?.value)}
+          {fieldPreviewRow("公司", fields.companyZh?.value || fields.companyEn?.value)}
+          {fields.phones.length > 0 && (
+            <li>
+              <span className={styles.fieldLabel}>電話</span>
+              <span>{fields.phones.map((p) => p.value).join("、")}</span>
+            </li>
+          )}
+          {fields.emails.length > 0 && (
+            <li>
+              <span className={styles.fieldLabel}>Email</span>
+              <span>{fields.emails.map((e) => e.value).join("、")}</span>
+            </li>
+          )}
+          {fields.social?.lineId?.value && (
+            <li>
+              <span className={styles.fieldLabel}>LINE</span>
+              <span>{fields.social.lineId.value}</span>
+            </li>
+          )}
+        </ul>
+      </div>
+      <div className={styles.applyRow}>
+        <button
+          type="button"
+          className={styles.primary}
+          disabled={disabled || fillEmptyCount === 0}
+          onClick={() => onApply("fill-empty")}
+          title="只填入目前空的欄位，不覆蓋你已經填好的內容"
+        >
+          只補空欄位（{fillEmptyCount} 項）
+        </button>
+        <button
+          type="button"
+          className={styles.secondary}
+          disabled={disabled || overwriteCount === 0}
+          onClick={() => onApply("overwrite")}
+          title="OCR 有值的全部覆蓋（目前有值的欄位也會被蓋過）"
+        >
+          全部覆蓋（{overwriteCount} 項）
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function fieldPreviewRow(label: string, value: string | undefined) {
+  if (!value) return null;
+  return (
+    <li>
+      <span className={styles.fieldLabel}>{label}</span>
+      <span>{value}</span>
+    </li>
+  );
+}
+
+function phaseWithPreview(phase: Extract<Phase, { kind: "review" }>): string {
+  return phase.previewUrl;
+}
+
+async function blobToBase64(file: File): Promise<string> {
+  const buf = await file.arrayBuffer();
+  let binary = "";
+  const bytes = new Uint8Array(buf);
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}

--- a/src/lib/ocr/__tests__/merge.test.ts
+++ b/src/lib/ocr/__tests__/merge.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import type { OcrFields } from "../types";
+import { countAffectedFields, mergeOcrIntoExisting } from "../merge";
+
+function ocr(overrides: Partial<OcrFields> = {}): OcrFields {
+  return {
+    phones: [],
+    emails: [],
+    addresses: [],
+    social: {},
+    ...overrides,
+  };
+}
+
+describe("mergeOcrIntoExisting — fill-empty (default)", () => {
+  it("fills blanks only and leaves existing non-empty fields alone", () => {
+    const current = { nameZh: "陳玉涵", jobTitleZh: "" };
+    const patch = mergeOcrIntoExisting(
+      current,
+      ocr({
+        nameZh: { value: "陳Override", confidence: 0.9 },
+        jobTitleZh: { value: "產品經理", confidence: 0.9 },
+        companyZh: { value: "ACME", confidence: 0.8 },
+      }),
+    );
+    // nameZh already filled → untouched; jobTitleZh blank → set; companyZh missing → set.
+    expect(patch.nameZh).toBeUndefined();
+    expect(patch.jobTitleZh).toBe("產品經理");
+    expect(patch.companyZh).toBe("ACME");
+  });
+
+  it("fills an empty phones array from OCR", () => {
+    const patch = mergeOcrIntoExisting(
+      { phones: [] },
+      ocr({ phones: [{ label: "mobile", value: "0912345678" }] }),
+    );
+    expect(patch.phones).toEqual([{ label: "mobile", value: "0912345678" }]);
+  });
+
+  it("does NOT touch a phones array that already has entries", () => {
+    const patch = mergeOcrIntoExisting(
+      { phones: [{ label: "office", value: "02-1234-5678" }] },
+      ocr({ phones: [{ label: "mobile", value: "0912345678" }] }),
+    );
+    expect(patch.phones).toBeUndefined();
+  });
+
+  it("fills empty social ids and leaves set ones alone", () => {
+    const patch = mergeOcrIntoExisting(
+      { social: { lineId: "@existing" } },
+      ocr({
+        social: {
+          lineId: { value: "@new" },
+          wechatId: { value: "wc-new" },
+        },
+      }),
+    );
+    expect(patch.social?.lineId).toBe("@existing");
+    expect(patch.social?.wechatId).toBe("wc-new");
+  });
+
+  it("returns an empty patch when OCR provides nothing new", () => {
+    const patch = mergeOcrIntoExisting(
+      { nameZh: "X", companyZh: "Y" },
+      ocr({
+        nameZh: { value: "A" },
+        companyZh: { value: "B" },
+      }),
+    );
+    expect(Object.keys(patch)).toHaveLength(0);
+  });
+});
+
+describe("mergeOcrIntoExisting — overwrite", () => {
+  it("replaces non-empty fields with OCR values", () => {
+    const patch = mergeOcrIntoExisting(
+      { nameZh: "舊名", companyZh: "舊公司" },
+      ocr({
+        nameZh: { value: "新名" },
+        companyZh: { value: "新公司" },
+      }),
+      "overwrite",
+    );
+    expect(patch.nameZh).toBe("新名");
+    expect(patch.companyZh).toBe("新公司");
+  });
+
+  it("never wipes a populated field when OCR is silent on it", () => {
+    const patch = mergeOcrIntoExisting(
+      { nameZh: "保留", companyZh: "保留" },
+      ocr({ nameZh: { value: "新" } }),
+      "overwrite",
+    );
+    expect(patch.nameZh).toBe("新");
+    expect(patch.companyZh).toBeUndefined();
+  });
+
+  it("replaces phones array even when non-empty", () => {
+    const patch = mergeOcrIntoExisting(
+      { phones: [{ label: "office", value: "02-1" }] },
+      ocr({ phones: [{ label: "mobile", value: "0912" }] }),
+      "overwrite",
+    );
+    expect(patch.phones).toEqual([{ label: "mobile", value: "0912" }]);
+  });
+});
+
+describe("countAffectedFields", () => {
+  it("counts fill-empty patches correctly", () => {
+    expect(
+      countAffectedFields(
+        { nameZh: "有", jobTitleZh: "" },
+        ocr({
+          nameZh: { value: "NEW" },
+          jobTitleZh: { value: "PM" },
+          companyZh: { value: "ACME" },
+        }),
+      ),
+    ).toBe(2);
+  });
+});

--- a/src/lib/ocr/merge.ts
+++ b/src/lib/ocr/merge.ts
@@ -1,0 +1,105 @@
+import type { CardUpdateInput } from "@/db/schema";
+import type { OcrFields } from "./types";
+
+export type MergeStrategy = "fill-empty" | "overwrite";
+
+type Current = Partial<CardUpdateInput>;
+
+/**
+ * Merge OCR-extracted fields into an existing card's values, producing
+ * a CardUpdateInput payload suitable for updateCardAction.
+ *
+ *  - fill-empty (default, recommended): only set fields that the
+ *    current card has left blank (string "" / null / undefined, or
+ *    empty phones/emails arrays). Non-empty current values are left
+ *    intact.
+ *  - overwrite: every OCR-detected field replaces the current value.
+ *    Empty OCR fields never overwrite non-empty current values —
+ *    absence of signal is never a reason to wipe data.
+ */
+export function mergeOcrIntoExisting(
+  current: Current,
+  ocr: OcrFields,
+  strategy: MergeStrategy = "fill-empty",
+): CardUpdateInput {
+  const patch: CardUpdateInput = {};
+
+  assignString(patch, current, "nameZh", ocr.nameZh?.value, strategy);
+  assignString(patch, current, "nameEn", ocr.nameEn?.value, strategy);
+  assignString(patch, current, "namePhonetic", ocr.namePhonetic?.value, strategy);
+  assignString(patch, current, "jobTitleZh", ocr.jobTitleZh?.value, strategy);
+  assignString(patch, current, "jobTitleEn", ocr.jobTitleEn?.value, strategy);
+  assignString(patch, current, "department", ocr.department?.value, strategy);
+  assignString(patch, current, "companyZh", ocr.companyZh?.value, strategy);
+  assignString(patch, current, "companyEn", ocr.companyEn?.value, strategy);
+
+  const ocrPhones = (ocr.phones ?? []).map((p) => ({ label: p.label, value: p.value }));
+  if (ocrPhones.length > 0 && shouldAssignArray(current.phones, strategy)) {
+    patch.phones = ocrPhones;
+  }
+  const ocrEmails = (ocr.emails ?? []).map((e) => ({ label: e.label, value: e.value }));
+  if (ocrEmails.length > 0 && shouldAssignArray(current.emails, strategy)) {
+    patch.emails = ocrEmails;
+  }
+
+  const social: NonNullable<CardUpdateInput["social"]> = { ...(current.social ?? {}) };
+  const socialPatch: NonNullable<CardUpdateInput["social"]> = {};
+  assignSocial(socialPatch, social, "lineId", ocr.social?.lineId?.value, strategy);
+  assignSocial(socialPatch, social, "wechatId", ocr.social?.wechatId?.value, strategy);
+  assignSocial(socialPatch, social, "linkedinUrl", ocr.social?.linkedinUrl?.value, strategy);
+  if (Object.keys(socialPatch).length > 0) {
+    patch.social = { ...social, ...socialPatch };
+  }
+
+  return patch;
+}
+
+/** Count of fields that would actually change under the given strategy. */
+export function countAffectedFields(
+  current: Current,
+  ocr: OcrFields,
+  strategy: MergeStrategy = "fill-empty",
+): number {
+  return Object.keys(mergeOcrIntoExisting(current, ocr, strategy)).length;
+}
+
+function assignString(
+  patch: CardUpdateInput,
+  current: Current,
+  key: keyof Pick<
+    CardUpdateInput,
+    | "nameZh"
+    | "nameEn"
+    | "namePhonetic"
+    | "jobTitleZh"
+    | "jobTitleEn"
+    | "department"
+    | "companyZh"
+    | "companyEn"
+  >,
+  ocrValue: string | undefined,
+  strategy: MergeStrategy,
+): void {
+  if (!ocrValue) return;
+  const existing = current[key];
+  if (strategy === "fill-empty" && existing) return;
+  patch[key] = ocrValue;
+}
+
+function assignSocial(
+  patch: NonNullable<CardUpdateInput["social"]>,
+  current: NonNullable<CardUpdateInput["social"]>,
+  key: "lineId" | "wechatId" | "linkedinUrl",
+  ocrValue: string | undefined,
+  strategy: MergeStrategy,
+): void {
+  if (!ocrValue) return;
+  const existing = current[key];
+  if (strategy === "fill-empty" && existing) return;
+  patch[key] = ocrValue;
+}
+
+function shouldAssignArray<T>(current: T[] | undefined, strategy: MergeStrategy): boolean {
+  if (strategy === "overwrite") return true;
+  return !current || current.length === 0;
+}


### PR DESCRIPTION
Closes #45. Fifth business-UX slice.

## What

Edit page now has a disclosure 「📷 從照片重新解析欄位」. Upload a fresh photo → OCR → review → apply with 1 of 2 strategies:

- **只補空欄位** (fill-empty, default): only touches blank fields. Never overwrites typed content. Empty arrays count as blank; populated arrays are left alone.
- **全部覆蓋** (overwrite): OCR values replace current ones, but OCR silence never wipes data (absence ≠ intent to delete).

## Under the hood

- New pure fn `src/lib/ocr/merge.ts` with `mergeOcrIntoExisting` + `countAffectedFields`.
- New `<OcrRescanPanel>` component — reuses existing `scanCardAction` for upload/OCR + `updateCardAction` for the write. **No new server action**.
- Edit page mounts the panel above `<CardForm>`.

## Tests

- 9 UT for the merge fn covering both strategies, array semantics, silence safety, and the count util.
- Full suite: 315 pass / 21 skipped (was 306 / 21).
- typecheck + lint + format all clean.

## Deploy

No rules/schema change. After merge:
- `pnpm build` with basePath
- `pm2 reload namecard-web --update-env`