### PR TITLE
feat(followups): /followups page — 誰該 ping 了 (Closes #55)

### DIFF
--- a/src/app/(app)/followups/followups.module.css
+++ b/src/app/(app)/followups/followups.module.css
@@ -1,0 +1,94 @@
+.article {
+  padding: var(--space-xl) var(--space-lg);
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.header {
+  margin-bottom: var(--space-xl);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h1);
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-fg);
+  margin: var(--space-xs) 0 var(--space-sm);
+}
+
+.subtitle {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-body);
+  color: var(--color-fg-muted);
+  margin: 0;
+}
+
+.empty {
+  padding: var(--space-xl) 0;
+  text-align: center;
+}
+
+.emptyBody {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-fg-muted);
+}
+
+.link {
+  color: var(--color-accent-ink);
+  text-decoration: underline;
+}
+
+.bucket {
+  margin-bottom: var(--space-xl);
+}
+
+.bucketHeader {
+  margin-bottom: var(--space-sm);
+  padding-bottom: var(--space-xs);
+  border-bottom: var(--border-thin) solid var(--color-border);
+}
+
+.bucketTitle {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+  font-family: var(--font-display);
+  font-size: var(--text-h3);
+  color: var(--color-fg);
+  margin: 0 0 4px;
+}
+
+.bucketCount {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: 2px 10px;
+  background: var(--color-bg-raised);
+  border-radius: var(--radius-md);
+  color: var(--color-fg-muted);
+}
+
+.bucketDesc {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+  margin: 0;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}

--- a/src/app/(app)/followups/page.tsx
+++ b/src/app/(app)/followups/page.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+
+import { FollowupCardRow } from "@/components/followups/FollowupCardRow";
+import { listCardsForUser } from "@/db/cards";
+import { readSession } from "@/lib/firebase/session";
+import { bucketFollowups, totalFollowups, type FollowupBucket } from "@/lib/timeline/followups";
+
+import styles from "./followups.module.css";
+
+export const metadata = {
+  title: "追蹤",
+};
+
+export default async function FollowupsPage() {
+  const user = await readSession();
+  if (!user) return null;
+
+  const cards = await listCardsForUser(user.uid, {
+    limit: 200,
+    orderBy: "createdAt",
+    order: "desc",
+  });
+  const groups = bucketFollowups(cards, new Date());
+  const total = totalFollowups(groups);
+
+  const ordered: FollowupBucket[] = [
+    groups.pinnedStale,
+    groups.critical,
+    groups.overdue,
+    groups.due,
+  ];
+
+  return (
+    <article className={styles.article}>
+      <header className={styles.header}>
+        <p className={styles.kicker}>追蹤</p>
+        <h1 className={styles.title}>
+          {total === 0 ? "全部都跟上了。" : <>有 {total} 個人該 ping 了。</>}
+        </h1>
+        <p className={styles.subtitle}>
+          按急迫度排序。點 <em>✅ 已聯絡</em> 會把這個人從清單裡拿掉。
+        </p>
+      </header>
+
+      {total === 0 ? (
+        <section className={styles.empty}>
+          <p className={styles.emptyBody}>
+            沒有人在排隊等你追蹤。想提前找點人接觸？到
+            <Link href="/cards" className={styles.link}>
+              {" "}
+              名片冊
+            </Link>{" "}
+            切「最近聯絡」排序看看。
+          </p>
+        </section>
+      ) : (
+        ordered
+          .filter((b) => b.cards.length > 0)
+          .map((bucket) => (
+            <section key={bucket.id} className={styles.bucket} aria-label={bucket.title}>
+              <header className={styles.bucketHeader}>
+                <h2 className={styles.bucketTitle}>
+                  {bucket.title}
+                  <span className={styles.bucketCount}>{bucket.cards.length}</span>
+                </h2>
+                <p className={styles.bucketDesc}>{bucket.description}</p>
+              </header>
+              <ol className={styles.list}>
+                {bucket.cards.map(({ card, days }) => (
+                  <FollowupCardRow key={card.id} card={card} days={days} />
+                ))}
+              </ol>
+            </section>
+          ))
+      )}
+    </article>
+  );
+}

--- a/src/components/followups/FollowupCardRow.module.css
+++ b/src/components/followups/FollowupCardRow.module.css
@@ -1,0 +1,80 @@
+.row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-md);
+  align-items: center;
+  padding: var(--space-sm) 0;
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.link {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-md);
+  align-items: baseline;
+  text-decoration: none;
+  color: inherit;
+  min-width: 0;
+}
+
+.primary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  align-items: baseline;
+  min-width: 0;
+}
+
+.pin {
+  font-size: 0.85em;
+}
+
+.name {
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  font-weight: 500;
+  color: var(--color-fg);
+  letter-spacing: var(--tracking-tight);
+}
+
+.secondary {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+}
+
+.days {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-accent);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.markBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-raised);
+  color: var(--color-fg);
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.markBtn:hover:not(:disabled) {
+  border-color: var(--color-ink);
+  background: var(--color-ink);
+  color: var(--color-paper);
+}
+
+.markBtn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}

--- a/src/components/followups/FollowupCardRow.tsx
+++ b/src/components/followups/FollowupCardRow.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { logContactAction } from "@/app/(app)/cards/actions";
+import type { CardSummary } from "@/db/cards";
+
+import styles from "./FollowupCardRow.module.css";
+
+interface FollowupCardRowProps {
+  card: CardSummary;
+  days: number;
+}
+
+/**
+ * One row of the follow-up list: card summary + inline "I contacted
+ * this person just now" button. Skips the note capture step on
+ * purpose — triage flow should be fast; typing a note is an extra
+ * click the user can do from the detail page when they want to.
+ */
+export function FollowupCardRow({ card, days }: FollowupCardRowProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [done, setDone] = useState(false);
+
+  const primary = card.nameZh || card.nameEn || "（未命名）";
+  const secondary = [card.jobTitleZh || card.jobTitleEn, card.companyZh || card.companyEn]
+    .filter(Boolean)
+    .join(" · ");
+
+  function handleMark() {
+    startTransition(async () => {
+      const result = await logContactAction({ id: card.id, note: "" });
+      if (result?.serverError) return;
+      setDone(true);
+      // Give the user a moment to register the "done" state, then refresh
+      // the list so this row drops out of the bucket.
+      setTimeout(() => router.refresh(), 600);
+    });
+  }
+
+  return (
+    <li className={styles.row}>
+      <Link href={`/cards/${card.id}`} className={styles.link}>
+        <div className={styles.primary}>
+          {card.isPinned && <span className={styles.pin}>📍</span>}
+          <span className={styles.name}>{primary}</span>
+          {secondary && <span className={styles.secondary}>{secondary}</span>}
+        </div>
+        <span className={styles.days}>{days} 天</span>
+      </Link>
+      <button
+        type="button"
+        className={styles.markBtn}
+        onClick={handleMark}
+        disabled={pending || done}
+        aria-label={`標記已聯絡 ${primary}`}
+      >
+        {done ? "✓ 完成" : pending ? "記錄中…" : "✅ 已聯絡"}
+      </button>
+    </li>
+  );
+}

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -15,6 +15,7 @@ interface NavItem {
 
 const PRIMARY: NavItem[] = [
   { href: "/", label: "時間軸", description: "最近沒聯絡 · 本月認識" },
+  { href: "/followups", label: "追蹤", description: "誰該 ping 了" },
   { href: "/cards", label: "名片冊", description: "畫廊 · 清單" },
   { href: "/cards/new", label: "新增", description: "手動建立一張" },
   { href: "/tags", label: "標籤", description: "分類 · 重新命名" },

--- a/src/lib/timeline/__tests__/followups.test.ts
+++ b/src/lib/timeline/__tests__/followups.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import { bucketFollowups, totalFollowups } from "../followups";
+
+const NOW = new Date("2026-04-24T00:00:00Z");
+
+function mk(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    social: {},
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function daysAgo(n: number): Date {
+  return new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000);
+}
+
+describe("bucketFollowups — basic bucketing", () => {
+  it("puts 30-59 days into due", () => {
+    const c = mk({ id: "a", lastContactedAt: daysAgo(45) });
+    const g = bucketFollowups([c], NOW);
+    expect(g.due.cards).toHaveLength(1);
+    expect(g.overdue.cards).toHaveLength(0);
+    expect(g.critical.cards).toHaveLength(0);
+  });
+
+  it("puts 60-89 days into overdue", () => {
+    const c = mk({ id: "a", lastContactedAt: daysAgo(75) });
+    const g = bucketFollowups([c], NOW);
+    expect(g.overdue.cards).toHaveLength(1);
+  });
+
+  it("puts 90+ days into critical", () => {
+    const c = mk({ id: "a", lastContactedAt: daysAgo(200) });
+    const g = bucketFollowups([c], NOW);
+    expect(g.critical.cards).toHaveLength(1);
+  });
+
+  it("ignores cards with <30 days (fresh)", () => {
+    const c = mk({ id: "a", lastContactedAt: daysAgo(10) });
+    expect(totalFollowups(bucketFollowups([c], NOW))).toBe(0);
+  });
+});
+
+describe("bucketFollowups — pinned handling", () => {
+  it("puts pinned + ≥30 days into pinnedStale regardless of bucket", () => {
+    const a = mk({ id: "a", isPinned: true, lastContactedAt: daysAgo(45) });
+    const b = mk({ id: "b", isPinned: true, lastContactedAt: daysAgo(95) });
+    const g = bucketFollowups([a, b], NOW);
+    expect(g.pinnedStale.cards.map((c) => c.card.id)).toEqual(["b", "a"]); // most overdue first
+    expect(g.due.cards).toHaveLength(0);
+    expect(g.critical.cards).toHaveLength(0);
+  });
+
+  it("ignores pinned cards that are fresh (<30 days)", () => {
+    const c = mk({ id: "a", isPinned: true, lastContactedAt: daysAgo(10) });
+    expect(bucketFollowups([c], NOW).pinnedStale.cards).toHaveLength(0);
+  });
+});
+
+describe("bucketFollowups — data hygiene", () => {
+  it("skips soft-deleted cards", () => {
+    const c = mk({ id: "a", lastContactedAt: daysAgo(100), deletedAt: daysAgo(5) });
+    expect(totalFollowups(bucketFollowups([c], NOW))).toBe(0);
+  });
+
+  it("skips cards with no time signal (no createdAt, no lastContactedAt)", () => {
+    const c = mk({ id: "a" });
+    expect(totalFollowups(bucketFollowups([c], NOW))).toBe(0);
+  });
+
+  it("falls back to createdAt when lastContactedAt is null", () => {
+    const c = mk({ id: "a", createdAt: daysAgo(95) });
+    expect(bucketFollowups([c], NOW).critical.cards).toHaveLength(1);
+  });
+});
+
+describe("bucketFollowups — sorting", () => {
+  it("most overdue first within each bucket, stable by id", () => {
+    const a = mk({ id: "a", lastContactedAt: daysAgo(35) });
+    const b = mk({ id: "b", lastContactedAt: daysAgo(50) });
+    const c = mk({ id: "c", lastContactedAt: daysAgo(35) });
+    const g = bucketFollowups([a, b, c], NOW);
+    expect(g.due.cards.map((x) => x.card.id)).toEqual(["b", "a", "c"]);
+  });
+});
+
+describe("totalFollowups", () => {
+  it("sums across all four buckets", () => {
+    const cards = [
+      mk({ id: "1", lastContactedAt: daysAgo(35) }),
+      mk({ id: "2", lastContactedAt: daysAgo(75) }),
+      mk({ id: "3", lastContactedAt: daysAgo(120) }),
+      mk({ id: "4", isPinned: true, lastContactedAt: daysAgo(40) }),
+    ];
+    expect(totalFollowups(bucketFollowups(cards, NOW))).toBe(4);
+  });
+
+  it("is 0 for an empty or all-fresh corpus", () => {
+    expect(totalFollowups(bucketFollowups([], NOW))).toBe(0);
+  });
+});

--- a/src/lib/timeline/followups.ts
+++ b/src/lib/timeline/followups.ts
@@ -1,0 +1,103 @@
+import type { CardSummary } from "@/db/cards";
+
+import { daysSinceContact } from "./staleness";
+
+export interface FollowupBucket {
+  id: "critical" | "overdue" | "due" | "pinnedStale";
+  title: string;
+  description: string;
+  cards: Array<{ card: CardSummary; days: number }>;
+}
+
+export interface FollowupGroups {
+  critical: FollowupBucket;
+  overdue: FollowupBucket;
+  due: FollowupBucket;
+  pinnedStale: FollowupBucket;
+}
+
+/**
+ * Bucket cards by how overdue they are for a follow-up.
+ *
+ * Priority rules:
+ *  - Pinned cards that are also stale (≥30 days) go to a dedicated
+ *    `pinnedStale` bucket regardless of how old — core contacts live
+ *    there, not in the general-purpose overdue buckets.
+ *  - Everything else (not pinned, no future lastContactedAt) buckets by
+ *    days-since-contact into: due (30-59), overdue (60-89), critical (90+).
+ *  - Each bucket sorted oldest-first (most overdue top).
+ *  - Cards without any time signal (no createdAt AND no lastContactedAt)
+ *    are ignored — we have nothing to rank them by.
+ *  - Soft-deleted cards are ignored.
+ */
+export function bucketFollowups(cards: CardSummary[], now: Date): FollowupGroups {
+  const critical: FollowupBucket["cards"] = [];
+  const overdue: FollowupBucket["cards"] = [];
+  const due: FollowupBucket["cards"] = [];
+  const pinnedStale: FollowupBucket["cards"] = [];
+
+  for (const card of cards) {
+    if (card.deletedAt) continue;
+    const days = daysSinceContact(card, now);
+    if (days === null) continue;
+
+    if (card.isPinned) {
+      if (days >= 30) pinnedStale.push({ card, days });
+      continue;
+    }
+
+    if (days >= 90) critical.push({ card, days });
+    else if (days >= 60) overdue.push({ card, days });
+    else if (days >= 30) due.push({ card, days });
+  }
+
+  // Most overdue first in each bucket; id tiebreak for determinism.
+  const compare = (
+    a: { card: CardSummary; days: number },
+    b: { card: CardSummary; days: number },
+  ) => b.days - a.days || a.card.id.localeCompare(b.card.id);
+  critical.sort(compare);
+  overdue.sort(compare);
+  due.sort(compare);
+  pinnedStale.sort(compare);
+
+  return {
+    critical: {
+      id: "critical",
+      title: "嚴重過期",
+      description: "超過 90 天沒聯絡。若還想維繫，這週就動。",
+      cards: critical,
+    },
+    overdue: {
+      id: "overdue",
+      title: "過期",
+      description: "60-89 天沒聯絡。簡單一句「最近好嗎」就夠。",
+      cards: overdue,
+    },
+    due: {
+      id: "due",
+      title: "該追蹤",
+      description: "30-59 天沒聯絡，建議本週內接觸。",
+      cards: due,
+    },
+    pinnedStale: {
+      id: "pinnedStale",
+      title: "重要聯絡人 · 該 ping 了",
+      description: "你標為重要的聯絡人，30 天以上沒互動。",
+      cards: pinnedStale,
+    },
+  };
+}
+
+/**
+ * Total count across all buckets — used to show the "all caught up"
+ * empty state.
+ */
+export function totalFollowups(groups: FollowupGroups): number {
+  return (
+    groups.critical.cards.length +
+    groups.overdue.cards.length +
+    groups.due.cards.length +
+    groups.pinnedStale.cards.length
+  );
+}


### PR DESCRIPTION
Closes #55. Tenth business-UX slice.

## What

New `/followups` page groups stale contacts into four priority buckets (pinnedStale / critical ≥90d / overdue 60-89d / due 30-59d). Each row has an inline ✅ 已聯絡 button that fires `logContactAction` and drops the row from the bucket on refresh.

## Why

"這週該 ping 誰" in one glance, without scanning the timeline home's capped 5-card 「最近沒聯絡」 section.

## Tests

- 12 UT (bucket thresholds, pinned override, soft-delete skip, null timestamps, most-overdue-first sort + stable tiebreaker)
- 364 pass / 21 skipped (was 352 / 21)
- typecheck + lint + format clean

## Deploy

No schema/rules change. After merge:
- `pnpm build` with basePath
- `pm2 reload namecard-web --update-env`