### PR TITLE
feat(cards): bulk operations — multi-select tag / event / pin / delete (Closes #60)

### DIFF
--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -5,6 +5,8 @@ import { z } from "zod";
 
 import { authedAction } from "@/lib/auth/safe-action";
 import {
+  bulkSoftDeleteCardsForUser,
+  bulkUpdateCardsForUser,
   createCardForUser,
   logContactEvent,
   setCardPinned,
@@ -72,6 +74,62 @@ export const logContactAction = authedAction
     revalidatePath("/");
     revalidatePath(`/cards/${parsedInput.id}`);
     return { ok: true as const, eventId };
+  });
+
+const bulkPatchSchema = z
+  .object({
+    addTagIds: z.array(z.string().min(1).max(80)).max(30).optional(),
+    addTagNames: z.array(z.string().min(1).max(60)).max(30).optional(),
+    setEventTag: z.string().max(100).optional(),
+    setPinned: z.boolean().optional(),
+  })
+  .refine(
+    (p) =>
+      Boolean(
+        (p.addTagIds && p.addTagIds.length > 0) ||
+        (p.addTagNames && p.addTagNames.length > 0) ||
+        p.setEventTag !== undefined ||
+        p.setPinned !== undefined,
+      ),
+    { message: "patch must touch at least one field" },
+  );
+
+/**
+ * Apply the same patch to many cards at once. Skips cards the user
+ * is not a member of. Used by /cards multi-select toolbar to
+ * bulk-add tags / bulk-set event / bulk pin.
+ */
+export const bulkUpdateCardsAction = authedAction
+  .inputSchema(
+    z.object({
+      ids: z.array(z.string().min(1)).min(1).max(500),
+      patch: bulkPatchSchema,
+    }),
+  )
+  .action(async ({ parsedInput, ctx }) => {
+    const result = await bulkUpdateCardsForUser(ctx.user.uid, parsedInput.ids, parsedInput.patch);
+    revalidatePath("/");
+    revalidatePath("/cards");
+    revalidatePath("/followups");
+    return { ok: true as const, ...result };
+  });
+
+/**
+ * Bulk soft-delete (sets deletedAt + reindex). Mirrors the single
+ * deleteCardAction semantics across many ids.
+ */
+export const bulkSoftDeleteCardsAction = authedAction
+  .inputSchema(
+    z.object({
+      ids: z.array(z.string().min(1)).min(1).max(500),
+    }),
+  )
+  .action(async ({ parsedInput, ctx }) => {
+    const result = await bulkSoftDeleteCardsForUser(ctx.user.uid, parsedInput.ids);
+    revalidatePath("/");
+    revalidatePath("/cards");
+    revalidatePath("/followups");
+    return { ok: true as const, ...result };
   });
 
 /**

--- a/src/app/(app)/cards/page.tsx
+++ b/src/app/(app)/cards/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 
-import { CardGallery } from "@/components/cards/CardGallery";
-import { CardList } from "@/components/cards/CardList";
+import { CardsSelectionShell } from "@/components/cards/CardsSelectionShell";
 import { ExportButton } from "@/components/cards/ExportButton";
 import { TagFilterBar } from "@/components/cards/TagFilterBar";
 import { ViewToggle } from "@/components/cards/ViewToggle";
@@ -146,10 +145,8 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
             建立第一張名片
           </Link>
         </div>
-      ) : isGallery ? (
-        <CardGallery cards={cards} />
       ) : (
-        <CardList cards={cards} />
+        <CardsSelectionShell cards={cards} view={isGallery ? "gallery" : "list"} tags={allTags} />
       )}
     </article>
   );

--- a/src/components/cards/CardGallery.module.css
+++ b/src/components/cards/CardGallery.module.css
@@ -36,6 +36,7 @@
 }
 
 .card {
+  position: relative;
   aspect-ratio: 3 / 2;
   padding: var(--space-lg);
   background: var(--color-bg-raised);
@@ -137,4 +138,42 @@
   letter-spacing: var(--tracking-wide);
   color: var(--color-accent);
   font-weight: 500;
+}
+
+.toggleBtn {
+  background: transparent;
+  border: none;
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+  padding: 0;
+}
+
+.checkbox {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: 3px;
+  background: var(--color-paper);
+  font-size: var(--text-caption);
+  color: var(--color-paper);
+}
+
+.checked {
+  background: var(--color-ink);
+  border-color: var(--color-ink);
+  color: var(--color-paper);
+}
+
+.itemSelected .card {
+  box-shadow: 0 0 0 2px var(--color-ink);
 }

--- a/src/components/cards/CardGallery.tsx
+++ b/src/components/cards/CardGallery.tsx
@@ -4,9 +4,12 @@ import type { CardSummary } from "@/db/cards";
 import { daysSinceContact, shouldShowStaleBadge } from "@/lib/timeline/staleness";
 
 import styles from "./CardGallery.module.css";
+import type { CardSelectionApi } from "./useCardSelection";
 
 interface CardGalleryProps {
   cards: CardSummary[];
+  /** When provided, tiles toggle selection instead of navigating. */
+  selection?: CardSelectionApi;
 }
 
 function primaryName(card: CardSummary): string {
@@ -34,7 +37,7 @@ function tiltFor(id: string): number {
   return magnitude * 0.5;
 }
 
-export function CardGallery({ cards }: CardGalleryProps) {
+export function CardGallery({ cards, selection }: CardGalleryProps) {
   const now = new Date();
   return (
     <ul className={styles.grid}>
@@ -43,42 +46,63 @@ export function CardGallery({ cards }: CardGalleryProps) {
         const isFeatured = index % 7 === 0 && cards.length > 6;
         const stale = shouldShowStaleBadge(card, now);
         const days = stale ? daysSinceContact(card, now) : null;
+        const checked = selection?.isSelected(card.id) ?? false;
+        const inner = (
+          <article className={styles.card}>
+            {selection && (
+              <span
+                className={`${styles.checkbox} ${checked ? styles.checked : ""}`}
+                aria-hidden="true"
+              >
+                {checked ? "✓" : ""}
+              </span>
+            )}
+            <header className={styles.cardHeader}>
+              <h2 className={styles.name}>
+                {card.isPinned && (
+                  <span className={styles.pinBadge} aria-label="重要聯絡人" title="重要聯絡人">
+                    📍{" "}
+                  </span>
+                )}
+                {primaryName(card)}
+              </h2>
+              {secondaryName(card) && <p className={styles.nameEn}>{secondaryName(card)}</p>}
+              {role(card) && <p className={styles.role}>{role(card)}</p>}
+              {company(card) && <p className={styles.company}>{company(card)}</p>}
+            </header>
+            {card.whyRemember && <blockquote className={styles.why}>{card.whyRemember}</blockquote>}
+            <footer className={styles.cardFooter}>
+              {card.firstMetEventTag ? (
+                <span className={styles.eventTag}>@ {card.firstMetEventTag}</span>
+              ) : card.firstMetDate ? (
+                <span className={styles.eventTag}>{card.firstMetDate}</span>
+              ) : null}
+              {stale && days !== null && <span className={styles.staleBadge}>{days} 天沒聯絡</span>}
+            </footer>
+          </article>
+        );
         return (
           <li
             key={card.id}
-            className={`${styles.item} ${isFeatured ? styles.featured : ""}`}
+            className={`${styles.item} ${isFeatured ? styles.featured : ""} ${checked ? styles.itemSelected : ""}`}
             style={{ "--tilt": `${tilt}deg` } as React.CSSProperties}
           >
-            <Link href={`/cards/${card.id}`} className={styles.link}>
-              <article className={styles.card}>
-                <header className={styles.cardHeader}>
-                  <h2 className={styles.name}>
-                    {card.isPinned && (
-                      <span className={styles.pinBadge} aria-label="重要聯絡人" title="重要聯絡人">
-                        📍{" "}
-                      </span>
-                    )}
-                    {primaryName(card)}
-                  </h2>
-                  {secondaryName(card) && <p className={styles.nameEn}>{secondaryName(card)}</p>}
-                  {role(card) && <p className={styles.role}>{role(card)}</p>}
-                  {company(card) && <p className={styles.company}>{company(card)}</p>}
-                </header>
-                {card.whyRemember && (
-                  <blockquote className={styles.why}>{card.whyRemember}</blockquote>
-                )}
-                <footer className={styles.cardFooter}>
-                  {card.firstMetEventTag ? (
-                    <span className={styles.eventTag}>@ {card.firstMetEventTag}</span>
-                  ) : card.firstMetDate ? (
-                    <span className={styles.eventTag}>{card.firstMetDate}</span>
-                  ) : null}
-                  {stale && days !== null && (
-                    <span className={styles.staleBadge}>{days} 天沒聯絡</span>
-                  )}
-                </footer>
-              </article>
-            </Link>
+            {selection ? (
+              <button
+                type="button"
+                role="checkbox"
+                aria-checked={checked}
+                aria-label={`選取 ${primaryName(card)}`}
+                className={`${styles.link} ${styles.toggleBtn}`}
+                onClick={() => selection.toggle(card.id)}
+              >
+                {inner}
+              </button>
+            ) : (
+              <Link href={`/cards/${card.id}`} className={styles.link}>
+                {inner}
+              </Link>
+            )}
           </li>
         );
       })}

--- a/src/components/cards/CardList.tsx
+++ b/src/components/cards/CardList.tsx
@@ -4,9 +4,12 @@ import type { CardSummary } from "@/db/cards";
 import { daysSinceContact, shouldShowStaleBadge } from "@/lib/timeline/staleness";
 
 import styles from "./CardList.module.css";
+import type { CardSelectionApi } from "./useCardSelection";
 
 interface CardListProps {
   cards: CardSummary[];
+  /** When provided, rows render as toggles instead of navigation links. */
+  selection?: CardSelectionApi;
 }
 
 function primaryName(card: CardSummary): string {
@@ -21,7 +24,7 @@ function role(card: CardSummary): string | null {
   return card.jobTitleZh || card.jobTitleEn || null;
 }
 
-export function CardList({ cards }: CardListProps) {
+export function CardList({ cards, selection }: CardListProps) {
   // Compute now once per render so staleness is stable across the list and
   // doesn't diverge between items rendered a few ms apart.
   const now = new Date();
@@ -30,30 +33,55 @@ export function CardList({ cards }: CardListProps) {
       {cards.map((card) => {
         const stale = shouldShowStaleBadge(card, now);
         const days = stale ? daysSinceContact(card, now) : null;
+        const checked = selection?.isSelected(card.id) ?? false;
+        const inner = (
+          <>
+            {selection && (
+              <span
+                className={`${styles.checkbox} ${checked ? styles.checked : ""}`}
+                aria-hidden="true"
+              >
+                {checked ? "✓" : ""}
+              </span>
+            )}
+            <div className={styles.primary}>
+              {card.isPinned && (
+                <span className={styles.pinBadge} aria-label="重要聯絡人" title="重要聯絡人">
+                  📍
+                </span>
+              )}
+              <span className={styles.name}>{primaryName(card)}</span>
+              {role(card) && <span className={styles.role}>{role(card)}</span>}
+              {company(card) && <span className={styles.company}>{company(card)}</span>}
+            </div>
+            <p className={styles.why}>{card.whyRemember}</p>
+            <div className={styles.meta}>
+              {card.firstMetEventTag && (
+                <span className={styles.event}>@ {card.firstMetEventTag}</span>
+              )}
+              {card.firstMetDate && <span className={styles.date}>{card.firstMetDate}</span>}
+              {stale && days !== null && <span className={styles.staleBadge}>{days} 天沒聯絡</span>}
+            </div>
+          </>
+        );
         return (
-          <li key={card.id} className={styles.row}>
-            <Link href={`/cards/${card.id}`} className={styles.link}>
-              <div className={styles.primary}>
-                {card.isPinned && (
-                  <span className={styles.pinBadge} aria-label="重要聯絡人" title="重要聯絡人">
-                    📍
-                  </span>
-                )}
-                <span className={styles.name}>{primaryName(card)}</span>
-                {role(card) && <span className={styles.role}>{role(card)}</span>}
-                {company(card) && <span className={styles.company}>{company(card)}</span>}
-              </div>
-              <p className={styles.why}>{card.whyRemember}</p>
-              <div className={styles.meta}>
-                {card.firstMetEventTag && (
-                  <span className={styles.event}>@ {card.firstMetEventTag}</span>
-                )}
-                {card.firstMetDate && <span className={styles.date}>{card.firstMetDate}</span>}
-                {stale && days !== null && (
-                  <span className={styles.staleBadge}>{days} 天沒聯絡</span>
-                )}
-              </div>
-            </Link>
+          <li key={card.id} className={`${styles.row} ${checked ? styles.rowSelected : ""}`}>
+            {selection ? (
+              <button
+                type="button"
+                role="checkbox"
+                aria-checked={checked}
+                aria-label={`選取 ${primaryName(card)}`}
+                className={`${styles.link} ${styles.toggleBtn}`}
+                onClick={() => selection.toggle(card.id)}
+              >
+                {inner}
+              </button>
+            ) : (
+              <Link href={`/cards/${card.id}`} className={styles.link}>
+                {inner}
+              </Link>
+            )}
           </li>
         );
       })}

--- a/src/components/cards/CardsSelectionShell.module.css
+++ b/src/components/cards/CardsSelectionShell.module.css
@@ -1,0 +1,138 @@
+.shell {
+  position: relative;
+}
+
+.bar {
+  display: flex;
+  gap: var(--space-md);
+  align-items: center;
+  margin-bottom: var(--space-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+}
+
+.barInfo strong {
+  color: var(--color-fg);
+}
+
+.barLink {
+  background: transparent;
+  border: var(--border-thin) solid var(--color-border);
+  color: var(--color-fg);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: 4px var(--space-sm);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.barLink:hover {
+  border-color: var(--color-ink);
+  color: var(--color-ink);
+}
+
+.toolbar {
+  position: sticky;
+  bottom: var(--space-md);
+  margin-top: var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  z-index: 50;
+}
+
+.actionRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.input {
+  flex: 1 1 200px;
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  padding: var(--space-xs) var(--space-sm);
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-paper);
+  color: var(--color-fg);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-ink);
+}
+
+.primary,
+.secondary,
+.destructive {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+  border-radius: var(--radius-sm);
+  border: var(--border-thin) solid var(--color-border);
+  background: var(--color-bg-raised);
+  color: var(--color-fg);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.primary {
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-color: var(--color-ink);
+}
+
+.primary:disabled,
+.secondary:disabled,
+.destructive:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.secondary:hover:not(:disabled) {
+  border-color: var(--color-fg-muted);
+}
+
+.destructive {
+  color: var(--color-accent);
+  border-color: var(--color-border);
+  background: transparent;
+}
+
+.destructive.armed {
+  background: var(--color-accent);
+  color: var(--color-paper);
+  border-color: var(--color-accent);
+}
+
+.error {
+  margin: var(--space-xs) 0 0;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-accent);
+}
+
+.toast {
+  position: fixed;
+  bottom: calc(var(--space-xl) + 80px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-md);
+  border-radius: var(--radius-md);
+  z-index: 60;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}

--- a/src/components/cards/CardsSelectionShell.tsx
+++ b/src/components/cards/CardsSelectionShell.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { CardGallery } from "@/components/cards/CardGallery";
+import { CardList } from "@/components/cards/CardList";
+import { bulkSoftDeleteCardsAction, bulkUpdateCardsAction } from "@/app/(app)/cards/actions";
+import type { CardSummary } from "@/db/cards";
+import type { TagSummary } from "@/db/tags";
+
+import styles from "./CardsSelectionShell.module.css";
+import { useCardSelection } from "./useCardSelection";
+
+type View = "gallery" | "list";
+
+interface CardsSelectionShellProps {
+  cards: CardSummary[];
+  view: View;
+  tags: TagSummary[];
+}
+
+/**
+ * Wraps the gallery/list view with a multi-select toggle + floating
+ * bulk-action toolbar. Toolbar appears only when selection mode is on.
+ *
+ * Selection state stays in this component — by design page navigation
+ * (sort change / pagination) clears selection. Cross-page persistence
+ * was deliberately scoped out; users have only one page of cards.
+ */
+export function CardsSelectionShell({ cards, view, tags }: CardsSelectionShellProps) {
+  const router = useRouter();
+  const [selectMode, setSelectMode] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [toast, setToast] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showAddTag, setShowAddTag] = useState(false);
+  const [tagDraft, setTagDraft] = useState("");
+  const [showSetEvent, setShowSetEvent] = useState(false);
+  const [eventDraft, setEventDraft] = useState("");
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const selection = useCardSelection();
+  const allIds = cards.map((c) => c.id);
+  const allSelected = selection.count > 0 && selection.count === allIds.length;
+
+  function exitSelectMode() {
+    setSelectMode(false);
+    selection.clear();
+    setShowAddTag(false);
+    setShowSetEvent(false);
+    setConfirmDelete(false);
+    setError(null);
+  }
+
+  function flashToast(msg: string) {
+    setToast(msg);
+    setTimeout(() => setToast(null), 2400);
+  }
+
+  function applyBulk(input: Parameters<typeof bulkUpdateCardsAction>[0]) {
+    setError(null);
+    startTransition(async () => {
+      const res = await bulkUpdateCardsAction(input);
+      if (res?.serverError) setError(res.serverError);
+      else if (res?.validationErrors) setError("輸入格式有問題");
+      else {
+        flashToast(`已更新 ${res?.data?.updated ?? 0} 張`);
+        exitSelectMode();
+        router.refresh();
+      }
+    });
+  }
+
+  function handleAddTag() {
+    const name = tagDraft.trim();
+    if (!name) return;
+    const known = tags.find((t) => t.name === name);
+    const patch: { addTagIds?: string[]; addTagNames?: string[] } = {};
+    patch.addTagNames = [name];
+    if (known) patch.addTagIds = [known.id];
+    applyBulk({ ids: selection.selectedIds, patch });
+  }
+
+  function handleSetEvent() {
+    applyBulk({
+      ids: selection.selectedIds,
+      patch: { setEventTag: eventDraft.trim() },
+    });
+  }
+
+  function handleSetPin(pinned: boolean) {
+    applyBulk({ ids: selection.selectedIds, patch: { setPinned: pinned } });
+  }
+
+  function handleBulkDelete() {
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      const res = await bulkSoftDeleteCardsAction({ ids: selection.selectedIds });
+      if (res?.serverError) setError(res.serverError);
+      else {
+        flashToast(`已刪除 ${res?.data?.deleted ?? 0} 張`);
+        exitSelectMode();
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div className={styles.shell}>
+      <div className={styles.bar}>
+        {selectMode ? (
+          <>
+            <span className={styles.barInfo}>
+              已選 <strong>{selection.count}</strong> / {allIds.length}
+            </span>
+            <button
+              type="button"
+              className={styles.barLink}
+              onClick={() => selection.setMany(allIds, !allSelected)}
+            >
+              {allSelected ? "取消全選" : "全選"}
+            </button>
+            <button type="button" className={styles.barLink} onClick={exitSelectMode}>
+              離開選取模式
+            </button>
+          </>
+        ) : (
+          <button type="button" className={styles.barLink} onClick={() => setSelectMode(true)}>
+            ☑ 選取模式
+          </button>
+        )}
+      </div>
+
+      {view === "gallery" ? (
+        <CardGallery cards={cards} selection={selectMode ? selection : undefined} />
+      ) : (
+        <CardList cards={cards} selection={selectMode ? selection : undefined} />
+      )}
+
+      {selectMode && selection.count > 0 && (
+        <div className={styles.toolbar} role="toolbar" aria-label="批次動作">
+          {showAddTag ? (
+            <div className={styles.actionRow}>
+              <input
+                type="text"
+                className={styles.input}
+                placeholder="標籤名（既有或新建）"
+                value={tagDraft}
+                onChange={(e) => setTagDraft(e.target.value.slice(0, 60))}
+                list="bulk-tag-suggestions"
+                autoFocus
+              />
+              <datalist id="bulk-tag-suggestions">
+                {tags.map((t) => (
+                  <option key={t.id} value={t.name} />
+                ))}
+              </datalist>
+              <button
+                type="button"
+                className={styles.primary}
+                onClick={handleAddTag}
+                disabled={pending || !tagDraft.trim()}
+              >
+                加到 {selection.count} 張
+              </button>
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={() => {
+                  setShowAddTag(false);
+                  setTagDraft("");
+                }}
+              >
+                取消
+              </button>
+            </div>
+          ) : showSetEvent ? (
+            <div className={styles.actionRow}>
+              <input
+                type="text"
+                className={styles.input}
+                placeholder="場合，例如「2024 COMPUTEX」"
+                value={eventDraft}
+                onChange={(e) => setEventDraft(e.target.value.slice(0, 100))}
+                autoFocus
+              />
+              <button
+                type="button"
+                className={styles.primary}
+                onClick={handleSetEvent}
+                disabled={pending}
+              >
+                套用到 {selection.count} 張
+              </button>
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={() => {
+                  setShowSetEvent(false);
+                  setEventDraft("");
+                }}
+              >
+                取消
+              </button>
+            </div>
+          ) : (
+            <div className={styles.actionRow}>
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={() => setShowAddTag(true)}
+                disabled={pending}
+              >
+                + 加標籤
+              </button>
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={() => setShowSetEvent(true)}
+                disabled={pending}
+              >
+                ＠ 設場合
+              </button>
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={() => handleSetPin(true)}
+                disabled={pending}
+              >
+                📍 置頂
+              </button>
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={() => handleSetPin(false)}
+                disabled={pending}
+              >
+                取消置頂
+              </button>
+              <button
+                type="button"
+                className={`${styles.destructive} ${confirmDelete ? styles.armed : ""}`}
+                onClick={handleBulkDelete}
+                disabled={pending}
+              >
+                {confirmDelete ? `確定刪除 ${selection.count} 張？` : "🗑 刪除"}
+              </button>
+            </div>
+          )}
+          {error && (
+            <p role="alert" className={styles.error}>
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+
+      {toast && (
+        <div role="status" aria-live="polite" className={styles.toast}>
+          {toast}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/cards/__tests__/useCardSelection.test.ts
+++ b/src/components/cards/__tests__/useCardSelection.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { useCardSelection } from "../useCardSelection";
+
+describe("useCardSelection", () => {
+  it("starts empty", () => {
+    const { result } = renderHook(() => useCardSelection());
+    expect(result.current.count).toBe(0);
+    expect(result.current.selectedIds).toEqual([]);
+  });
+
+  it("toggle adds and removes", () => {
+    const { result } = renderHook(() => useCardSelection());
+    act(() => result.current.toggle("a"));
+    expect(result.current.isSelected("a")).toBe(true);
+    expect(result.current.count).toBe(1);
+    act(() => result.current.toggle("a"));
+    expect(result.current.isSelected("a")).toBe(false);
+    expect(result.current.count).toBe(0);
+  });
+
+  it("setMany on=true adds all (deduped)", () => {
+    const { result } = renderHook(() => useCardSelection());
+    act(() => result.current.setMany(["a", "b", "a"], true));
+    expect(result.current.count).toBe(2);
+    expect(result.current.selectedIds.sort()).toEqual(["a", "b"]);
+  });
+
+  it("setMany on=false removes only the listed ids", () => {
+    const { result } = renderHook(() => useCardSelection());
+    act(() => result.current.setMany(["a", "b", "c"], true));
+    act(() => result.current.setMany(["b"], false));
+    expect(result.current.selectedIds.sort()).toEqual(["a", "c"]);
+  });
+
+  it("clear empties everything", () => {
+    const { result } = renderHook(() => useCardSelection());
+    act(() => result.current.setMany(["a", "b"], true));
+    act(() => result.current.clear());
+    expect(result.current.count).toBe(0);
+  });
+
+  it("api object identity changes only when state does", () => {
+    const { result, rerender } = renderHook(() => useCardSelection());
+    const before = result.current;
+    rerender();
+    expect(result.current).toBe(before);
+    act(() => result.current.toggle("x"));
+    expect(result.current).not.toBe(before);
+  });
+});

--- a/src/components/cards/useCardSelection.ts
+++ b/src/components/cards/useCardSelection.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+
+/**
+ * Selection state for the /cards multi-select toolbar.
+ *
+ * Backed by a Set so duplicate-toggle is O(1). Read paths return
+ * stable arrays / counts via memoization to keep React happy.
+ */
+export interface CardSelectionApi {
+  selected: ReadonlySet<string>;
+  selectedIds: string[];
+  count: number;
+  isSelected: (id: string) => boolean;
+  toggle: (id: string) => void;
+  setMany: (ids: string[], on: boolean) => void;
+  clear: () => void;
+}
+
+export function useCardSelection(): CardSelectionApi {
+  const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
+
+  const isSelected = useCallback((id: string) => selected.has(id), [selected]);
+
+  const toggle = useCallback((id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const setMany = useCallback((ids: string[], on: boolean) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      for (const id of ids) {
+        if (on) next.add(id);
+        else next.delete(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(() => setSelected(new Set()), []);
+
+  const selectedIds = useMemo(() => Array.from(selected), [selected]);
+
+  return useMemo(
+    () => ({
+      selected,
+      selectedIds,
+      count: selected.size,
+      isSelected,
+      toggle,
+      setMany,
+      clear,
+    }),
+    [selected, selectedIds, isSelected, toggle, setMany, clear],
+  );
+}

--- a/src/db/__tests__/cards.sit.test.ts
+++ b/src/db/__tests__/cards.sit.test.ts
@@ -313,6 +313,93 @@ describe("cards repository (SIT)", () => {
     });
   });
 
+  describe("bulkUpdateCardsForUser", () => {
+    it("adds tags to many cards in one go (deduped)", async () => {
+      const a = await repo.createCardForUser(aCard({ tagIds: ["t1"] }), {
+        uid: TEST_UID_ALICE,
+      });
+      const b = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+
+      const result = await repo.bulkUpdateCardsForUser(TEST_UID_ALICE, [a.id, b.id], {
+        addTagIds: ["t1", "t2"],
+        addTagNames: ["客戶"],
+      });
+      expect(result.updated).toBe(2);
+
+      const aCardAfter = (await repo.getCardForUser(TEST_UID_ALICE, a.id))!;
+      const bCardAfter = (await repo.getCardForUser(TEST_UID_ALICE, b.id))!;
+      // a kept t1 (no dup) + got t2 + got "客戶"
+      expect(aCardAfter.tagIds.sort()).toEqual(["t1", "t2"]);
+      expect(aCardAfter.tagNames).toContain("客戶");
+      expect(bCardAfter.tagIds.sort()).toEqual(["t1", "t2"]);
+    });
+
+    it("sets firstMetEventTag and isPinned in one batch", async () => {
+      const a = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      const b = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await repo.bulkUpdateCardsForUser(TEST_UID_ALICE, [a.id, b.id], {
+        setEventTag: "2024 COMPUTEX",
+        setPinned: true,
+      });
+      for (const id of [a.id, b.id]) {
+        const card = (await repo.getCardForUser(TEST_UID_ALICE, id))!;
+        expect(card.firstMetEventTag).toBe("2024 COMPUTEX");
+        expect(card.isPinned).toBe(true);
+      }
+    });
+
+    it("skips cards the caller is not a member of (cross-user safety)", async () => {
+      const a = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      const bobCard = await repo.createCardForUser(aCard(), { uid: TEST_UID_BOB });
+
+      const result = await repo.bulkUpdateCardsForUser(TEST_UID_ALICE, [a.id, bobCard.id], {
+        setPinned: true,
+      });
+      // bob's card should be invisible / unaffected — alice's reach is her workspace.
+      expect(result.updated).toBe(1);
+    });
+
+    it("skips soft-deleted cards", async () => {
+      const a = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      const b = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await repo.softDeleteCardForUser(b.id, { uid: TEST_UID_ALICE });
+
+      const result = await repo.bulkUpdateCardsForUser(TEST_UID_ALICE, [a.id, b.id], {
+        setPinned: true,
+      });
+      expect(result.updated).toBe(1);
+    });
+
+    it("noops on empty ids", async () => {
+      const result = await repo.bulkUpdateCardsForUser(TEST_UID_ALICE, [], { setPinned: true });
+      expect(result.updated).toBe(0);
+    });
+  });
+
+  describe("bulkSoftDeleteCardsForUser", () => {
+    it("soft-deletes the requested cards", async () => {
+      const a = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      const b = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+
+      const result = await repo.bulkSoftDeleteCardsForUser(TEST_UID_ALICE, [a.id, b.id]);
+      expect(result.deleted).toBe(2);
+
+      const list = await repo.listCardsForUser(TEST_UID_ALICE);
+      expect(list.map((c) => c.id)).not.toContain(a.id);
+      expect(list.map((c) => c.id)).not.toContain(b.id);
+    });
+
+    it("does not affect cards owned by other users", async () => {
+      const aliceCard = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      const bobCard = await repo.createCardForUser(aCard(), { uid: TEST_UID_BOB });
+
+      await repo.bulkSoftDeleteCardsForUser(TEST_UID_ALICE, [aliceCard.id, bobCard.id]);
+
+      const bobList = await repo.listCardsForUser(TEST_UID_BOB);
+      expect(bobList.map((c) => c.id)).toContain(bobCard.id);
+    });
+  });
+
   describe("getCardsBySharedEvent", () => {
     it("returns other cards with the same firstMetEventTag, excluding self", async () => {
       const a = await repo.createCardForUser(

--- a/src/db/cards.ts
+++ b/src/db/cards.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/firebase/shared";
 import { syncWithFallback } from "@/lib/search/reconcile";
 
+import { chunkArray, runParallelLimited } from "./_utils";
 import type { CardCreateInput, CardUpdateInput } from "./schema";
 
 /**
@@ -193,6 +194,142 @@ export async function touchLastContactedAt(
   if (after.exists && after.data()?.deletedAt === null) {
     await syncWithFallback(wid, "upsert", cardId, toSummary(cardId, after.data()!));
   }
+}
+
+/**
+ * Patch shape for bulk operations. Optional fields:
+ *   - addTagIds / addTagNames: union into existing arrays (deduped)
+ *   - setEventTag: replace firstMetEventTag (empty string clears)
+ *   - setPinned: replace isPinned
+ *
+ * Combines the most-asked-for "scrub a stack of cards" actions while
+ * staying conservative — no overwrite of name / phone / email at the
+ * bulk layer (those need per-card review).
+ */
+export interface BulkPatch {
+  addTagIds?: string[];
+  addTagNames?: string[];
+  setEventTag?: string;
+  setPinned?: boolean;
+}
+
+const BULK_CHUNK = 400;
+
+function mergeUnique<T>(a: readonly T[], b: readonly T[]): T[] {
+  const set = new Set<T>(a);
+  for (const item of b) set.add(item);
+  return Array.from(set);
+}
+
+/**
+ * Apply `patch` to every card in `ids` that the caller is a member of.
+ * Skips ids the user can't access. Each chunk is one Firestore batch.
+ * Typesense reindex follows so search ranking stays in sync.
+ *
+ * Returns the count of cards actually mutated.
+ */
+export async function bulkUpdateCardsForUser(
+  uid: string,
+  ids: readonly string[],
+  patch: BulkPatch,
+): Promise<{ updated: number }> {
+  if (ids.length === 0) return { updated: 0 };
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const chunks = chunkArray(ids, BULK_CHUNK);
+  let updated = 0;
+  const updatedSummaries: CardSummary[] = [];
+
+  await runParallelLimited(chunks, 3, async (chunk) => {
+    const refs = chunk.map((id) => db.doc(`${cardsPath(wid)}/${id}`));
+    const snaps = await db.getAll(...refs);
+    const batch = db.batch();
+    let touched = 0;
+    for (const snap of snaps) {
+      if (!snap.exists) continue;
+      const data = snap.data()!;
+      if (!data.memberUids?.includes(uid)) continue;
+      if (data.deletedAt) continue;
+      const update: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+        updatedAt: FieldValue.serverTimestamp(),
+      };
+      if (patch.addTagIds && patch.addTagIds.length > 0) {
+        update.tagIds = mergeUnique(data.tagIds ?? [], patch.addTagIds);
+      }
+      if (patch.addTagNames && patch.addTagNames.length > 0) {
+        update.tagNames = mergeUnique(data.tagNames ?? [], patch.addTagNames);
+      }
+      if (patch.setEventTag !== undefined) {
+        update.firstMetEventTag = patch.setEventTag;
+      }
+      if (patch.setPinned !== undefined) {
+        update.isPinned = patch.setPinned;
+      }
+      batch.update(snap.ref, update);
+      touched++;
+    }
+    if (touched > 0) {
+      await batch.commit();
+      updated += touched;
+      const refresh = await db.getAll(...refs);
+      for (const snap of refresh) {
+        if (!snap.exists) continue;
+        const data = snap.data()!;
+        if (!data.memberUids?.includes(uid) || data.deletedAt) continue;
+        updatedSummaries.push(toSummary(snap.id, data));
+      }
+    }
+  });
+
+  for (const card of updatedSummaries) {
+    await syncWithFallback(wid, "upsert", card.id, card);
+  }
+  return { updated };
+}
+
+/**
+ * Soft-delete every card in `ids` the caller can access. Mirrors
+ * single-card softDeleteCardForUser semantics (deletedAt + Typesense
+ * delete). Returns count actually deleted.
+ */
+export async function bulkSoftDeleteCardsForUser(
+  uid: string,
+  ids: readonly string[],
+): Promise<{ deleted: number }> {
+  if (ids.length === 0) return { deleted: 0 };
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const chunks = chunkArray(ids, BULK_CHUNK);
+  let deleted = 0;
+  const deletedIds: string[] = [];
+
+  await runParallelLimited(chunks, 3, async (chunk) => {
+    const refs = chunk.map((id) => db.doc(`${cardsPath(wid)}/${id}`));
+    const snaps = await db.getAll(...refs);
+    const batch = db.batch();
+    let touched = 0;
+    for (const snap of snaps) {
+      if (!snap.exists) continue;
+      const data = snap.data()!;
+      if (!data.memberUids?.includes(uid)) continue;
+      if (data.deletedAt) continue;
+      batch.update(snap.ref, {
+        deletedAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      deletedIds.push(snap.id);
+      touched++;
+    }
+    if (touched > 0) {
+      await batch.commit();
+      deleted += touched;
+    }
+  });
+
+  for (const id of deletedIds) {
+    await syncWithFallback(wid, "delete", id, null);
+  }
+  return { deleted };
 }
 
 /**


### PR DESCRIPTION
Closes #60. Twelfth business-UX slice — biggest workflow win yet. 30 cards from one event tagged + event-stamped + pinned in 3 taps.

## What

- 「☑ 選取模式」 toggle on /cards
- Floating sticky toolbar with: 加標籤 / 設場合 / 置頂 / 取消置頂 / 刪除（雙擊確認）
- All-select / exit-mode controls
- Selection state Set-backed; stable API identity

## Server

- bulkUpdateCardsForUser + bulkSoftDeleteCardsForUser (Firestore batch chunks of 400, 3 in flight)
- Per-card memberUids enforcement; silently skips cards user can't reach
- Typesense reindex follows
- bulkUpdateCardsAction + bulkSoftDeleteCardsAction with Zod patch validation requiring ≥ 1 field

## Tests

- 6 UT for useCardSelection
- 7 SIT for bulk fns (cross-user safety, soft-delete skip, empty no-op, batch atomicity)
- 370 pass / 21 skipped (was 364)
- typecheck + lint + format clean

## Deploy

No schema/rules. After merge:
- `pnpm build` with basePath
- `pm2 reload namecard-web --update-env`