### PR TITLE
feat(cards): multi-value phone / email picker (Closes #62)

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -208,8 +208,8 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
           <CardActions
             cardId={card.id}
             displayName={primary}
-            primaryPhone={primaryPhone?.value}
-            primaryEmail={primaryEmail?.value}
+            phones={card.phones?.map((p) => ({ label: p.label, value: p.value }))}
+            emails={card.emails?.map((e) => ({ label: e.label, value: e.value }))}
             lineId={card.social?.lineId}
             linkedinUrl={card.social?.linkedinUrl}
             isPinned={card.isPinned}

--- a/src/components/cards/CardActions.module.css
+++ b/src/components/cards/CardActions.module.css
@@ -176,6 +176,72 @@
   padding: var(--space-xs) var(--space-sm);
 }
 
+.pickerWrap {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+.pickerBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: transparent;
+}
+
+.pickerMenu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  background: var(--color-paper);
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+  z-index: 70;
+  min-width: 200px;
+}
+
+.pickerItem {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  padding: var(--space-xs) var(--space-sm);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-decoration: none;
+  text-align: left;
+  color: var(--color-fg);
+  font-family: inherit;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.pickerItem:hover,
+.pickerItem:focus {
+  background: var(--color-accent-soft);
+  outline: none;
+}
+
+.pickerLabel {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+}
+
+.pickerValue {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-fg);
+}
+
 .toast {
   margin: 0;
   padding: var(--space-xs) var(--space-sm);

--- a/src/components/cards/CardActions.tsx
+++ b/src/components/cards/CardActions.tsx
@@ -9,11 +9,28 @@ import { shareCardVcard } from "@/lib/share/card-share";
 
 import styles from "./CardActions.module.css";
 
+interface PhoneEntry {
+  label: string;
+  value: string;
+}
+interface EmailEntry {
+  label: string;
+  value: string;
+}
+
 interface CardActionsProps {
   cardId: string;
   displayName?: string;
+  /** Backwards-compat single-value prop. Prefer phones[]. */
   primaryPhone?: string;
+  /** Backwards-compat single-value prop. Prefer emails[]. */
   primaryEmail?: string;
+  /**
+   * Full phone list. When >1, the 📞 quick CTA becomes a picker.
+   * Falls back to primaryPhone when omitted.
+   */
+  phones?: PhoneEntry[];
+  emails?: EmailEntry[];
   lineId?: string;
   linkedinUrl?: string;
   isPinned?: boolean;
@@ -24,10 +41,23 @@ export function CardActions({
   displayName,
   primaryPhone,
   primaryEmail,
+  phones,
+  emails,
   lineId,
   linkedinUrl,
   isPinned = false,
 }: CardActionsProps) {
+  // Normalize: prefer the full list when given, else wrap the single
+  // primary into a 1-item list. Empty when there's nothing to show.
+  const phoneList: PhoneEntry[] =
+    phones?.filter((p) => p.value) ??
+    (primaryPhone ? [{ label: "phone", value: primaryPhone }] : []);
+  const emailList: EmailEntry[] =
+    emails?.filter((e) => e.value) ??
+    (primaryEmail ? [{ label: "email", value: primaryEmail }] : []);
+  const [phonePickerOpen, setPhonePickerOpen] = useState(false);
+  const [emailPickerOpen, setEmailPickerOpen] = useState(false);
+  const [copyPickerOpen, setCopyPickerOpen] = useState<"phone" | "email" | null>(null);
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [confirming, setConfirming] = useState(false);
@@ -125,44 +155,24 @@ export function CardActions({
 
       {/* Primary CTAs — 商務人士最常觸發的四個動作 */}
       <div className={styles.quick}>
-        {primaryPhone ? (
-          <a
-            href={`tel:${primaryPhone}`}
-            className={styles.quickButton}
-            aria-label={`撥打 ${primaryPhone}`}
-          >
-            <span className={styles.quickIcon} aria-hidden="true">
-              📞
-            </span>
-            <span className={styles.quickLabel}>電話</span>
-          </a>
-        ) : (
-          <span className={`${styles.quickButton} ${styles.quickDisabled}`} aria-disabled="true">
-            <span className={styles.quickIcon} aria-hidden="true">
-              📞
-            </span>
-            <span className={styles.quickLabel}>電話</span>
-          </span>
-        )}
-        {primaryEmail ? (
-          <a
-            href={`mailto:${primaryEmail}`}
-            className={styles.quickButton}
-            aria-label={`寄信到 ${primaryEmail}`}
-          >
-            <span className={styles.quickIcon} aria-hidden="true">
-              📧
-            </span>
-            <span className={styles.quickLabel}>Email</span>
-          </a>
-        ) : (
-          <span className={`${styles.quickButton} ${styles.quickDisabled}`} aria-disabled="true">
-            <span className={styles.quickIcon} aria-hidden="true">
-              📧
-            </span>
-            <span className={styles.quickLabel}>Email</span>
-          </span>
-        )}
+        <ChannelQuickButton
+          icon="📞"
+          label="電話"
+          entries={phoneList}
+          scheme="tel"
+          open={phonePickerOpen}
+          onToggle={() => setPhonePickerOpen((v) => !v)}
+          onClose={() => setPhonePickerOpen(false)}
+        />
+        <ChannelQuickButton
+          icon="📧"
+          label="Email"
+          entries={emailList}
+          scheme="mailto"
+          open={emailPickerOpen}
+          onToggle={() => setEmailPickerOpen((v) => !v)}
+          onClose={() => setEmailPickerOpen(false)}
+        />
         {lineHref ? (
           <a
             href={lineHref}
@@ -238,25 +248,29 @@ export function CardActions({
       )}
 
       {/* Copy-to-clipboard row — 商務常需快速複製貼到其他 app */}
-      {(primaryEmail || primaryPhone) && (
+      {(emailList.length > 0 || phoneList.length > 0) && (
         <div className={styles.copyRow}>
-          {primaryEmail && (
-            <button
-              type="button"
-              className={styles.secondary}
-              onClick={() => copyToClipboard(primaryEmail, " email")}
-            >
-              複製 Email
-            </button>
+          {emailList.length > 0 && (
+            <CopyButton
+              label="複製 Email"
+              valueLabel=" email"
+              entries={emailList}
+              open={copyPickerOpen === "email"}
+              onToggle={() => setCopyPickerOpen((c) => (c === "email" ? null : "email"))}
+              onClose={() => setCopyPickerOpen(null)}
+              onCopy={(value, label) => copyToClipboard(value, label)}
+            />
           )}
-          {primaryPhone && (
-            <button
-              type="button"
-              className={styles.secondary}
-              onClick={() => copyToClipboard(primaryPhone, "電話")}
-            >
-              複製電話
-            </button>
+          {phoneList.length > 0 && (
+            <CopyButton
+              label="複製電話"
+              valueLabel="電話"
+              entries={phoneList}
+              open={copyPickerOpen === "phone"}
+              onToggle={() => setCopyPickerOpen((c) => (c === "phone" ? null : "phone"))}
+              onClose={() => setCopyPickerOpen(null)}
+              onCopy={(value, label) => copyToClipboard(value, label)}
+            />
           )}
         </div>
       )}
@@ -312,5 +326,178 @@ export function CardActions({
         </p>
       )}
     </section>
+  );
+}
+
+interface ChannelQuickButtonProps {
+  icon: string;
+  label: string;
+  entries: PhoneEntry[];
+  scheme: "tel" | "mailto";
+  open: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+}
+
+function ChannelQuickButton({
+  icon,
+  label,
+  entries,
+  scheme,
+  open,
+  onToggle,
+  onClose,
+}: ChannelQuickButtonProps) {
+  if (entries.length === 0) {
+    return (
+      <span className={`${styles.quickButton} ${styles.quickDisabled}`} aria-disabled="true">
+        <span className={styles.quickIcon} aria-hidden="true">
+          {icon}
+        </span>
+        <span className={styles.quickLabel}>{label}</span>
+      </span>
+    );
+  }
+  if (entries.length === 1) {
+    const e = entries[0];
+    return (
+      <a
+        href={`${scheme}:${e.value}`}
+        className={styles.quickButton}
+        aria-label={`${label} ${e.value}`}
+      >
+        <span className={styles.quickIcon} aria-hidden="true">
+          {icon}
+        </span>
+        <span className={styles.quickLabel}>{label}</span>
+      </a>
+    );
+  }
+  return (
+    <div className={styles.pickerWrap}>
+      <button
+        type="button"
+        className={styles.quickButton}
+        onClick={onToggle}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`${label} (${entries.length} 個選項)`}
+      >
+        <span className={styles.quickIcon} aria-hidden="true">
+          {icon}
+        </span>
+        <span className={styles.quickLabel}>{label} ▾</span>
+      </button>
+      {open && (
+        <ChannelPicker
+          entries={entries}
+          renderHref={(e) => `${scheme}:${e.value}`}
+          onClose={onClose}
+        />
+      )}
+    </div>
+  );
+}
+
+interface CopyButtonProps {
+  label: string;
+  valueLabel: string;
+  entries: PhoneEntry[];
+  open: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  onCopy: (value: string, label: string) => void;
+}
+
+function CopyButton({
+  label,
+  valueLabel,
+  entries,
+  open,
+  onToggle,
+  onClose,
+  onCopy,
+}: CopyButtonProps) {
+  if (entries.length === 1) {
+    const e = entries[0];
+    return (
+      <button
+        type="button"
+        className={styles.secondary}
+        onClick={() => onCopy(e.value, valueLabel)}
+      >
+        {label}
+      </button>
+    );
+  }
+  return (
+    <div className={styles.pickerWrap}>
+      <button
+        type="button"
+        className={styles.secondary}
+        onClick={onToggle}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        {label} ▾
+      </button>
+      {open && (
+        <ChannelPicker
+          entries={entries}
+          onSelect={(e) => {
+            onCopy(e.value, valueLabel);
+            onClose();
+          }}
+          onClose={onClose}
+        />
+      )}
+    </div>
+  );
+}
+
+interface ChannelPickerProps {
+  entries: PhoneEntry[];
+  renderHref?: (e: PhoneEntry) => string;
+  onSelect?: (e: PhoneEntry) => void;
+  onClose: () => void;
+}
+
+function ChannelPicker({ entries, renderHref, onSelect, onClose }: ChannelPickerProps) {
+  // Close on Escape; outside-click handled by absolute backdrop.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <>
+      <div className={styles.pickerBackdrop} onClick={onClose} aria-hidden="true" />
+      <ul role="menu" className={styles.pickerMenu}>
+        {entries.map((e, i) => {
+          const inner = (
+            <>
+              <span className={styles.pickerLabel}>{e.label}</span>
+              <span className={styles.pickerValue}>{e.value}</span>
+            </>
+          );
+          return (
+            <li key={`${e.label}-${i}`} role="menuitem">
+              {renderHref ? (
+                <a href={renderHref(e)} className={styles.pickerItem} onClick={onClose}>
+                  {inner}
+                </a>
+              ) : (
+                <button type="button" className={styles.pickerItem} onClick={() => onSelect?.(e)}>
+                  {inner}
+                </button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </>
   );
 }

--- a/src/components/cards/__tests__/CardActions.test.tsx
+++ b/src/components/cards/__tests__/CardActions.test.tsx
@@ -27,13 +27,13 @@ describe("CardActions quick CTA row", () => {
 
   it("emits tel: deep link when primaryPhone is provided", () => {
     render(<CardActions cardId="abc" primaryPhone="0928030326" />);
-    const phoneLink = screen.getByLabelText("撥打 0928030326") as HTMLAnchorElement;
+    const phoneLink = screen.getByLabelText(/0928030326/) as HTMLAnchorElement;
     expect(phoneLink.href).toBe("tel:0928030326");
   });
 
   it("emits mailto: deep link when primaryEmail is provided", () => {
     render(<CardActions cardId="abc" primaryEmail="x@y.com" />);
-    const mailLink = screen.getByLabelText("寄信到 x@y.com") as HTMLAnchorElement;
+    const mailLink = screen.getByLabelText(/x@y.com/) as HTMLAnchorElement;
     expect(mailLink.href).toBe("mailto:x@y.com");
   });
 
@@ -100,6 +100,53 @@ describe("CardActions quick CTA row", () => {
           note: "wrote follow-up email",
         });
       });
+    });
+  });
+
+  describe("multi-value channel picker", () => {
+    it("renders single anchor when phones has exactly 1 entry", () => {
+      render(<CardActions cardId="abc" phones={[{ label: "mobile", value: "0900111222" }]} />);
+      const link = screen.getByLabelText(/0900111222/) as HTMLAnchorElement;
+      expect(link.href).toBe("tel:0900111222");
+    });
+
+    it("renders a picker button with caret when phones has 2+ entries", () => {
+      render(
+        <CardActions
+          cardId="abc"
+          phones={[
+            { label: "mobile", value: "0900111222" },
+            { label: "office", value: "02-1234-5678" },
+          ]}
+        />,
+      );
+      // No direct anchor — picker is a button until opened.
+      expect(screen.queryByRole("link", { name: /0900111222/ })).not.toBeInTheDocument();
+      const trigger = screen.getByRole("button", { name: /電話 \(2 個選項\)/ });
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("opens picker on click and lists all phone entries", () => {
+      render(
+        <CardActions
+          cardId="abc"
+          phones={[
+            { label: "mobile", value: "0900111222" },
+            { label: "office", value: "02-1234-5678" },
+          ]}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /電話 \(2 個選項\)/ }));
+      const links = screen.getAllByRole("menuitem");
+      expect(links).toHaveLength(2);
+      const tel = screen.getByText("0900111222").closest("a") as HTMLAnchorElement;
+      expect(tel.href).toBe("tel:0900111222");
+    });
+
+    it("falls back to primaryPhone (legacy prop) when phones is omitted", () => {
+      render(<CardActions cardId="abc" primaryPhone="0900111222" />);
+      const link = screen.getByLabelText(/0900111222/) as HTMLAnchorElement;
+      expect(link.href).toBe("tel:0900111222");
     });
   });
 


### PR DESCRIPTION
Closes #62. Thirteenth business-UX slice.

## What

Quick CTA (📞 / 📧) now handles 0/1/2+ entries:
- 0 → disabled
- 1 → direct anchor (unchanged)
- 2+ → picker button → menu listing label + value, tap any row to trigger system handler

Same pattern applied to 複製 Email / 複製電話 below — if multiple, picker chooses which to copy.

Backwards compat: primaryPhone / primaryEmail props kept as 1-item fallback. New phones/emails arrays are preferred when both sent.

## Tests

- 4 new UT (1-entry direct, 2-entry picker, picker open + menuitem rows, legacy fallback)
- 374 pass / 21 skipped (was 370)
- typecheck + lint + format clean

## Deploy

No schema/rules. After merge:
- `pnpm build` with basePath
- `pm2 reload namecard-web --update-env`