### PR TITLE
feat(cards): duplicate detection + merge — /cards/duplicates

### DIFF
--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -9,6 +9,7 @@ import {
   bulkUpdateCardsForUser,
   createCardForUser,
   logContactEvent,
+  mergeCardsForUser,
   setCardPinned,
   softDeleteCardForUser,
   updateCardForUser,
@@ -144,6 +145,28 @@ export const toggleCardPinAction = authedAction
     revalidatePath("/cards");
     revalidatePath(`/cards/${parsedInput.id}`);
     return { ok: true as const, pinned: parsedInput.pinned };
+  });
+
+/**
+ * Merge N duplicate cards into a chosen "keep" card: union phones / emails /
+ * tags / social, append notes with provenance, take max(lastContactedAt),
+ * then soft-delete the merged ones. The /cards/duplicates page is the
+ * primary caller; surface refuses if keepId appears in mergeIds.
+ */
+export const mergeCardsAction = authedAction
+  .inputSchema(
+    z.object({
+      keepId: z.string().min(1),
+      mergeIds: z.array(z.string().min(1)).min(1).max(20),
+    }),
+  )
+  .action(async ({ parsedInput, ctx }) => {
+    const result = await mergeCardsForUser(ctx.user.uid, parsedInput.keepId, parsedInput.mergeIds);
+    revalidatePath("/");
+    revalidatePath("/cards");
+    revalidatePath("/cards/duplicates");
+    revalidatePath(`/cards/${parsedInput.keepId}`);
+    return { ok: true as const, ...result };
   });
 
 /**

--- a/src/app/(app)/cards/cards.module.css
+++ b/src/app/(app)/cards/cards.module.css
@@ -63,6 +63,26 @@
   color: var(--color-paper);
 }
 
+.duplicatesLink {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+  border: var(--border-hair) solid var(--color-accent-ink);
+  color: var(--color-accent-ink);
+  background: transparent;
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+}
+
+.duplicatesLink:hover {
+  background: var(--color-accent-ink);
+  color: var(--color-paper);
+}
+
 .empty {
   padding: var(--space-2xl) var(--space-xl);
   text-align: center;

--- a/src/app/(app)/cards/duplicates/duplicates.module.css
+++ b/src/app/(app)/cards/duplicates/duplicates.module.css
@@ -1,0 +1,105 @@
+.article {
+  max-width: var(--content-max);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.crumbs {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+}
+
+.crumbs a {
+  color: var(--color-ink-muted);
+  text-decoration: none;
+}
+
+.crumbs a:hover {
+  color: var(--color-ink);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding-bottom: var(--space-md);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h2);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+}
+
+.title em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-accent);
+}
+
+.lead {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  line-height: var(--leading-relaxed);
+  margin: var(--space-xs) 0 0;
+  max-width: 56ch;
+}
+
+.lead strong {
+  color: var(--color-ink);
+  font-weight: 600;
+}
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-2xl) var(--space-md);
+  text-align: center;
+  font-family: var(--font-sans);
+  color: var(--color-ink-muted);
+}
+
+.empty p {
+  font-size: var(--text-body);
+  margin: 0;
+}
+
+.backLink {
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  text-decoration: none;
+  letter-spacing: var(--tracking-wide);
+}
+
+.backLink:hover {
+  text-decoration: underline;
+}
+
+.groupList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}

--- a/src/app/(app)/cards/duplicates/page.tsx
+++ b/src/app/(app)/cards/duplicates/page.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+
+import { MergeGroup } from "@/components/cards/MergeGroup";
+import { listCardsForUser } from "@/db/cards";
+import { findDuplicateGroups } from "@/lib/cards/duplicates";
+import { readSession } from "@/lib/firebase/session";
+
+import styles from "./duplicates.module.css";
+
+export const metadata = {
+  title: "重複名片",
+};
+
+const SCAN_LIMIT = 500;
+
+export default async function DuplicatesPage() {
+  const user = await readSession();
+  if (!user) return null;
+
+  // Same 500-card ceiling as the bulk-edit toolbar — covers >99% of
+  // personal address books without paginating. If a user ever crosses
+  // this, we'll page from the most-recently-touched cards first since
+  // duplicates almost always cluster around recent imports.
+  const cards = await listCardsForUser(user.uid, {
+    limit: SCAN_LIMIT,
+    orderBy: "createdAt",
+    order: "desc",
+  });
+  const groups = findDuplicateGroups(cards);
+
+  const totalDuplicateCards = groups.reduce((sum, g) => sum + g.cards.length, 0);
+  const reclaimable = groups.reduce((sum, g) => sum + (g.cards.length - 1), 0);
+
+  return (
+    <article className={styles.article}>
+      <nav aria-label="Breadcrumbs" className={styles.crumbs}>
+        <Link href="/cards">名片冊</Link>
+        <span aria-hidden="true"> · </span>
+        <span>重複名片</span>
+      </nav>
+
+      <header className={styles.header}>
+        <p className={styles.kicker}>名片整理</p>
+        <h1 className={styles.title}>
+          <em>{groups.length}</em> 組可能重複
+        </h1>
+        {groups.length > 0 ? (
+          <p className={styles.lead}>
+            共 {totalDuplicateCards} 張卡集中在這些組別。合併後可釋出 <strong>{reclaimable}</strong>{" "}
+            張的空間，並把所有電話、Email、標籤、互動歷史集中到
+            一張卡上。被合併的卡會做軟刪除，可從備份還原。
+          </p>
+        ) : (
+          <p className={styles.lead}>
+            目前沒有偵測到重複名片。系統會自動偵測「共用 Email」或「同名同公司」的卡片
+            並提示你合併。
+          </p>
+        )}
+      </header>
+
+      {groups.length === 0 ? (
+        <section className={styles.empty} aria-live="polite">
+          <p>名片冊乾淨無重複 ✨</p>
+          <Link href="/cards" className={styles.backLink}>
+            ← 回名片冊
+          </Link>
+        </section>
+      ) : (
+        <ol className={styles.groupList}>
+          {groups.map((group) => (
+            <li key={group.id}>
+              <MergeGroup group={group} />
+            </li>
+          ))}
+        </ol>
+      )}
+    </article>
+  );
+}

--- a/src/app/(app)/cards/page.tsx
+++ b/src/app/(app)/cards/page.tsx
@@ -7,6 +7,7 @@ import { ViewToggle } from "@/components/cards/ViewToggle";
 import { listCardsForUser, type CardSummary } from "@/db/cards";
 import { listTagsForUser } from "@/db/tags";
 import { readSession } from "@/lib/firebase/session";
+import { findDuplicateGroups } from "@/lib/cards/duplicates";
 import { applyTagFilter } from "@/lib/cards/filter";
 import { parseSortKey, sortCards } from "@/lib/cards/sort";
 import { getTypesenseClient } from "@/lib/search/client";
@@ -97,6 +98,12 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
   // (or a tag-filtered list) we respect the segment control.
   if (!q) cards = sortCards(cards, sort);
 
+  // Surface a duplicate-count nudge in the header. Computed over the
+  // unfiltered list so the link is visible regardless of the current
+  // search/tag state — the actual /cards/duplicates page also runs
+  // its own independent scan, so this is just a notification.
+  const duplicateGroupCount = hasSearchState ? 0 : findDuplicateGroups(allCards).length;
+
   return (
     <article className={styles.article}>
       <header className={styles.header}>
@@ -120,6 +127,15 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
           </h1>
         </div>
         <div className={styles.controls}>
+          {duplicateGroupCount > 0 && (
+            <Link
+              href="/cards/duplicates"
+              className={styles.duplicatesLink}
+              title="有重複名片可合併"
+            >
+              {duplicateGroupCount} 組可合併
+            </Link>
+          )}
           <ViewToggle current={isGallery ? "gallery" : "list"} sort={sort} />
           {cards.length > 0 && (
             <ExportButton

--- a/src/components/cards/MergeGroup.module.css
+++ b/src/components/cards/MergeGroup.module.css
@@ -1,0 +1,185 @@
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-lg);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-paper);
+  box-shadow: var(--shadow-card);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.badge {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: 0.15em 0.7em;
+  border-radius: 999px;
+  background: var(--color-accent-soft, var(--color-accent));
+  color: var(--color-accent-ink);
+  border: var(--border-hair) solid var(--color-accent-ink);
+}
+
+.count {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+}
+
+.hint {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.cardList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.cardItem,
+.cardItemKeep {
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.cardItemKeep {
+  border-color: var(--color-accent-ink);
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.cardLabel {
+  display: flex;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  cursor: pointer;
+  align-items: flex-start;
+}
+
+.cardLabel input[type="radio"] {
+  margin-top: 0.3em;
+  accent-color: var(--color-accent-ink);
+  flex-shrink: 0;
+}
+
+.cardBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25em;
+  min-width: 0;
+  flex: 1;
+}
+
+.cardName {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.cardNameLink {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-ink);
+  text-decoration: none;
+}
+
+.cardNameLink:hover {
+  text-decoration: underline;
+}
+
+.keepTag {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.7rem);
+  letter-spacing: var(--tracking-wide);
+  padding: 0.1em 0.5em;
+  border-radius: 999px;
+  background: var(--color-accent-ink);
+  color: var(--color-paper);
+}
+
+.cardSubline {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+}
+
+.cardMeta {
+  font-family: var(--font-mono, var(--font-sans));
+  font-size: var(--text-micro, 0.72rem);
+  color: var(--color-ink-faint, var(--color-ink-muted));
+  letter-spacing: var(--tracking-wide);
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  align-items: flex-start;
+}
+
+.mergeBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-radius: var(--radius-md);
+  border: none;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.mergeBtn:hover:not(:disabled) {
+  background: var(--color-accent-ink);
+}
+
+.mergeBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.helper {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  color: var(--color-ink-muted);
+}
+
+.error {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-error, #b00020);
+  margin: 0;
+}
+
+.doneMsg {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  margin: 0;
+}
+
+.doneLink {
+  color: var(--color-accent-ink);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}

--- a/src/components/cards/MergeGroup.tsx
+++ b/src/components/cards/MergeGroup.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMemo, useState, useTransition } from "react";
+
+import { mergeCardsAction } from "@/app/(app)/cards/actions";
+import type { CardSummary } from "@/db/cards";
+import type { DuplicateGroup } from "@/lib/cards/duplicates";
+
+import styles from "./MergeGroup.module.css";
+
+interface MergeGroupProps {
+  group: DuplicateGroup;
+}
+
+function reasonLabel(reason: DuplicateGroup["reason"]): string {
+  return reason === "email-match" ? "共用 Email" : "同名同公司";
+}
+
+function cardDisplayName(card: CardSummary): string {
+  return card.nameZh || card.nameEn || "（未命名）";
+}
+
+function cardSubline(card: CardSummary): string {
+  const role = card.jobTitleZh || card.jobTitleEn;
+  const company = card.companyZh || card.companyEn;
+  return [role, company].filter(Boolean).join(" · ");
+}
+
+function formatYmd(date: Date | null | undefined): string {
+  if (!date) return "—";
+  return date.toLocaleDateString("zh-Hant", { year: "numeric", month: "2-digit", day: "2-digit" });
+}
+
+export function MergeGroup({ group }: MergeGroupProps) {
+  const router = useRouter();
+  const [keepId, setKeepId] = useState(group.cards[0]?.id ?? "");
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState<{ merged: number } | null>(null);
+
+  const mergeIds = useMemo(
+    () => group.cards.filter((c) => c.id !== keepId).map((c) => c.id),
+    [group.cards, keepId],
+  );
+
+  function handleMerge() {
+    setError(null);
+    startTransition(async () => {
+      const res = await mergeCardsAction({ keepId, mergeIds });
+      if (res?.serverError) {
+        setError(res.serverError);
+        return;
+      }
+      if (res?.validationErrors) {
+        setError("輸入格式有問題，請重試");
+        return;
+      }
+      const merged = res?.data?.merged ?? mergeIds.length;
+      setDone({ merged });
+      router.refresh();
+    });
+  }
+
+  if (done) {
+    const keepCard = group.cards.find((c) => c.id === keepId);
+    return (
+      <section className={styles.group} aria-live="polite">
+        <p className={styles.doneMsg}>
+          ✅ 已合併 {done.merged} 張到{" "}
+          <Link href={`/cards/${keepId}`} className={styles.doneLink}>
+            {keepCard ? cardDisplayName(keepCard) : "保留卡"}
+          </Link>
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.group}>
+      <header className={styles.header}>
+        <span className={styles.badge}>{reasonLabel(group.reason)}</span>
+        <span className={styles.count}>{group.cards.length} 張可能重複</span>
+      </header>
+
+      <p className={styles.hint}>選一張要保留的卡，其餘會合併進去：</p>
+
+      <ul className={styles.cardList}>
+        {group.cards.map((card) => {
+          const isKeep = card.id === keepId;
+          const phones = card.phones?.length ?? 0;
+          const emails = card.emails?.length ?? 0;
+          const tags = card.tagNames?.length ?? 0;
+          return (
+            <li key={card.id} className={isKeep ? styles.cardItemKeep : styles.cardItem}>
+              <label className={styles.cardLabel}>
+                <input
+                  type="radio"
+                  name={`keep-${group.id}`}
+                  value={card.id}
+                  checked={isKeep}
+                  onChange={() => setKeepId(card.id)}
+                  disabled={pending}
+                />
+                <div className={styles.cardBody}>
+                  <div className={styles.cardName}>
+                    <Link
+                      href={`/cards/${card.id}`}
+                      className={styles.cardNameLink}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {cardDisplayName(card)}
+                    </Link>
+                    {isKeep && <span className={styles.keepTag}>保留</span>}
+                  </div>
+                  {cardSubline(card) && (
+                    <div className={styles.cardSubline}>{cardSubline(card)}</div>
+                  )}
+                  <div className={styles.cardMeta}>
+                    建立：{formatYmd(card.createdAt)} · 上次互動：
+                    {formatYmd(card.lastContactedAt)} · 電話 {phones} · Email {emails} · 標籤 {tags}
+                  </div>
+                </div>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+
+      {error && (
+        <p role="alert" className={styles.error}>
+          {error}
+        </p>
+      )}
+
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={styles.mergeBtn}
+          onClick={handleMerge}
+          disabled={pending || mergeIds.length === 0}
+        >
+          {pending ? "合併中…" : `合併其餘 ${mergeIds.length} 張到此卡`}
+        </button>
+        <span className={styles.helper}>
+          被合併的卡會做軟刪除（電話／Email／標籤／備註會 union 到保留卡）
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/src/db/__tests__/cards.sit.test.ts
+++ b/src/db/__tests__/cards.sit.test.ts
@@ -557,4 +557,117 @@ describe("cards repository (SIT)", () => {
       expect(events).toEqual([]);
     });
   });
+
+  describe("mergeCardsForUser", () => {
+    it("unions phones / emails / tags from merged into keep (deduped)", async () => {
+      const keep = await repo.createCardForUser(
+        aCard({
+          phones: [{ label: "mobile", value: "0900-111-222" }],
+          emails: [{ label: "work", value: "k@x.com" }],
+          tagIds: ["t1"],
+          tagNames: ["客戶"],
+        }),
+        { uid: TEST_UID_ALICE },
+      );
+      const dup = await repo.createCardForUser(
+        aCard({
+          phones: [
+            { label: "mobile", value: "0900-111-222" }, // dup → drop
+            { label: "office", value: "02-1234-5678" }, // new → keep
+          ],
+          emails: [{ label: "personal", value: "k@y.com" }],
+          tagIds: ["t1", "t2"],
+          tagNames: ["VIP"],
+        }),
+        { uid: TEST_UID_ALICE },
+      );
+
+      const result = await repo.mergeCardsForUser(TEST_UID_ALICE, keep.id, [dup.id]);
+      expect(result.merged).toBe(1);
+
+      const after = (await repo.getCardForUser(TEST_UID_ALICE, keep.id))!;
+      expect(after.phones.map((p) => p.value).sort()).toEqual(
+        ["0900-111-222", "02-1234-5678"].sort(),
+      );
+      expect(after.emails.map((e) => e.value).sort()).toEqual(["k@x.com", "k@y.com"].sort());
+      expect(after.tagIds.sort()).toEqual(["t1", "t2"]);
+      expect(after.tagNames.sort()).toEqual(["VIP", "客戶"]);
+    });
+
+    it("appends provenance-tagged notes from merged cards", async () => {
+      const keep = await repo.createCardForUser(aCard({ notes: "原本的備註" }), {
+        uid: TEST_UID_ALICE,
+      });
+      const dup = await repo.createCardForUser(
+        aCard({
+          whyRemember: "Computex 偶遇",
+          notes: "想找他做合作",
+        }),
+        { uid: TEST_UID_ALICE },
+      );
+      await repo.mergeCardsForUser(TEST_UID_ALICE, keep.id, [dup.id]);
+      const after = (await repo.getCardForUser(TEST_UID_ALICE, keep.id))!;
+      expect(after.notes).toContain("原本的備註");
+      expect(after.notes).toContain("【併入：Computex 偶遇】");
+      expect(after.notes).toContain("想找他做合作");
+    });
+
+    it("takes max(lastContactedAt) across keep + merged", async () => {
+      const keep = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      const dup = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+
+      // Touch dup more recently than keep.
+      await repo.touchLastContactedAt(keep.id, { uid: TEST_UID_ALICE });
+      await new Promise((r) => setTimeout(r, 50));
+      await repo.touchLastContactedAt(dup.id, { uid: TEST_UID_ALICE });
+
+      const dupCardBefore = (await repo.getCardForUser(TEST_UID_ALICE, dup.id))!;
+      const dupContactedAt = dupCardBefore.lastContactedAt!.getTime();
+
+      await repo.mergeCardsForUser(TEST_UID_ALICE, keep.id, [dup.id]);
+
+      const after = (await repo.getCardForUser(TEST_UID_ALICE, keep.id))!;
+      expect(after.lastContactedAt).not.toBeNull();
+      expect(after.lastContactedAt!.getTime()).toBe(dupContactedAt);
+    });
+
+    it("soft-deletes the merged cards (keep stays live)", async () => {
+      const keep = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      const dup1 = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      const dup2 = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+
+      await repo.mergeCardsForUser(TEST_UID_ALICE, keep.id, [dup1.id, dup2.id]);
+
+      const list = await repo.listCardsForUser(TEST_UID_ALICE);
+      const visibleIds = list.map((c) => c.id);
+      expect(visibleIds).toContain(keep.id);
+      expect(visibleIds).not.toContain(dup1.id);
+      expect(visibleIds).not.toContain(dup2.id);
+    });
+
+    it("refuses cross-user merges (throws when caller isn't a member)", async () => {
+      const aliceKeep = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      const bobCard = await repo.createCardForUser(aCard(), { uid: TEST_UID_BOB });
+
+      await expect(
+        repo.mergeCardsForUser(TEST_UID_ALICE, aliceKeep.id, [bobCard.id]),
+      ).rejects.toThrow();
+      // Bob's card stays live in his workspace.
+      const bobList = await repo.listCardsForUser(TEST_UID_BOB);
+      expect(bobList.map((c) => c.id)).toContain(bobCard.id);
+    });
+
+    it("refuses when keepId appears in mergeIds", async () => {
+      const keep = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await expect(repo.mergeCardsForUser(TEST_UID_ALICE, keep.id, [keep.id])).rejects.toThrow(
+        /keepId cannot/,
+      );
+    });
+
+    it("noops on empty mergeIds", async () => {
+      const keep = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      const result = await repo.mergeCardsForUser(TEST_UID_ALICE, keep.id, []);
+      expect(result.merged).toBe(0);
+    });
+  });
 });

--- a/src/db/cards.ts
+++ b/src/db/cards.ts
@@ -333,6 +333,130 @@ export async function bulkSoftDeleteCardsForUser(
 }
 
 /**
+ * Merge `mergeIds` cards into `keepId`:
+ *   - Union phones / emails (dedup by value), tagIds + tagNames
+ *   - Fill empty social fields from merged-in records
+ *   - Concatenate notes with provenance prefix per merged card
+ *   - lastContactedAt → max across all
+ *   - Soft-delete merged + Typesense delete
+ *
+ * Refuses if any id isn't accessible to the caller, the keep card
+ * is missing/deleted, or keepId appears in mergeIds.
+ */
+export async function mergeCardsForUser(
+  uid: string,
+  keepId: string,
+  mergeIds: readonly string[],
+): Promise<{ merged: number }> {
+  if (mergeIds.length === 0) return { merged: 0 };
+  if (mergeIds.includes(keepId)) {
+    throw new Error("keepId cannot also appear in mergeIds");
+  }
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const allIds = [keepId, ...mergeIds];
+  const refs = allIds.map((id) => db.doc(`${cardsPath(wid)}/${id}`));
+  const snaps = await db.getAll(...refs);
+  const docs = snaps.map((s, i) => ({ id: allIds[i], snap: s }));
+
+  const keep = docs.find((d) => d.id === keepId)!.snap;
+  if (!keep.exists) throw new Error("keep card not found");
+  const keepData = keep.data()!;
+  if (!keepData.memberUids?.includes(uid)) throw new Error("無權限合併此名片");
+  if (keepData.deletedAt) throw new Error("不能合併已刪除的名片");
+
+  const mergeData: FirebaseFirestore.DocumentData[] = [];
+  for (const m of docs) {
+    if (m.id === keepId) continue;
+    if (!m.snap.exists) throw new Error(`merge card ${m.id} not found`);
+    const data = m.snap.data()!;
+    if (!data.memberUids?.includes(uid)) throw new Error("無權限合併此名片");
+    if (data.deletedAt) continue;
+    mergeData.push(data);
+  }
+
+  // Phones — dedup by trimmed value (preserve original case).
+  const phoneByValue = new Map<string, { label: string; value: string; primary?: boolean }>();
+  for (const arr of [keepData.phones ?? [], ...mergeData.map((d) => d.phones ?? [])]) {
+    for (const p of arr) {
+      const key = (p.value ?? "").trim();
+      if (key && !phoneByValue.has(key)) phoneByValue.set(key, p);
+    }
+  }
+  const emailByValue = new Map<string, { label: string; value: string; primary?: boolean }>();
+  for (const arr of [keepData.emails ?? [], ...mergeData.map((d) => d.emails ?? [])]) {
+    for (const e of arr) {
+      const key = (e.value ?? "").trim().toLowerCase();
+      if (key && !emailByValue.has(key)) emailByValue.set(key, e);
+    }
+  }
+  const tagIds = mergeUnique<string>(
+    keepData.tagIds ?? [],
+    mergeData.flatMap((d) => d.tagIds ?? []),
+  );
+  const tagNames = mergeUnique<string>(
+    keepData.tagNames ?? [],
+    mergeData.flatMap((d) => d.tagNames ?? []),
+  );
+  const social: Record<string, string | undefined> = { ...(keepData.social ?? {}) };
+  for (const md of mergeData) {
+    const s = (md.social ?? {}) as Record<string, unknown>;
+    for (const [k, v] of Object.entries(s)) {
+      if (v && !social[k]) social[k] = String(v);
+    }
+  }
+
+  const notesParts: string[] = [];
+  if (keepData.notes) notesParts.push(String(keepData.notes));
+  for (const md of mergeData) {
+    const tag = md.whyRemember ? `【併入：${md.whyRemember}】` : "【併入】";
+    if (md.notes) notesParts.push(`${tag}\n${md.notes}`);
+    else notesParts.push(tag);
+  }
+  const notes = notesParts.join("\n\n").slice(0, 4000);
+
+  const lastContactedAtMs = Math.max(
+    keepData.lastContactedAt?.toMillis?.() ?? 0,
+    ...mergeData.map((d) => d.lastContactedAt?.toMillis?.() ?? 0),
+  );
+
+  const update: FirebaseFirestore.UpdateData<FirebaseFirestore.DocumentData> = {
+    phones: Array.from(phoneByValue.values()).slice(0, 10),
+    emails: Array.from(emailByValue.values()).slice(0, 10),
+    tagIds: tagIds.slice(0, 30),
+    tagNames: tagNames.slice(0, 30),
+    social,
+    notes,
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+  if (lastContactedAtMs > 0) {
+    update.lastContactedAt = new Date(lastContactedAtMs);
+  }
+
+  const batch = db.batch();
+  batch.update(keep.ref, update);
+  for (const m of docs) {
+    if (m.id === keepId) continue;
+    if (!m.snap.exists || m.snap.data()?.deletedAt) continue;
+    batch.update(m.snap.ref, {
+      deletedAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  }
+  await batch.commit();
+
+  const after = await keep.ref.get();
+  if (after.exists && after.data()?.deletedAt === null) {
+    await syncWithFallback(wid, "upsert", keepId, toSummary(keepId, after.data()!));
+  }
+  for (const m of docs) {
+    if (m.id === keepId) continue;
+    await syncWithFallback(wid, "delete", m.id, null);
+  }
+  return { merged: mergeData.length };
+}
+
+/**
  * Find other cards from the same event tag (e.g. "2024 COMPUTEX") so
  * the detail page can show 「同場合認識的人」. Filtered by memberUids
  * to honor the same access boundary as `listCardsForUser` and exclude

--- a/src/lib/cards/__tests__/duplicates.test.ts
+++ b/src/lib/cards/__tests__/duplicates.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import { findDuplicateGroups } from "../duplicates";
+
+function mk(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    social: {},
+    createdAt: new Date("2026-04-01T00:00:00Z"),
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe("findDuplicateGroups — email signal", () => {
+  it("clusters two cards sharing one email", () => {
+    const a = mk({ id: "a", emails: [{ label: "work", value: "x@y.com" }] });
+    const b = mk({ id: "b", emails: [{ label: "work", value: "X@y.com " }] });
+    const groups = findDuplicateGroups([a, b]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].reason).toBe("email-match");
+    expect(groups[0].cards.map((c) => c.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("does not cluster cards with disjoint emails and different name+company", () => {
+    const a = mk({ id: "a", emails: [{ label: "work", value: "a@y.com" }] });
+    const b = mk({ id: "b", emails: [{ label: "work", value: "b@y.com" }] });
+    expect(findDuplicateGroups([a, b])).toEqual([]);
+  });
+});
+
+describe("findDuplicateGroups — name+company signal", () => {
+  it("clusters cards with same name and company (case-insensitive)", () => {
+    const a = mk({ id: "a", nameZh: "陳玉涵", companyZh: "ACME" });
+    const b = mk({ id: "b", nameZh: "陳玉涵", companyZh: "acme" });
+    const groups = findDuplicateGroups([a, b]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].reason).toBe("name-company-match");
+  });
+
+  it("doesn't cluster on name alone (without company)", () => {
+    const a = mk({ id: "a", nameZh: "陳玉涵" });
+    const b = mk({ id: "b", nameZh: "陳玉涵" });
+    expect(findDuplicateGroups([a, b])).toEqual([]);
+  });
+
+  it("nameEn fallback when nameZh is empty", () => {
+    const a = mk({ id: "a", nameEn: "Alice Chen", companyEn: "ACME" });
+    const b = mk({ id: "b", nameEn: "alice chen", companyEn: "acme" });
+    expect(findDuplicateGroups([a, b])).toHaveLength(1);
+  });
+});
+
+describe("findDuplicateGroups — transitivity + reason precedence", () => {
+  it("A↔B by email and B↔C by name+company puts all three together with email-match reason", () => {
+    const a = mk({
+      id: "a",
+      nameZh: "張三",
+      companyZh: "ACME",
+      emails: [{ label: "work", value: "a@x.com" }],
+    });
+    const b = mk({
+      id: "b",
+      nameZh: "張三",
+      companyZh: "ACME",
+      emails: [{ label: "work", value: "a@x.com" }],
+    });
+    const c = mk({
+      id: "c",
+      nameZh: "張三",
+      companyZh: "ACME",
+    });
+    const groups = findDuplicateGroups([a, b, c]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].cards.map((x) => x.id).sort()).toEqual(["a", "b", "c"]);
+    expect(groups[0].reason).toBe("email-match");
+  });
+});
+
+describe("findDuplicateGroups — hygiene", () => {
+  it("excludes soft-deleted cards", () => {
+    const a = mk({ id: "a", emails: [{ label: "work", value: "x@y.com" }] });
+    const b = mk({
+      id: "b",
+      emails: [{ label: "work", value: "x@y.com" }],
+      deletedAt: new Date(),
+    });
+    expect(findDuplicateGroups([a, b])).toEqual([]);
+  });
+
+  it("returns empty array when nothing is duplicated", () => {
+    expect(findDuplicateGroups([])).toEqual([]);
+    expect(findDuplicateGroups([mk()])).toEqual([]);
+  });
+
+  it("sorts each group oldest-first (keep candidate first)", () => {
+    const older = mk({
+      id: "older",
+      createdAt: new Date("2026-01-01"),
+      emails: [{ label: "work", value: "x@y.com" }],
+    });
+    const newer = mk({
+      id: "newer",
+      createdAt: new Date("2026-04-01"),
+      emails: [{ label: "work", value: "x@y.com" }],
+    });
+    const groups = findDuplicateGroups([newer, older]);
+    expect(groups[0].cards.map((c) => c.id)).toEqual(["older", "newer"]);
+  });
+
+  it("sorts groups largest-first", () => {
+    // 3-member group from email "x"
+    const a = mk({ id: "a", emails: [{ label: "work", value: "x@y.com" }] });
+    const b = mk({ id: "b", emails: [{ label: "work", value: "x@y.com" }] });
+    const c = mk({ id: "c", emails: [{ label: "work", value: "x@y.com" }] });
+    // 2-member group from email "y"
+    const d = mk({ id: "d", emails: [{ label: "work", value: "y@y.com" }] });
+    const e = mk({ id: "e", emails: [{ label: "work", value: "y@y.com" }] });
+    const groups = findDuplicateGroups([d, e, a, b, c]);
+    expect(groups[0].cards).toHaveLength(3);
+    expect(groups[1].cards).toHaveLength(2);
+  });
+});

--- a/src/lib/cards/duplicates.ts
+++ b/src/lib/cards/duplicates.ts
@@ -1,0 +1,139 @@
+import type { CardSummary } from "@/db/cards";
+
+export type DuplicateReason = "email-match" | "name-company-match";
+
+export interface DuplicateGroup {
+  /** A stable key derived from the matching signal — useful for React lists. */
+  id: string;
+  /** Why this group was clustered. If multiple signals matched, "email-match" wins. */
+  reason: DuplicateReason;
+  /** All cards in the group, sorted oldest-first (so the original keep candidate is index 0). */
+  cards: CardSummary[];
+}
+
+function norm(s: string | undefined): string {
+  return (s ?? "").toLowerCase().trim();
+}
+
+function nameCompanyKey(card: CardSummary): string | null {
+  const n = norm(card.nameZh) || norm(card.nameEn);
+  const c = norm(card.companyZh) || norm(card.companyEn);
+  if (!n || !c) return null;
+  return `${n}::${c}`;
+}
+
+/**
+ * Lightweight union-find for clustering cards by shared keys without
+ * pulling a library. Tracks both parent pointer and a representative
+ * "winning" reason per root so the UI can label the cluster.
+ */
+class UnionFind {
+  parent = new Map<string, string>();
+  size = new Map<string, number>();
+  reason = new Map<string, DuplicateReason>();
+
+  add(id: string): void {
+    if (!this.parent.has(id)) {
+      this.parent.set(id, id);
+      this.size.set(id, 1);
+    }
+  }
+
+  find(id: string): string {
+    let cur = id;
+    while (this.parent.get(cur) !== cur) {
+      const p = this.parent.get(cur)!;
+      this.parent.set(cur, this.parent.get(p)!); // path compression
+      cur = this.parent.get(cur)!;
+    }
+    return cur;
+  }
+
+  /** Union with reason precedence: email-match > name-company-match. */
+  union(a: string, b: string, reason: DuplicateReason): void {
+    const ra = this.find(a);
+    const rb = this.find(b);
+    if (ra === rb) {
+      // Upgrade reason if needed.
+      if (reason === "email-match" && this.reason.get(ra) !== "email-match") {
+        this.reason.set(ra, "email-match");
+      }
+      return;
+    }
+    const sa = this.size.get(ra) ?? 1;
+    const sb = this.size.get(rb) ?? 1;
+    const [keep, drop] = sa >= sb ? [ra, rb] : [rb, ra];
+    this.parent.set(drop, keep);
+    this.size.set(keep, sa + sb);
+    const existing = this.reason.get(keep) ?? this.reason.get(drop);
+    const winner =
+      reason === "email-match" || existing === "email-match" ? "email-match" : "name-company-match";
+    this.reason.set(keep, winner);
+  }
+}
+
+/**
+ * Cluster a set of cards into duplicate groups. Two cards are in the
+ * same group when they share at least one normalized email OR have
+ * identical (name, company) keys. Membership is transitive — if
+ * A↔B by email and B↔C by name+company, all three end up together.
+ *
+ *  - Soft-deleted cards are excluded.
+ *  - Singleton clusters (no actual duplicates) are NOT returned.
+ *  - Cards inside each group are sorted by createdAt asc so the oldest
+ *    record is the natural keep candidate.
+ */
+export function findDuplicateGroups(cards: readonly CardSummary[]): DuplicateGroup[] {
+  const live = cards.filter((c) => !c.deletedAt);
+  const uf = new UnionFind();
+  for (const card of live) uf.add(card.id);
+
+  // Index by signal — first card to claim a key sets the merge anchor.
+  const emailFirst = new Map<string, string>();
+  for (const card of live) {
+    for (const e of card.emails) {
+      const key = norm(e.value);
+      if (!key) continue;
+      const prior = emailFirst.get(key);
+      if (prior) uf.union(prior, card.id, "email-match");
+      else emailFirst.set(key, card.id);
+    }
+  }
+  const ncFirst = new Map<string, string>();
+  for (const card of live) {
+    const key = nameCompanyKey(card);
+    if (!key) continue;
+    const prior = ncFirst.get(key);
+    if (prior) uf.union(prior, card.id, "name-company-match");
+    else ncFirst.set(key, card.id);
+  }
+
+  // Bucket by root.
+  const byRoot = new Map<string, CardSummary[]>();
+  for (const card of live) {
+    const root = uf.find(card.id);
+    const bucket = byRoot.get(root) ?? [];
+    bucket.push(card);
+    byRoot.set(root, bucket);
+  }
+
+  const groups: DuplicateGroup[] = [];
+  for (const [root, bucket] of byRoot) {
+    if (bucket.length < 2) continue;
+    bucket.sort((a, b) => {
+      const ta = a.createdAt?.getTime() ?? 0;
+      const tb = b.createdAt?.getTime() ?? 0;
+      if (ta !== tb) return ta - tb;
+      return a.id.localeCompare(b.id);
+    });
+    groups.push({
+      id: root,
+      reason: uf.reason.get(root) ?? "name-company-match",
+      cards: bucket,
+    });
+  }
+
+  // Largest groups first; tiebreak on stable group id.
+  groups.sort((a, b) => b.cards.length - a.cards.length || a.id.localeCompare(b.id));
+  return groups;
+}


### PR DESCRIPTION
Closes #64

## Summary
- 商務匯入 vCard / LinkedIn / 多次 OCR 後常出現「同一個人有兩三張」。新 `/cards/duplicates` 路由把它們聚成可一鍵合併的組。
- Pure fn `findDuplicateGroups(cards)` 用 UnionFind 連通：同 email 或同 (name, company) → 同組；priority `email-match > name-company-match`；transitivity 自動成立（A↔B by email + B↔C by name+company ⇒ all three together）。
- DB 層 `mergeCardsForUser(uid, keepId, mergeIds)` 一個 batch 完成：union phones / emails / tags / social, append `【併入：…】` provenance 備註，max(lastContactedAt)，soft-delete 被合併卡，sync Typesense（upsert keep + delete merged）。Refuses cross-user / `keepId ∈ mergeIds`.
- Server Action `mergeCardsAction` (max 20 merges/call, Zod-validated)。
- `/cards` header 偵測到 ≥1 組重複時顯示 `N 組可合併` link。

## Files
- `src/lib/cards/duplicates.ts` (+139, new) + `__tests__/duplicates.test.ts` (10 UT)
- `src/db/cards.ts` `mergeCardsForUser` (+112)
- `src/db/__tests__/cards.sit.test.ts` 新增 7 SIT cases (union, provenance, lastContactedAt max, soft-delete, cross-user refusal, keepId-overlap refusal, empty noop)
- `src/app/(app)/cards/actions.ts` `mergeCardsAction` (+20)
- `src/app/(app)/cards/duplicates/{page.tsx,duplicates.module.css}` 新路由
- `src/components/cards/{MergeGroup.tsx,MergeGroup.module.css}` client component (radio-pick keep + 一鍵合併)
- `src/app/(app)/cards/page.tsx` + `cards.module.css` 加 duplicates link

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no new warnings (existing 4 unrelated)
- [x] `pnpm test` — 384 pass (10 new in duplicates.test.ts)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — `/cards/duplicates` registered
- [ ] CI `test:sit` — covers 7 new mergeCardsForUser cases (Java emulator unavailable locally)
- [ ] CI green → merge → deploy to mac mini PM2