### PR TITLE
feat(cards): sort toggle — 最新建立 / 最近聯絡 / 姓名 (Closes #49)

### DIFF
--- a/src/app/(app)/cards/page.tsx
+++ b/src/app/(app)/cards/page.tsx
@@ -9,6 +9,7 @@ import { listCardsForUser, type CardSummary } from "@/db/cards";
 import { listTagsForUser } from "@/db/tags";
 import { readSession } from "@/lib/firebase/session";
 import { applyTagFilter } from "@/lib/cards/filter";
+import { parseSortKey, sortCards } from "@/lib/cards/sort";
 import { getTypesenseClient } from "@/lib/search/client";
 import { buildSearchParams } from "@/lib/search/query";
 import { CARDS_COLLECTION_NAME } from "@/lib/search/schema";
@@ -61,14 +62,16 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
   if (!user) return null;
   const raw = await searchParams;
   const view = typeof raw.view === "string" ? raw.view : "gallery";
-  const sort = typeof raw.sort === "string" ? raw.sort : "newest";
+  const sort = parseSortKey(raw.sort);
   const isGallery = view !== "list";
-  const orderBy: "createdAt" | "updatedAt" = "createdAt";
-  const order: "asc" | "desc" = sort === "oldest" ? "asc" : "desc";
   const { q, tag, tagMode } = parseSearchParams(raw);
 
+  // Always fetch in createdAt desc (Firestore-side); we do the final
+  // sort client-side on the page to support 「最近聯絡」 / 「姓名」
+  // keys without needing per-key Firestore indexes. 200-card ceiling
+  // makes this cheap.
   const [allCards, allTags] = await Promise.all([
-    listCardsForUser(user.uid, { limit: 200, orderBy, order }),
+    listCardsForUser(user.uid, { limit: 200, orderBy: "createdAt", order: "desc" }),
     listTagsForUser(user.uid),
   ]);
 
@@ -89,6 +92,11 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
   } else {
     cards = allCards;
   }
+
+  // Apply the user's chosen sort — Typesense search path already
+  // orders hits by relevance, but once we're showing the full list
+  // (or a tag-filtered list) we respect the segment control.
+  if (!q) cards = sortCards(cards, sort);
 
   return (
     <article className={styles.article}>

--- a/src/components/cards/ViewToggle.module.css
+++ b/src/components/cards/ViewToggle.module.css
@@ -1,3 +1,10 @@
+.row {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+  align-items: center;
+}
+
 .toggle {
   display: inline-flex;
   border: var(--border-hair) solid var(--color-border);

--- a/src/components/cards/ViewToggle.tsx
+++ b/src/components/cards/ViewToggle.tsx
@@ -1,37 +1,60 @@
 import Link from "next/link";
 
+import type { SortKey } from "@/lib/cards/sort";
+
 import styles from "./ViewToggle.module.css";
 
 interface ViewToggleProps {
   current: "gallery" | "list";
-  sort: string;
+  sort: SortKey;
 }
 
+const SORT_OPTIONS: Array<{ key: SortKey; label: string; title: string }> = [
+  { key: "newest", label: "最新建立", title: "最近新增的名片在前" },
+  { key: "contacted", label: "最近聯絡", title: "最近互動過的在前；從未聯絡的排最後" },
+  { key: "name", label: "姓名", title: "依中文筆畫 / 字母排序" },
+];
+
 export function ViewToggle({ current, sort }: ViewToggleProps) {
-  const buildHref = (view: "gallery" | "list") => {
+  const buildHref = (view: "gallery" | "list", nextSort: SortKey = sort) => {
     const params = new URLSearchParams();
     if (view === "list") params.set("view", "list");
-    if (sort && sort !== "newest") params.set("sort", sort);
+    if (nextSort && nextSort !== "newest") params.set("sort", nextSort);
     const qs = params.toString();
     return qs ? `/cards?${qs}` : "/cards";
   };
 
   return (
-    <div className={styles.toggle} role="group" aria-label="View mode">
-      <Link
-        href={buildHref("gallery")}
-        className={`${styles.option} ${current === "gallery" ? styles.active : ""}`}
-        aria-pressed={current === "gallery"}
-      >
-        畫廊
-      </Link>
-      <Link
-        href={buildHref("list")}
-        className={`${styles.option} ${current === "list" ? styles.active : ""}`}
-        aria-pressed={current === "list"}
-      >
-        清單
-      </Link>
+    <div className={styles.row}>
+      <div className={styles.toggle} role="group" aria-label="View mode">
+        <Link
+          href={buildHref("gallery")}
+          className={`${styles.option} ${current === "gallery" ? styles.active : ""}`}
+          aria-pressed={current === "gallery"}
+        >
+          畫廊
+        </Link>
+        <Link
+          href={buildHref("list")}
+          className={`${styles.option} ${current === "list" ? styles.active : ""}`}
+          aria-pressed={current === "list"}
+        >
+          清單
+        </Link>
+      </div>
+      <div className={styles.toggle} role="group" aria-label="Sort">
+        {SORT_OPTIONS.map((opt) => (
+          <Link
+            key={opt.key}
+            href={buildHref(current, opt.key)}
+            className={`${styles.option} ${sort === opt.key ? styles.active : ""}`}
+            aria-pressed={sort === opt.key}
+            title={opt.title}
+          >
+            {opt.label}
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/lib/cards/__tests__/sort.test.ts
+++ b/src/lib/cards/__tests__/sort.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import { parseSortKey, sortCards } from "../sort";
+
+function mk(overrides: Partial<CardSummary>): CardSummary {
+  return {
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    whyRemember: "",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    social: {},
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe("parseSortKey", () => {
+  it("defaults to newest for unknown / missing", () => {
+    expect(parseSortKey(undefined)).toBe("newest");
+    expect(parseSortKey("garbage")).toBe("newest");
+    expect(parseSortKey(42)).toBe("newest");
+  });
+
+  it("passes known keys through", () => {
+    for (const k of ["newest", "oldest", "contacted", "name"] as const) {
+      expect(parseSortKey(k)).toBe(k);
+    }
+  });
+});
+
+describe("sortCards", () => {
+  it("newest: createdAt desc with nulls at the bottom", () => {
+    const a = mk({ id: "a", createdAt: new Date("2026-04-01") });
+    const b = mk({ id: "b", createdAt: new Date("2026-04-10") });
+    const c = mk({ id: "c", createdAt: null });
+    const out = sortCards([a, b, c], "newest").map((x) => x.id);
+    expect(out).toEqual(["b", "a", "c"]);
+  });
+
+  it("oldest: createdAt asc with nulls at the bottom", () => {
+    const a = mk({ id: "a", createdAt: new Date("2026-04-01") });
+    const b = mk({ id: "b", createdAt: new Date("2026-04-10") });
+    const c = mk({ id: "c", createdAt: null });
+    const out = sortCards([b, a, c], "oldest").map((x) => x.id);
+    expect(out).toEqual(["a", "b", "c"]);
+  });
+
+  it("contacted: lastContactedAt desc with nulls last", () => {
+    const a = mk({ id: "a", lastContactedAt: new Date("2026-04-10") });
+    const b = mk({ id: "b", lastContactedAt: new Date("2026-04-20") });
+    const c = mk({ id: "c", lastContactedAt: null });
+    const out = sortCards([a, c, b], "contacted").map((x) => x.id);
+    expect(out).toEqual(["b", "a", "c"]);
+  });
+
+  it("name: localeCompare zh-Hant orders CJK by default collation, Latin after", () => {
+    const chen = mk({ id: "1", nameZh: "陳玉涵" });
+    const wang = mk({ id: "2", nameZh: "王小明" });
+    const alice = mk({ id: "3", nameEn: "Alice" });
+    const out = sortCards([chen, wang, alice], "name").map((x) => x.id);
+    // zh-Hant collator (Node's ICU default): 王 → 陳 → Alice.
+    // Test just asserts stable determinism + the known relative order.
+    expect(out).toEqual(["2", "1", "3"]);
+  });
+
+  it("name: cards with no name sink to the bottom", () => {
+    const named = mk({ id: "1", nameZh: "甲" });
+    const blank = mk({ id: "2" });
+    const out = sortCards([blank, named], "name").map((x) => x.id);
+    expect(out).toEqual(["1", "2"]);
+  });
+
+  it("returns a new array (doesn't mutate)", () => {
+    const input = [mk({ id: "a", createdAt: new Date("2026-01-01") })];
+    const out = sortCards(input, "newest");
+    expect(out).not.toBe(input);
+  });
+
+  it("tiebreaker by id keeps order stable across calls", () => {
+    const shared = new Date("2026-04-15");
+    const cards = ["c", "a", "b"].map((id) => mk({ id, createdAt: shared }));
+    expect(sortCards(cards, "newest").map((c) => c.id)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/src/lib/cards/sort.ts
+++ b/src/lib/cards/sort.ts
@@ -1,0 +1,74 @@
+import type { CardSummary } from "@/db/cards";
+
+export type SortKey = "newest" | "oldest" | "contacted" | "name";
+
+export const SORT_KEYS: readonly SortKey[] = ["newest", "oldest", "contacted", "name"];
+
+export function parseSortKey(raw: unknown): SortKey {
+  if (typeof raw !== "string") return "newest";
+  return (SORT_KEYS as readonly string[]).includes(raw) ? (raw as SortKey) : "newest";
+}
+
+function primaryName(c: CardSummary): string {
+  return c.nameZh || c.nameEn || "";
+}
+
+/**
+ * Pure sort — returns a new array, doesn't mutate input. Stable because
+ * fall-through comparators rely on `id` last.
+ *
+ * - newest: createdAt desc (null last)
+ * - oldest: createdAt asc (null last)
+ * - contacted: lastContactedAt desc (null last — "no contact" is stalest)
+ * - name: primary name localeCompare("zh-Hant")；name-less cards sink
+ */
+export function sortCards(cards: CardSummary[], key: SortKey): CardSummary[] {
+  const out = [...cards];
+  switch (key) {
+    case "newest":
+      out.sort((a, b) => tsDesc(a.createdAt, b.createdAt) || stableFallback(a, b));
+      break;
+    case "oldest":
+      out.sort((a, b) => tsAsc(a.createdAt, b.createdAt) || stableFallback(a, b));
+      break;
+    case "contacted":
+      out.sort((a, b) => tsDesc(a.lastContactedAt, b.lastContactedAt) || stableFallback(a, b));
+      break;
+    case "name": {
+      const collator = new Intl.Collator("zh-Hant", { sensitivity: "base", numeric: true });
+      out.sort((a, b) => {
+        const na = primaryName(a);
+        const nb = primaryName(b);
+        if (na && !nb) return -1;
+        if (!na && nb) return 1;
+        const cmp = collator.compare(na, nb);
+        return cmp !== 0 ? cmp : stableFallback(a, b);
+      });
+      break;
+    }
+  }
+  return out;
+}
+
+// Date desc where null goes to the bottom (after all non-null values).
+function tsDesc(a: Date | null, b: Date | null): number {
+  if (a === null && b === null) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  return b.getTime() - a.getTime();
+}
+
+function tsAsc(a: Date | null, b: Date | null): number {
+  if (a === null && b === null) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  return a.getTime() - b.getTime();
+}
+
+// Deterministic tiebreaker so identical primary keys don't shuffle
+// between renders. Uses id lexical order.
+function stableFallback(a: CardSummary, b: CardSummary): number {
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
+}


### PR DESCRIPTION
Closes #49. Seventh business-UX slice.

## What

- `/cards` has three sort keys: 最新建立 / 最近聯絡 / 姓名. Default remains 最新建立.
- Client-side sort on the page (≤200 cards); no new Firestore indexes.
- Null timestamps always sink to the bottom — 「從沒聯絡的」 doesn't shove fresh cards off the first screen.
- URL sync: `?sort=newest|oldest|contacted|name`.

## Tests

- 9 UT in `sort.test.ts` covering each key, null handling, name-less cards, immutability, stable tiebreaker.
- 330 pass / 21 skipped (was 321 / 21).

## Deploy

No rules/schema. After merge:
- `pnpm build` with basePath
- `pm2 reload namecard-web --update-env`