### PR TITLE
feat(shell): global keyboard shortcuts — c / g-prefix / ? (Closes #53)

### DIFF
--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -5,6 +5,7 @@ import { SearchBox } from "@/components/search/SearchBox";
 import type { SessionUser } from "@/lib/firebase/session";
 
 import styles from "./AppShell.module.css";
+import { GlobalShortcuts } from "./GlobalShortcuts";
 
 interface NavItem {
   href: string;
@@ -73,6 +74,7 @@ export function AppShell({ user, children }: AppShellProps) {
         </footer>
       </aside>
       <main className={styles.main}>{children}</main>
+      <GlobalShortcuts />
     </div>
   );
 }

--- a/src/components/shell/GlobalShortcuts.module.css
+++ b/src/components/shell/GlobalShortcuts.module.css
@@ -1,0 +1,101 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(20, 18, 16, 0.55);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-md);
+  z-index: 100;
+}
+
+.sheet {
+  max-width: 480px;
+  width: 100%;
+  background: var(--color-paper);
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.2);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-md);
+}
+
+.title {
+  font-family: var(--font-serif);
+  font-size: var(--text-h3);
+  margin: 0;
+  color: var(--color-fg);
+}
+
+.close {
+  background: transparent;
+  border: none;
+  color: var(--color-fg-muted);
+  font-size: var(--text-body);
+  cursor: pointer;
+  padding: 4px 10px;
+}
+
+.close:hover {
+  color: var(--color-fg);
+}
+
+.list {
+  margin: 0 0 var(--space-md);
+  padding: 0;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: minmax(96px, auto) 1fr;
+  gap: var(--space-md);
+  align-items: center;
+  padding: var(--space-xs) 0;
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.row:last-child {
+  border-bottom: none;
+}
+
+.row dt {
+  display: flex;
+  gap: 4px;
+}
+
+.row dd {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-fg);
+}
+
+kbd {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--text-caption);
+  padding: 2px 8px;
+  background: var(--color-bg-raised);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-fg);
+  box-shadow: 0 1px 0 var(--color-border);
+  min-width: 22px;
+  text-align: center;
+  display: inline-block;
+  line-height: 1;
+}
+
+.hint {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+  line-height: var(--leading-relaxed, 1.5);
+}

--- a/src/components/shell/GlobalShortcuts.module.css
+++ b/src/components/shell/GlobalShortcuts.module.css
@@ -77,7 +77,8 @@
   color: var(--color-fg);
 }
 
-kbd {
+.sheet :global(kbd),
+.hint :global(kbd) {
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: var(--text-caption);
   padding: 2px 8px;

--- a/src/components/shell/GlobalShortcuts.tsx
+++ b/src/components/shell/GlobalShortcuts.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+import { matchKeyEvent } from "@/lib/shortcuts/match";
+
+import styles from "./GlobalShortcuts.module.css";
+
+/**
+ * Global keyboard shortcuts wired at AppShell level.
+ * - c → /cards/new
+ * - g h / g c / g t → navigate
+ * - ? → show help overlay
+ * - Esc → close help overlay
+ *
+ * The prefix buffer auto-cancels 1 second after the prefix key to
+ * avoid stale state trapping the next character.
+ */
+
+const PREFIX_TIMEOUT_MS = 1000;
+
+export function GlobalShortcuts() {
+  const router = useRouter();
+  const [helpOpen, setHelpOpen] = useState(false);
+  const prefixRef = useRef<"g" | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const clearPrefix = () => {
+      prefixRef.current = null;
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+
+    const handler = (e: KeyboardEvent) => {
+      const result = matchKeyEvent(
+        { prefix: prefixRef.current, helpOpen },
+        {
+          key: e.key,
+          metaKey: e.metaKey,
+          ctrlKey: e.ctrlKey,
+          altKey: e.altKey,
+          target: e.target as { tagName?: string; isContentEditable?: boolean } | null,
+        },
+      );
+
+      if (result.action) {
+        switch (result.action.kind) {
+          case "go":
+            e.preventDefault();
+            router.push(result.action.href);
+            break;
+          case "show-help":
+            e.preventDefault();
+            setHelpOpen(true);
+            break;
+          case "close-help":
+            e.preventDefault();
+            setHelpOpen(false);
+            break;
+        }
+        clearPrefix();
+        return;
+      }
+
+      // No action but prefix may have changed.
+      if (result.nextPrefix !== prefixRef.current) {
+        prefixRef.current = result.nextPrefix;
+        if (timerRef.current) clearTimeout(timerRef.current);
+        if (result.nextPrefix) {
+          timerRef.current = setTimeout(clearPrefix, PREFIX_TIMEOUT_MS);
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => {
+      window.removeEventListener("keydown", handler);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [helpOpen, router]);
+
+  if (!helpOpen) return null;
+
+  return (
+    <div
+      className={styles.overlay}
+      role="dialog"
+      aria-modal="true"
+      aria-label="鍵盤快捷鍵"
+      onClick={() => setHelpOpen(false)}
+    >
+      <div className={styles.sheet} onClick={(e) => e.stopPropagation()}>
+        <header className={styles.header}>
+          <h2 className={styles.title}>鍵盤快捷鍵</h2>
+          <button
+            type="button"
+            className={styles.close}
+            aria-label="關閉"
+            onClick={() => setHelpOpen(false)}
+          >
+            ✕
+          </button>
+        </header>
+        <dl className={styles.list}>
+          <div className={styles.row}>
+            <dt>
+              <kbd>c</kbd>
+            </dt>
+            <dd>新增名片</dd>
+          </div>
+          <div className={styles.row}>
+            <dt>
+              <kbd>g</kbd> <kbd>h</kbd>
+            </dt>
+            <dd>回首頁（時間軸）</dd>
+          </div>
+          <div className={styles.row}>
+            <dt>
+              <kbd>g</kbd> <kbd>c</kbd>
+            </dt>
+            <dd>名片冊</dd>
+          </div>
+          <div className={styles.row}>
+            <dt>
+              <kbd>g</kbd> <kbd>t</kbd>
+            </dt>
+            <dd>標籤</dd>
+          </div>
+          <div className={styles.row}>
+            <dt>
+              <kbd>⌘</kbd> <kbd>K</kbd>
+            </dt>
+            <dd>搜尋（Ctrl+K on Windows/Linux）</dd>
+          </div>
+          <div className={styles.row}>
+            <dt>
+              <kbd>?</kbd>
+            </dt>
+            <dd>這個畫面</dd>
+          </div>
+          <div className={styles.row}>
+            <dt>
+              <kbd>Esc</kbd>
+            </dt>
+            <dd>關閉</dd>
+          </div>
+        </dl>
+        <p className={styles.hint}>
+          當你在輸入框打字時快捷鍵會自動停用。按 <kbd>?</kbd> 隨時叫出這個畫面。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/shortcuts/__tests__/match.test.ts
+++ b/src/lib/shortcuts/__tests__/match.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { matchKeyEvent, type KeyEventLike, type ShortcutContext } from "../match";
+
+const noPrefix: ShortcutContext = { prefix: null, helpOpen: false };
+const gPrefix: ShortcutContext = { prefix: "g", helpOpen: false };
+const helpOpen: ShortcutContext = { prefix: null, helpOpen: true };
+
+function key(k: string, overrides: Partial<KeyEventLike> = {}): KeyEventLike {
+  return { key: k, ...overrides };
+}
+
+describe("matchKeyEvent — leaf keys", () => {
+  it("c navigates to /cards/new", () => {
+    const r = matchKeyEvent(noPrefix, key("c"));
+    expect(r.action).toEqual({ kind: "go", href: "/cards/new" });
+    expect(r.nextPrefix).toBeNull();
+  });
+
+  it("? shows help overlay", () => {
+    const r = matchKeyEvent(noPrefix, key("?"));
+    expect(r.action).toEqual({ kind: "show-help" });
+  });
+
+  it("g enters prefix without firing", () => {
+    const r = matchKeyEvent(noPrefix, key("g"));
+    expect(r.action).toBeNull();
+    expect(r.nextPrefix).toBe("g");
+  });
+
+  it("unknown key does nothing", () => {
+    expect(matchKeyEvent(noPrefix, key("z"))).toEqual({ action: null, nextPrefix: null });
+  });
+});
+
+describe("matchKeyEvent — g prefix", () => {
+  it("g then h → /", () => {
+    expect(matchKeyEvent(gPrefix, key("h")).action).toEqual({ kind: "go", href: "/" });
+  });
+
+  it("g then c → /cards", () => {
+    expect(matchKeyEvent(gPrefix, key("c")).action).toEqual({ kind: "go", href: "/cards" });
+  });
+
+  it("g then t → /tags", () => {
+    expect(matchKeyEvent(gPrefix, key("t")).action).toEqual({ kind: "go", href: "/tags" });
+  });
+
+  it("g then random key cancels without firing", () => {
+    const r = matchKeyEvent(gPrefix, key("x"));
+    expect(r.action).toBeNull();
+    expect(r.nextPrefix).toBeNull();
+  });
+
+  it("g then Escape cancels", () => {
+    const r = matchKeyEvent(gPrefix, key("Escape"));
+    expect(r.action).toBeNull();
+    expect(r.nextPrefix).toBeNull();
+  });
+});
+
+describe("matchKeyEvent — guards", () => {
+  it("ignores when focus is in an input", () => {
+    const r = matchKeyEvent(noPrefix, key("c", { target: { tagName: "INPUT" } }));
+    expect(r.action).toBeNull();
+  });
+
+  it("ignores when focus is in a textarea", () => {
+    const r = matchKeyEvent(noPrefix, key("c", { target: { tagName: "TEXTAREA" } }));
+    expect(r.action).toBeNull();
+  });
+
+  it("ignores when focus is contentEditable", () => {
+    const r = matchKeyEvent(
+      noPrefix,
+      key("c", { target: { tagName: "DIV", isContentEditable: true } }),
+    );
+    expect(r.action).toBeNull();
+  });
+
+  it("ignores modified keystrokes so ⌘K still works", () => {
+    expect(matchKeyEvent(noPrefix, key("k", { metaKey: true })).action).toBeNull();
+    expect(matchKeyEvent(noPrefix, key("c", { ctrlKey: true })).action).toBeNull();
+    expect(matchKeyEvent(noPrefix, key("?", { altKey: true })).action).toBeNull();
+  });
+});
+
+describe("matchKeyEvent — help overlay", () => {
+  it("only Escape closes; other keys no-op but prefix is preserved", () => {
+    expect(matchKeyEvent(helpOpen, key("Escape")).action).toEqual({ kind: "close-help" });
+    const ignored = matchKeyEvent(helpOpen, key("c"));
+    expect(ignored.action).toBeNull();
+    expect(ignored.nextPrefix).toBe(helpOpen.prefix);
+  });
+});

--- a/src/lib/shortcuts/match.ts
+++ b/src/lib/shortcuts/match.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure keyboard-shortcut matcher. Used by the client-side
+ * GlobalShortcuts component, but kept headless so the decision logic
+ * is unit-testable without DOM/React.
+ */
+
+export type ShortcutAction =
+  | { kind: "go"; href: string }
+  | { kind: "show-help" }
+  | { kind: "close-help" };
+
+export interface KeyEventLike {
+  key: string;
+  // Any modifier held — we ignore shortcuts when modifiers are on so
+  // browser/OS shortcuts (⌘K, Cmd+L, etc) keep working.
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  /**
+   * Where the event originated. We never trigger shortcuts from inside
+   * text inputs — the character would be swallowed.
+   */
+  target?: { tagName?: string; isContentEditable?: boolean } | null;
+}
+
+export interface ShortcutContext {
+  /** The key pressed immediately before this one, if within the prefix window. */
+  prefix: "g" | null;
+  /** True while the help overlay is open. Only Esc works then. */
+  helpOpen: boolean;
+}
+
+export interface MatchResult {
+  action: ShortcutAction | null;
+  /** What to do with the key buffer after this event. */
+  nextPrefix: "g" | null;
+}
+
+/**
+ * Returns the action triggered by this event (if any) AND what the
+ * next prefix-buffer state should be. Pure function — callers hold
+ * the actual state and timers.
+ */
+export function matchKeyEvent(ctx: ShortcutContext, e: KeyEventLike): MatchResult {
+  // Never intercept text input.
+  if (isTextInput(e.target)) return { action: null, nextPrefix: null };
+
+  // When the help overlay is open, only Esc does something.
+  if (ctx.helpOpen) {
+    if (e.key === "Escape") return { action: { kind: "close-help" }, nextPrefix: null };
+    return { action: null, nextPrefix: ctx.prefix };
+  }
+
+  // Ignore modified keystrokes (let ⌘K etc. through).
+  if (e.metaKey || e.ctrlKey || e.altKey) {
+    return { action: null, nextPrefix: null };
+  }
+
+  // Active g-prefix: consume a single following nav key.
+  if (ctx.prefix === "g") {
+    switch (e.key) {
+      case "h":
+        return { action: { kind: "go", href: "/" }, nextPrefix: null };
+      case "c":
+        return { action: { kind: "go", href: "/cards" }, nextPrefix: null };
+      case "t":
+        return { action: { kind: "go", href: "/tags" }, nextPrefix: null };
+      case "Escape":
+        return { action: null, nextPrefix: null };
+      default:
+        // Any other key cancels the g-prefix without firing.
+        return { action: null, nextPrefix: null };
+    }
+  }
+
+  // No prefix — leaf shortcuts.
+  switch (e.key) {
+    case "g":
+      return { action: null, nextPrefix: "g" };
+    case "c":
+      return { action: { kind: "go", href: "/cards/new" }, nextPrefix: null };
+    case "?":
+      return { action: { kind: "show-help" }, nextPrefix: null };
+    case "Escape":
+      return { action: null, nextPrefix: null };
+    default:
+      return { action: null, nextPrefix: null };
+  }
+}
+
+function isTextInput(target: KeyEventLike["target"]): boolean {
+  if (!target) return false;
+  const tag = (target.tagName ?? "").toUpperCase();
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (target.isContentEditable) return true;
+  return false;
+}


### PR DESCRIPTION
Closes #53. Ninth business-UX slice.

## Shortcuts

- **c** → `/cards/new`
- **g h** → `/`
- **g c** → `/cards`
- **g t** → `/tags`
- **?** → cheat-sheet overlay
- **Esc** → close overlay

## Guards

- Ignored inside text inputs / contentEditable
- Ignored when modifier keys held (⌘K search still works untouched)
- g-prefix auto-expires after 1s
- Overlay open → only Esc reacts

## Architecture

Pure `matchKeyEvent` decision fn + thin `<GlobalShortcuts>` mounting in AppShell.

## Tests

- 14 UT (every key, every g-combo, guards, overlay state)
- 352 pass / 21 skipped (was 338)
- typecheck + lint + format clean

## Deploy

No schema/rules. After merge:
- `pnpm build` with basePath
- `pm2 reload namecard-web --update-env`