### PR TITLE
feat(cards): related-by-event sidebar — 同場合認識的人 (Closes #58)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -23,6 +23,14 @@
         { "fieldPath": "memberUids", "arrayConfig": "CONTAINS" },
         { "fieldPath": "updatedAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "cards",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "memberUids", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "firstMetEventTag", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -3,8 +3,9 @@ import { notFound } from "next/navigation";
 
 import { CardActions } from "@/components/cards/CardActions";
 import { ContactEventList } from "@/components/cards/ContactEventList";
+import { RelatedByEvent } from "@/components/cards/RelatedByEvent";
 import { TagSuggestionsBanner } from "@/components/tags/TagSuggestionsBanner";
-import { getCardForUser, listContactEventsForUser } from "@/db/cards";
+import { getCardForUser, getCardsBySharedEvent, listContactEventsForUser } from "@/db/cards";
 import type { CardCreateInput } from "@/db/schema";
 import { readSession } from "@/lib/firebase/session";
 
@@ -35,6 +36,9 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
   const card = await getCardForUser(user.uid, id);
   if (!card || card.deletedAt) notFound();
   const contactEvents = await listContactEventsForUser(id, user.uid, 30);
+  const sharedEventCards = card.firstMetEventTag
+    ? await getCardsBySharedEvent(user.uid, card.firstMetEventTag, card.id, 8)
+    : [];
 
   const primary = card.nameZh || card.nameEn || "（未命名）";
   const secondary = card.nameZh && card.nameEn ? card.nameEn : null;
@@ -203,6 +207,10 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
             linkedinUrl={card.social?.linkedinUrl}
             isPinned={card.isPinned}
           />
+
+          {card.firstMetEventTag && sharedEventCards.length > 0 && (
+            <RelatedByEvent eventTag={card.firstMetEventTag} cards={sharedEventCards} />
+          )}
 
           <footer className={styles.timestamps}>
             {card.createdAt && (

--- a/src/components/cards/RelatedByEvent.module.css
+++ b/src/components/cards/RelatedByEvent.module.css
@@ -1,0 +1,81 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-raised);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.kicker {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+}
+
+.title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-fg);
+}
+
+.count {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.row {
+  border-top: var(--border-hair) solid var(--color-border);
+}
+
+.row:first-child {
+  border-top: none;
+}
+
+.link {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-xs) 0;
+  text-decoration: none;
+  color: inherit;
+  transition: color var(--duration-fast) var(--ease-standard);
+}
+
+.link:hover {
+  color: var(--color-accent-ink);
+}
+
+.name {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-fg);
+}
+
+.sub {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+}

--- a/src/components/cards/RelatedByEvent.tsx
+++ b/src/components/cards/RelatedByEvent.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+import type { CardSummary } from "@/db/cards";
+
+import styles from "./RelatedByEvent.module.css";
+
+interface RelatedByEventProps {
+  eventTag: string;
+  cards: CardSummary[];
+}
+
+/**
+ * Sidebar block on /cards/[id] surfacing other contacts met at the same
+ * event (matched by firstMetEventTag). Renders nothing when the list
+ * is empty so we don't show a depressing "no one else" placeholder.
+ */
+export function RelatedByEvent({ eventTag, cards }: RelatedByEventProps) {
+  if (cards.length === 0) return null;
+  return (
+    <section className={styles.section} aria-label={`${eventTag} 認識的其他人`}>
+      <header className={styles.header}>
+        <p className={styles.kicker}>同場合認識</p>
+        <h3 className={styles.title}>{eventTag}</h3>
+        <p className={styles.count}>另外 {cards.length} 位</p>
+      </header>
+      <ul className={styles.list}>
+        {cards.map((c) => {
+          const name = c.nameZh || c.nameEn || "（未命名）";
+          const sub = [c.jobTitleZh || c.jobTitleEn, c.companyZh || c.companyEn]
+            .filter(Boolean)
+            .join(" · ");
+          return (
+            <li key={c.id} className={styles.row}>
+              <Link href={`/cards/${c.id}`} className={styles.link}>
+                <span className={styles.name}>{name}</span>
+                {sub && <span className={styles.sub}>{sub}</span>}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/db/__tests__/cards.sit.test.ts
+++ b/src/db/__tests__/cards.sit.test.ts
@@ -313,6 +313,84 @@ describe("cards repository (SIT)", () => {
     });
   });
 
+  describe("getCardsBySharedEvent", () => {
+    it("returns other cards with the same firstMetEventTag, excluding self", async () => {
+      const a = await repo.createCardForUser(
+        aCard({ firstMetEventTag: "2024 COMPUTEX", whyRemember: "a" }),
+        { uid: TEST_UID_ALICE },
+      );
+      const b = await repo.createCardForUser(
+        aCard({ firstMetEventTag: "2024 COMPUTEX", whyRemember: "b" }),
+        { uid: TEST_UID_ALICE },
+      );
+      const c = await repo.createCardForUser(
+        aCard({ firstMetEventTag: "Other Event", whyRemember: "c" }),
+        { uid: TEST_UID_ALICE },
+      );
+
+      const others = await repo.getCardsBySharedEvent(TEST_UID_ALICE, "2024 COMPUTEX", a.id);
+      const ids = others.map((card) => card.id);
+      expect(ids).toContain(b.id);
+      expect(ids).not.toContain(a.id);
+      expect(ids).not.toContain(c.id);
+    });
+
+    it("respects the limit", async () => {
+      for (let i = 0; i < 5; i++) {
+        await repo.createCardForUser(
+          aCard({ firstMetEventTag: "Big Event", whyRemember: `c${i}` }),
+          { uid: TEST_UID_ALICE },
+        );
+      }
+      const seed = await repo.createCardForUser(
+        aCard({ firstMetEventTag: "Big Event", whyRemember: "seed" }),
+        { uid: TEST_UID_ALICE },
+      );
+      const result = await repo.getCardsBySharedEvent(TEST_UID_ALICE, "Big Event", seed.id, 3);
+      expect(result).toHaveLength(3);
+    });
+
+    it("returns empty when eventTag is empty / whitespace", async () => {
+      const a = await repo.createCardForUser(aCard({ firstMetEventTag: "" }), {
+        uid: TEST_UID_ALICE,
+      });
+      expect(await repo.getCardsBySharedEvent(TEST_UID_ALICE, "", a.id)).toEqual([]);
+      expect(await repo.getCardsBySharedEvent(TEST_UID_ALICE, "   ", a.id)).toEqual([]);
+    });
+
+    it("does not leak across users (memberUids isolation)", async () => {
+      const aliceCard = await repo.createCardForUser(
+        aCard({ firstMetEventTag: "Shared Event Name" }),
+        { uid: TEST_UID_ALICE },
+      );
+      const bobCard = await repo.createCardForUser(
+        aCard({ firstMetEventTag: "Shared Event Name" }),
+        { uid: TEST_UID_BOB },
+      );
+
+      const aliceSees = await repo.getCardsBySharedEvent(
+        TEST_UID_ALICE,
+        "Shared Event Name",
+        aliceCard.id,
+      );
+      expect(aliceSees.map((c) => c.id)).not.toContain(bobCard.id);
+    });
+
+    it("excludes soft-deleted cards", async () => {
+      const a = await repo.createCardForUser(
+        aCard({ firstMetEventTag: "Tag X", whyRemember: "a" }),
+        { uid: TEST_UID_ALICE },
+      );
+      const b = await repo.createCardForUser(
+        aCard({ firstMetEventTag: "Tag X", whyRemember: "b" }),
+        { uid: TEST_UID_ALICE },
+      );
+      await repo.softDeleteCardForUser(b.id, { uid: TEST_UID_ALICE });
+      const others = await repo.getCardsBySharedEvent(TEST_UID_ALICE, "Tag X", a.id);
+      expect(others.map((c) => c.id)).not.toContain(b.id);
+    });
+  });
+
   describe("setCardPinned", () => {
     it("flips isPinned on and off", async () => {
       const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });

--- a/src/db/cards.ts
+++ b/src/db/cards.ts
@@ -196,6 +196,33 @@ export async function touchLastContactedAt(
 }
 
 /**
+ * Find other cards from the same event tag (e.g. "2024 COMPUTEX") so
+ * the detail page can show 「同場合認識的人」. Filtered by memberUids
+ * to honor the same access boundary as `listCardsForUser` and exclude
+ * the card we're viewing. Returns at most `limit` results, sorted by
+ * createdAt desc so newer additions surface first.
+ */
+export async function getCardsBySharedEvent(
+  uid: string,
+  eventTag: string,
+  excludeCardId: string,
+  limit = 8,
+): Promise<CardSummary[]> {
+  if (!eventTag.trim()) return [];
+  const db = getAdminFirestore();
+  const snap = await db
+    .collectionGroup(SUB_COLLECTION_CARDS)
+    .where("memberUids", "array-contains", uid)
+    .where("firstMetEventTag", "==", eventTag)
+    .limit(limit + 1) // +1 so we can drop the current card and still hit the cap
+    .get();
+  return snap.docs
+    .map((doc) => toSummary(doc.id, doc.data()))
+    .filter((card) => card.id !== excludeCardId && card.deletedAt === null)
+    .slice(0, limit);
+}
+
+/**
  * Toggle the pin flag on a card. Pinned cards surface in the Timeline
  * "Pinned" section at the top and are excluded from "uncontacted"
  * so core contacts aren't shame-nudged. Pin state does not affect


### PR DESCRIPTION
Closes #58. Eleventh business-UX slice — turn each namecard into a doorway to its social cluster.

## What

- New DB fn `getCardsBySharedEvent(uid, eventTag, excludeId, limit=8)`
- `/cards/[id]` sidebar shows 「同場合認識」block when card has `firstMetEventTag` and ≥ 1 other card shares it
- Click any row → that card's detail page

## Schema / indexes

Adds composite index `cards COLLECTION_GROUP memberUids+firstMetEventTag`. Must `firebase deploy --only firestore:indexes` after merge or query throws FAILED_PRECONDITION.

## Tests

- 5 new SIT covering matches + exclude-self + limit + empty tag handling + cross-user isolation + soft-delete skip
- typecheck + lint + format clean

## Deploy

1. Merge
2. `pnpm exec firebase deploy --only firestore:indexes --project namecard-web-prd`
3. Wait for index state=READY (Firebase MCP firestore_list_indexes)
4. `pnpm build` with basePath
5. `pm2 reload namecard-web --update-env`