### PR TITLE
feat(cards): native share via Web Share API (Closes #51)

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -196,6 +196,7 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
 
           <CardActions
             cardId={card.id}
+            displayName={primary}
             primaryPhone={primaryPhone?.value}
             primaryEmail={primaryEmail?.value}
             lineId={card.social?.lineId}

--- a/src/components/cards/CardActions.tsx
+++ b/src/components/cards/CardActions.tsx
@@ -5,11 +5,13 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState, useTransition } from "react";
 
 import { deleteCardAction, logContactAction, toggleCardPinAction } from "@/app/(app)/cards/actions";
+import { shareCardVcard } from "@/lib/share/card-share";
 
 import styles from "./CardActions.module.css";
 
 interface CardActionsProps {
   cardId: string;
+  displayName?: string;
   primaryPhone?: string;
   primaryEmail?: string;
   lineId?: string;
@@ -19,6 +21,7 @@ interface CardActionsProps {
 
 export function CardActions({
   cardId,
+  displayName,
   primaryPhone,
   primaryEmail,
   lineId,
@@ -87,6 +90,18 @@ export function CardActions({
         router.refresh();
       }
     });
+  };
+
+  const handleShare = async () => {
+    setError(null);
+    try {
+      const outcome = await shareCardVcard(cardId, displayName ?? "名片");
+      if (outcome === "shared") setToast("已分享");
+      else if (outcome === "downloaded") setToast("已下載 vCard");
+      // "cancelled" → user dismissed the share sheet; no toast.
+    } catch {
+      setToast("分享失敗，已改為下載");
+    }
   };
 
   const copyToClipboard = async (value: string, label: string) => {
@@ -255,6 +270,9 @@ export function CardActions({
           aria-pressed={isPinned}
         >
           {isPinned ? "📍 已置頂（取消）" : "📌 設為重要聯絡人"}
+        </button>
+        <button type="button" className={styles.secondary} onClick={handleShare}>
+          📤 分享名片
         </button>
         <a href={`/api/cards/${cardId}/vcard`} className={styles.secondary}>
           匯出 vCard

--- a/src/lib/share/__tests__/card-share.test.ts
+++ b/src/lib/share/__tests__/card-share.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { sanitizeFilename, shareCardVcard } from "../card-share";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function stubNavigator(partial: Partial<Navigator> & { share?: unknown; canShare?: unknown }) {
+  return partial as Navigator;
+}
+
+function okResponse(body = "BEGIN:VCARD\r\nEND:VCARD\r\n"): Response {
+  return new Response(body, { status: 200, headers: { "Content-Type": "text/vcard" } });
+}
+
+describe("shareCardVcard", () => {
+  it("uses Web Share API when supported", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    const canShare = vi.fn().mockReturnValue(true);
+    const fetchFn = vi.fn().mockResolvedValue(okResponse());
+    const fallbackDownload = vi.fn();
+
+    const outcome = await shareCardVcard("abc", "陳玉涵", {
+      nav: stubNavigator({ share, canShare }),
+      fetchFn,
+      fallbackDownload,
+    });
+
+    expect(outcome).toBe("shared");
+    expect(share).toHaveBeenCalledOnce();
+    const sharePayload = share.mock.calls[0][0] as { files: File[]; title: string };
+    expect(sharePayload.title).toBe("陳玉涵");
+    expect(sharePayload.files).toHaveLength(1);
+    expect(sharePayload.files[0].name).toBe("陳玉涵.vcf");
+    expect(fallbackDownload).not.toHaveBeenCalled();
+  });
+
+  it("falls back to download when navigator.share is missing", async () => {
+    const fallbackDownload = vi.fn();
+    const outcome = await shareCardVcard("abc", "Alice", {
+      nav: stubNavigator({}),
+      fallbackDownload,
+    });
+    expect(outcome).toBe("downloaded");
+    expect(fallbackDownload).toHaveBeenCalledWith("/api/cards/abc/vcard");
+  });
+
+  it("falls back to download when canShare returns false for files", async () => {
+    const share = vi.fn();
+    const canShare = vi.fn().mockReturnValue(false);
+    const fetchFn = vi.fn().mockResolvedValue(okResponse());
+    const fallbackDownload = vi.fn();
+
+    const outcome = await shareCardVcard("abc", "Alice", {
+      nav: stubNavigator({ share, canShare }),
+      fetchFn,
+      fallbackDownload,
+    });
+
+    expect(outcome).toBe("downloaded");
+    expect(share).not.toHaveBeenCalled();
+    expect(fallbackDownload).toHaveBeenCalledOnce();
+  });
+
+  it("treats AbortError as 'cancelled' (user dismissed share sheet)", async () => {
+    const abortErr = new Error("cancelled");
+    abortErr.name = "AbortError";
+    const share = vi.fn().mockRejectedValue(abortErr);
+    const canShare = vi.fn().mockReturnValue(true);
+    const fetchFn = vi.fn().mockResolvedValue(okResponse());
+    const fallbackDownload = vi.fn();
+
+    const outcome = await shareCardVcard("abc", "Alice", {
+      nav: stubNavigator({ share, canShare }),
+      fetchFn,
+      fallbackDownload,
+    });
+
+    expect(outcome).toBe("cancelled");
+    expect(fallbackDownload).not.toHaveBeenCalled();
+  });
+
+  it("falls back to download on unexpected share errors", async () => {
+    const share = vi.fn().mockRejectedValue(new Error("surprise"));
+    const canShare = vi.fn().mockReturnValue(true);
+    const fetchFn = vi.fn().mockResolvedValue(okResponse());
+    const fallbackDownload = vi.fn();
+
+    const outcome = await shareCardVcard("abc", "Alice", {
+      nav: stubNavigator({ share, canShare }),
+      fetchFn,
+      fallbackDownload,
+    });
+
+    expect(outcome).toBe("downloaded");
+    expect(fallbackDownload).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to download when fetch fails (non-ok response)", async () => {
+    const share = vi.fn();
+    const canShare = vi.fn().mockReturnValue(true);
+    const fetchFn = vi.fn().mockResolvedValue(new Response("", { status: 500 }));
+    const fallbackDownload = vi.fn();
+
+    const outcome = await shareCardVcard("abc", "Alice", {
+      nav: stubNavigator({ share, canShare }),
+      fetchFn,
+      fallbackDownload,
+    });
+
+    expect(outcome).toBe("downloaded");
+    expect(share).not.toHaveBeenCalled();
+  });
+});
+
+describe("sanitizeFilename", () => {
+  it("keeps ASCII and CJK letters", () => {
+    expect(sanitizeFilename("陳玉涵")).toBe("陳玉涵");
+    expect(sanitizeFilename("Alice Chen")).toBe("Alice_Chen");
+  });
+  it("returns fallback when input stripped to empty", () => {
+    expect(sanitizeFilename("///**")).toBe("contact");
+  });
+});

--- a/src/lib/share/card-share.ts
+++ b/src/lib/share/card-share.ts
@@ -1,0 +1,80 @@
+/**
+ * Share a card's vCard via the Web Share API when available, falling
+ * back to a plain download of /api/cards/{id}/vcard. Returns a tag
+ * telling the caller what happened so the UI can surface the right
+ * toast.
+ *
+ *  - "shared"    → native share sheet completed successfully
+ *  - "cancelled" → user dismissed the share sheet (AbortError)
+ *  - "downloaded" → fallback path triggered (no Web Share support,
+ *                   or share threw something non-abort)
+ */
+
+export type ShareOutcome = "shared" | "cancelled" | "downloaded";
+
+export interface ShareCardDeps {
+  /**
+   * `fetch` indirection so tests can stub without touching the global.
+   * Defaults to the window's `fetch` at call time.
+   */
+  fetchFn?: typeof fetch;
+  /** Navigator to use. Defaults to `window.navigator`. */
+  nav?: Navigator;
+  /**
+   * Fallback trigger when Web Share isn't available. Defaults to
+   * `location.assign(url)` so the browser kicks a normal download.
+   */
+  fallbackDownload?: (url: string) => void;
+}
+
+export async function shareCardVcard(
+  cardId: string,
+  displayName: string,
+  deps: ShareCardDeps = {},
+): Promise<ShareOutcome> {
+  const fetchFn = deps.fetchFn ?? globalThis.fetch.bind(globalThis);
+  const nav = deps.nav ?? (typeof navigator !== "undefined" ? navigator : undefined);
+  const fallback =
+    deps.fallbackDownload ??
+    ((url: string) => {
+      if (typeof window !== "undefined") window.location.assign(url);
+    });
+
+  const url = `/api/cards/${encodeURIComponent(cardId)}/vcard`;
+
+  // 1) Try Web Share API with a File payload.
+  if (nav?.share && typeof nav.canShare === "function") {
+    try {
+      const res = await fetchFn(url);
+      if (res.ok) {
+        const blob = await res.blob();
+        const filename = sanitizeFilename(displayName) + ".vcf";
+        const file = new File([blob], filename, { type: "text/vcard" });
+        if (nav.canShare({ files: [file] })) {
+          await nav.share({
+            title: displayName || "名片",
+            text: "名片分享",
+            files: [file],
+          });
+          return "shared";
+        }
+      }
+    } catch (err: unknown) {
+      // User-initiated cancel is not an error condition.
+      if (err instanceof Error && err.name === "AbortError") return "cancelled";
+      // Any other failure falls through to download.
+    }
+  }
+
+  // 2) Fallback: plain download (behavior identical to existing 匯出 vCard).
+  fallback(url);
+  return "downloaded";
+}
+
+export function sanitizeFilename(raw: string): string {
+  const safe = raw.replace(/[^A-Za-z0-9_\-\u3400-\u9fff]+/g, "_").slice(0, 80);
+  // Treat all-separator leftovers ("_" or "") as empty so we never ship
+  // a bare-separator filename.
+  if (!safe || /^_+$/.test(safe)) return "contact";
+  return safe;
+}


### PR DESCRIPTION
Closes #51. Eighth business-UX slice.

## What

Tap 📤 分享名片 → native share sheet (AirDrop / iMessage / LINE / Telegram / Email) with the vCard file attached. One motion, no intermediate download.

- `shareCardVcard(cardId, displayName)` returns `shared | cancelled | downloaded`.
- Feature-detected via `navigator.canShare({ files })`.
- Fallback path is the existing `/api/cards/{id}/vcard` download, so older browsers / desktop without Web Share get the same result they had before.
- `AbortError` (user dismissed) is a no-op, not a visible failure.

## Tests

- 8 UT covering canShare true/false, AbortError, unexpected error fallback, non-ok fetch, missing share API, and filename sanitization edge cases.
- 338 pass / 21 skipped (was 330 / 21).

## Deploy

No rules/schema. After merge:
- `pnpm build` with basePath
- `pm2 reload namecard-web --update-env`