### PR TITLE
feat(vcard): embed contact-event log in NOTE field (Closes #47)

### DIFF
--- a/src/app/api/cards/[id]/vcard/route.ts
+++ b/src/app/api/cards/[id]/vcard/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { getCardForUser } from "@/db/cards";
+import { getCardForUser, listContactEventsForUser } from "@/db/cards";
 import { readSession } from "@/lib/firebase/session";
 import { toVcard, vcardFilename } from "@/lib/vcard/export";
 
@@ -14,7 +14,11 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
   if (!card) return new NextResponse("Not Found", { status: 404 });
   if (card.deletedAt) return new NextResponse("Gone", { status: 410 });
 
-  const body = toVcard(card);
+  // Pull at most 10 most-recent contact events to embed in the NOTE
+  // block; keeps the vCard small while preserving the "what did we last
+  // talk about" context business users need when archiving / sharing.
+  const events = await listContactEventsForUser(id, user.uid, 10);
+  const body = toVcard(card, { events });
   const filename = vcardFilename(card);
 
   return new NextResponse(body, {

--- a/src/lib/vcard/__tests__/export.test.ts
+++ b/src/lib/vcard/__tests__/export.test.ts
@@ -237,6 +237,107 @@ describe("toVcard", () => {
   });
 });
 
+describe("toVcard contact events", () => {
+  it("omits NOTE when there are no events and no other notes/why/context", () => {
+    const out = toVcard(makeCard({ nameEn: "A", whyRemember: "x" }));
+    // whyRemember still fills the NOTE; but there should be no 【互動紀錄】 marker.
+    expect(out).not.toContain("【互動紀錄】");
+  });
+
+  it("appends 【互動紀錄】 block when events are passed", () => {
+    const card = makeCard({ nameEn: "A", whyRemember: "x" });
+    const out = toVcard(card, {
+      events: [
+        {
+          id: "e1",
+          at: new Date("2026-04-24T05:03:00Z"),
+          note: "發了 proposal",
+          authorUid: "u",
+          authorDisplay: null,
+        },
+        {
+          id: "e2",
+          at: new Date("2026-04-20T07:30:00Z"),
+          note: "約週末碰面",
+          authorUid: "u",
+          authorDisplay: null,
+        },
+      ],
+    });
+    expect(out).toContain("【互動紀錄】");
+    expect(out).toContain("- 發了 proposal");
+    expect(out).toContain("- 約週末碰面");
+  });
+
+  it("marks empty-note events as（無備註）", () => {
+    const card = makeCard({ nameEn: "A", whyRemember: "x" });
+    const out = toVcard(card, {
+      events: [
+        {
+          id: "e",
+          at: new Date("2026-04-24T00:00:00Z"),
+          note: "",
+          authorUid: "u",
+          authorDisplay: null,
+        },
+      ],
+    });
+    expect(out).toContain("（無備註）");
+  });
+
+  it("caps at eventLimit (default 10)", () => {
+    const card = makeCard({ nameEn: "A", whyRemember: "x" });
+    const events = Array.from({ length: 15 }, (_, i) => ({
+      id: `e${i}`,
+      at: new Date(`2026-04-${String(10 + i).padStart(2, "0")}T00:00:00Z`),
+      // short tokens so RFC 6350 line-fold doesn't split them mid-match
+      note: `n${i}z`,
+      authorUid: "u",
+      authorDisplay: null,
+    }));
+    const out = toVcard(card, { events });
+    // Strip fold breaks so tokens that straddle a 75-char boundary are
+    // still findable by contain().
+    const unfolded = out.replace(/\r\n /g, "");
+    // Only the first 10 should appear; n0z..n9z yes, n10z..n14z no.
+    for (let i = 0; i < 10; i++) expect(unfolded).toContain(`n${i}z`);
+    for (let i = 10; i < 15; i++) expect(unfolded).not.toContain(`n${i}z`);
+  });
+
+  it("respects a custom eventLimit", () => {
+    const card = makeCard({ nameEn: "A", whyRemember: "x" });
+    const events = [
+      { id: "a", at: new Date(), note: "a", authorUid: "u", authorDisplay: null },
+      { id: "b", at: new Date(), note: "b", authorUid: "u", authorDisplay: null },
+      { id: "c", at: new Date(), note: "c", authorUid: "u", authorDisplay: null },
+    ];
+    const out = toVcard(card, { events, eventLimit: 2 });
+    expect(out).toContain("- a");
+    expect(out).toContain("- b");
+    expect(out).not.toContain("- c");
+  });
+
+  it("orders NOTE sections as: whyRemember → context → notes → events", () => {
+    const card = makeCard({
+      nameEn: "A",
+      whyRemember: "WHY",
+      firstMetContext: "CTX",
+      notes: "NOTES",
+    });
+    const out = toVcard(card, {
+      events: [{ id: "e", at: new Date(), note: "EV", authorUid: "u", authorDisplay: null }],
+    });
+    const whyIdx = out.indexOf("WHY");
+    const ctxIdx = out.indexOf("CTX");
+    const notesIdx = out.indexOf("NOTES");
+    const evIdx = out.indexOf("【互動紀錄】");
+    expect(whyIdx).toBeGreaterThan(0);
+    expect(ctxIdx).toBeGreaterThan(whyIdx);
+    expect(notesIdx).toBeGreaterThan(ctxIdx);
+    expect(evIdx).toBeGreaterThan(notesIdx);
+  });
+});
+
 describe("vcardFilename", () => {
   it("uses nameEn when available", () => {
     const filename = vcardFilename(makeCard({ nameEn: "Alice Chen", whyRemember: "x" }));

--- a/src/lib/vcard/export.ts
+++ b/src/lib/vcard/export.ts
@@ -1,9 +1,41 @@
-import type { CardSummary } from "@/db/cards";
+import type { CardSummary, ContactEvent } from "@/db/cards";
 
 /**
  * Minimal vCard 4.0 generator — handcrafted for reliable iOS / macOS / Google
  * Contacts import. Values are escaped per RFC 6350 §3.4.
  */
+
+export interface ToVcardOptions {
+  /**
+   * Optional interaction log to append to the NOTE field. Newest events
+   * first. Only the first `eventLimit` (default 10) are serialized to
+   * keep the vCard readable — older ones still live in Firestore.
+   */
+  events?: ContactEvent[];
+  eventLimit?: number;
+}
+
+function formatEventStamp(at: Date): string {
+  // Local-time, minute-precision. Keeps the vCard NOTE scannable by
+  // humans without dragging timezone machinery into the export.
+  const y = at.getFullYear();
+  const mo = String(at.getMonth() + 1).padStart(2, "0");
+  const d = String(at.getDate()).padStart(2, "0");
+  const h = String(at.getHours()).padStart(2, "0");
+  const m = String(at.getMinutes()).padStart(2, "0");
+  return `${y}-${mo}-${d} ${h}:${m}`;
+}
+
+function buildEventBlock(events: ContactEvent[], limit: number): string | null {
+  if (!events || events.length === 0) return null;
+  const head = events.slice(0, Math.max(1, limit));
+  const lines = head.map((e) => {
+    const stamp = formatEventStamp(e.at);
+    const note = e.note?.trim();
+    return note ? `${stamp} - ${note}` : `${stamp} -（無備註）`;
+  });
+  return `【互動紀錄】\n${lines.join("\n")}`;
+}
 
 function escapeValue(value: string): string {
   return value
@@ -65,7 +97,7 @@ function emailLineType(label: string): string {
   }
 }
 
-export function toVcard(card: CardSummary): string {
+export function toVcard(card: CardSummary, options: ToVcardOptions = {}): string {
   const lines: string[] = [];
   lines.push("BEGIN:VCARD");
   lines.push("VERSION:4.0");
@@ -125,6 +157,8 @@ export function toVcard(card: CardSummary): string {
   if (card.whyRemember) noteParts.push(`【為什麼記得】${card.whyRemember}`);
   if (card.firstMetContext) noteParts.push(`【場合】${card.firstMetContext}`);
   if (card.notes) noteParts.push(card.notes);
+  const eventBlock = buildEventBlock(options.events ?? [], options.eventLimit ?? 10);
+  if (eventBlock) noteParts.push(eventBlock);
   if (noteParts.length > 0) {
     pushLine(lines, `NOTE:${escapeValue(noteParts.join("\n\n"))}`);
   }


### PR DESCRIPTION
Closes #47. Sixth business-UX slice.

## What

vCard export now carries interaction history. Archiving / sharing a contact preserves 'what did we last talk about'.

- `toVcard(card, { events?, eventLimit? })` — optional 2nd arg; events default [], limit default 10.
- NOTE section order: whyRemember → context → notes → 【互動紀錄】.
- Minute-precision local-time stamps, empty-note events shown as 『（無備註）』.
- `/api/cards/[id]/vcard` pulls 10 newest events and pipes them in.

## Tests

- 7 new UT (no events, events present, empty-note fallback, default limit, custom limit, NOTE ordering)
- 321 pass / 21 skipped (was 315)
- typecheck + lint + format clean

## Deploy

No rules/schema. After merge:
- `pnpm build` with basePath
- `pm2 reload namecard-web --update-env`