### PR TITLE
fix(middleware): redirect honors basePath (prod 502 on protected routes)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,7 +30,14 @@ export function middleware(request: NextRequest) {
 
   const hasSession = request.cookies.has(SESSION_COOKIE_NAME);
   if (!hasSession) {
-    const loginUrl = new URL("/login", request.url);
+    // Clone `nextUrl` (a NextURL) so Next.js auto-prepends the configured
+    // `basePath` on redirect. Using `new URL("/login", request.url)` does
+    // NOT add basePath — it resolves to the raw host root — which under
+    // our Tailscale sub-path deploy goes to a foreign proxy and returns
+    // 502. `nextUrl.clone()` preserves basePath semantics.
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = "/login";
+    loginUrl.search = "";
     if (pathname !== "/") loginUrl.searchParams.set("next", pathname);
     return NextResponse.redirect(loginUrl);
   }


### PR DESCRIPTION
Discovered when new /followups page 502'd. `new URL('/login', request.url)` drops basePath, so the 302 went to bare /login which under Tailscale sub-path deploy falls through to a foreign proxy.

Fix: `request.nextUrl.clone()` preserves basePath. Next.js then auto-prepends /namecard-web before emitting the 302.

No functional change on non-basePath (dev) deploys.

## Tests

- 364 pass / 21 skipped (unchanged — existing tests cover the middleware behavior via E2E emulator path)
- typecheck + format clean

## Deploy priority

Urgent — this fixes a 502 on /cards, /followups, /cards/new etc. in prod.