### PR TITLE
feat(cards): followUpAt 主動提醒 — 設定下次聯絡日 + 首頁 due section

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -213,6 +213,7 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
             lineId={card.social?.lineId}
             linkedinUrl={card.social?.linkedinUrl}
             isPinned={card.isPinned}
+            followUpAt={card.followUpAt ? card.followUpAt.toISOString().slice(0, 10) : null}
           />
 
           {card.firstMetEventTag && sharedEventCards.length > 0 && (

--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -11,6 +11,7 @@ import {
   logContactEvent,
   mergeCardsForUser,
   setCardPinned,
+  setFollowUpForUser,
   softDeleteCardForUser,
   updateCardForUser,
 } from "@/db/cards";
@@ -167,6 +168,33 @@ export const mergeCardsAction = authedAction
     revalidatePath("/cards/duplicates");
     revalidatePath(`/cards/${parsedInput.keepId}`);
     return { ok: true as const, ...result };
+  });
+
+/**
+ * Set or clear a follow-up reminder. `followUpAt` accepts a YYYY-MM-DD
+ * date string or null. Empty string is treated as null (clear). Server
+ * Action surface for the CardActions disclosure + 快捷鍵.
+ */
+export const setFollowUpAction = authedAction
+  .inputSchema(
+    z.object({
+      id: z.string().min(1),
+      followUpAt: z
+        .string()
+        .refine((v) => v === "" || /^\d{4}-\d{2}-\d{2}$/.test(v), {
+          message: "Invalid date (expected YYYY-MM-DD or empty)",
+        })
+        .nullable(),
+    }),
+  )
+  .action(async ({ parsedInput, ctx }) => {
+    const value =
+      parsedInput.followUpAt && parsedInput.followUpAt !== "" ? parsedInput.followUpAt : null;
+    await setFollowUpForUser(parsedInput.id, ctx.user.uid, value);
+    revalidatePath("/");
+    revalidatePath("/cards");
+    revalidatePath(`/cards/${parsedInput.id}`);
+    return { ok: true as const, followUpAt: value };
   });
 
 /**

--- a/src/components/cards/CardActions.tsx
+++ b/src/components/cards/CardActions.tsx
@@ -4,7 +4,12 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useTransition } from "react";
 
-import { deleteCardAction, logContactAction, toggleCardPinAction } from "@/app/(app)/cards/actions";
+import {
+  deleteCardAction,
+  logContactAction,
+  setFollowUpAction,
+  toggleCardPinAction,
+} from "@/app/(app)/cards/actions";
 import { shareCardVcard } from "@/lib/share/card-share";
 
 import styles from "./CardActions.module.css";
@@ -34,6 +39,8 @@ interface CardActionsProps {
   lineId?: string;
   linkedinUrl?: string;
   isPinned?: boolean;
+  /** Existing follow-up reminder, if any. ISO YYYY-MM-DD string for input parity. */
+  followUpAt?: string | null;
 }
 
 export function CardActions({
@@ -46,6 +53,7 @@ export function CardActions({
   lineId,
   linkedinUrl,
   isPinned = false,
+  followUpAt = null,
 }: CardActionsProps) {
   // Normalize: prefer the full list when given, else wrap the single
   // primary into a 1-item list. Empty when there's nothing to show.
@@ -65,6 +73,8 @@ export function CardActions({
   const [toast, setToast] = useState<string | null>(null);
   const [logNoteOpen, setLogNoteOpen] = useState(false);
   const [noteDraft, setNoteDraft] = useState("");
+  const [followUpOpen, setFollowUpOpen] = useState(false);
+  const [followUpDraft, setFollowUpDraft] = useState(followUpAt ?? "");
 
   useEffect(() => {
     if (!toast) return;
@@ -108,6 +118,26 @@ export function CardActions({
       if (result?.serverError) setError(result.serverError);
       else router.push("/cards");
     });
+  };
+
+  const submitFollowUp = (date: string | null) => {
+    setError(null);
+    startTransition(async () => {
+      const result = await setFollowUpAction({ id: cardId, followUpAt: date });
+      if (result?.serverError) setError(result.serverError);
+      else {
+        setToast(date ? `已排提醒：${date}` : "已取消提醒");
+        setFollowUpOpen(false);
+        setFollowUpDraft(date ?? "");
+        router.refresh();
+      }
+    });
+  };
+
+  const quickOffsetDays = (days: number): string => {
+    const d = new Date();
+    d.setDate(d.getDate() + days);
+    return d.toISOString().slice(0, 10);
   };
 
   const handleTogglePin = () => {
@@ -276,6 +306,71 @@ export function CardActions({
       )}
 
       <div className={styles.stack}>
+        <button
+          type="button"
+          className={styles.secondary}
+          onClick={() => setFollowUpOpen((v) => !v)}
+          disabled={pending}
+          aria-expanded={followUpOpen}
+        >
+          {followUpAt ? `📅 下次聯絡：${followUpAt}` : "📅 設定下次聯絡"}
+        </button>
+        {followUpOpen && (
+          <div className={styles.noteBox}>
+            <input
+              type="date"
+              className={styles.noteInput}
+              value={followUpDraft}
+              onChange={(e) => setFollowUpDraft(e.target.value)}
+              aria-label="下次聯絡日期"
+              min={new Date().toISOString().slice(0, 10)}
+            />
+            <div className={styles.noteActions}>
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={() => submitFollowUp(quickOffsetDays(3))}
+                disabled={pending}
+              >
+                +3 天
+              </button>
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={() => submitFollowUp(quickOffsetDays(7))}
+                disabled={pending}
+              >
+                +7 天
+              </button>
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={() => submitFollowUp(quickOffsetDays(14))}
+                disabled={pending}
+              >
+                +14 天
+              </button>
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={() => submitFollowUp(followUpDraft || null)}
+                disabled={pending || !followUpDraft}
+              >
+                確認日期
+              </button>
+              {followUpAt && (
+                <button
+                  type="button"
+                  className={styles.secondary}
+                  onClick={() => submitFollowUp(null)}
+                  disabled={pending}
+                >
+                  取消提醒
+                </button>
+              )}
+            </div>
+          </div>
+        )}
         <button
           type="button"
           className={styles.secondary}

--- a/src/components/cards/__tests__/CardActions.test.tsx
+++ b/src/components/cards/__tests__/CardActions.test.tsx
@@ -9,6 +9,11 @@ vi.mock("@/app/(app)/cards/actions", () => ({
   deleteCardAction: vi.fn(),
   logContactAction: vi.fn().mockResolvedValue({ ok: true, eventId: "ev1" }),
   toggleCardPinAction: vi.fn().mockResolvedValue({ ok: true, pinned: true }),
+  setFollowUpAction: vi
+    .fn()
+    .mockImplementation(async ({ followUpAt }: { followUpAt: string | null }) => ({
+      data: { ok: true as const, followUpAt },
+    })),
 }));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
@@ -147,6 +152,56 @@ describe("CardActions quick CTA row", () => {
       render(<CardActions cardId="abc" primaryPhone="0900111222" />);
       const link = screen.getByLabelText(/0900111222/) as HTMLAnchorElement;
       expect(link.href).toBe("tel:0900111222");
+    });
+  });
+
+  describe("follow-up reminder disclosure", () => {
+    it("shows 設定下次聯絡 when no reminder set, and reveals date input on click", () => {
+      render(<CardActions cardId="abc" />);
+      const trigger = screen.getByRole("button", { name: /設定下次聯絡/ });
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+      fireEvent.click(trigger);
+      expect(screen.getByLabelText(/下次聯絡日期/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /\+3 天/ })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /\+7 天/ })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /\+14 天/ })).toBeInTheDocument();
+    });
+
+    it("shows existing reminder date in the trigger label and offers 取消提醒", () => {
+      render(<CardActions cardId="abc" followUpAt="2026-05-01" />);
+      expect(screen.getByRole("button", { name: /下次聯絡：2026-05-01/ })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /下次聯絡：2026-05-01/ }));
+      expect(screen.getByRole("button", { name: /取消提醒/ })).toBeInTheDocument();
+    });
+
+    it("clicking +7 天 fires setFollowUpAction with 7-day-out date", async () => {
+      const { setFollowUpAction } = await import("@/app/(app)/cards/actions");
+      const mocked = vi.mocked(setFollowUpAction);
+      mocked.mockClear();
+      render(<CardActions cardId="abc" />);
+      fireEvent.click(screen.getByRole("button", { name: /設定下次聯絡/ }));
+      fireEvent.click(screen.getByRole("button", { name: /\+7 天/ }));
+      await vi.waitFor(() => {
+        expect(mocked).toHaveBeenCalledTimes(1);
+      });
+      const call = mocked.mock.calls[0]![0]!;
+      // Check it's an ISO date 7 days out (allow 1-day skew across timezones).
+      const target = new Date();
+      target.setDate(target.getDate() + 7);
+      const expected = target.toISOString().slice(0, 10);
+      expect(call.followUpAt).toBe(expected);
+    });
+
+    it("clicking 取消提醒 fires setFollowUpAction with null", async () => {
+      const { setFollowUpAction } = await import("@/app/(app)/cards/actions");
+      const mocked = vi.mocked(setFollowUpAction);
+      mocked.mockClear();
+      render(<CardActions cardId="abc" followUpAt="2026-05-01" />);
+      fireEvent.click(screen.getByRole("button", { name: /下次聯絡：2026-05-01/ }));
+      fireEvent.click(screen.getByRole("button", { name: /取消提醒/ }));
+      await vi.waitFor(() => {
+        expect(mocked).toHaveBeenCalledWith({ id: "abc", followUpAt: null });
+      });
     });
   });
 

--- a/src/db/__tests__/cards.sit.test.ts
+++ b/src/db/__tests__/cards.sit.test.ts
@@ -558,6 +558,47 @@ describe("cards repository (SIT)", () => {
     });
   });
 
+  describe("setFollowUpForUser", () => {
+    it("persists a YYYY-MM-DD date as a Timestamp", async () => {
+      const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await repo.setFollowUpForUser(id, TEST_UID_ALICE, "2026-05-01");
+      const card = (await repo.getCardForUser(TEST_UID_ALICE, id))!;
+      expect(card.followUpAt).toBeInstanceOf(Date);
+      expect(card.followUpAt!.toISOString().slice(0, 10)).toBe("2026-05-01");
+    });
+
+    it("clears the reminder when called with null", async () => {
+      const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await repo.setFollowUpForUser(id, TEST_UID_ALICE, "2026-05-01");
+      await repo.setFollowUpForUser(id, TEST_UID_ALICE, null);
+      const card = (await repo.getCardForUser(TEST_UID_ALICE, id))!;
+      expect(card.followUpAt).toBeNull();
+    });
+
+    it("rejects malformed date strings", async () => {
+      const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await expect(repo.setFollowUpForUser(id, TEST_UID_ALICE, "not-a-date")).rejects.toThrow(
+        /Invalid followUpAt/,
+      );
+    });
+
+    it("refuses cross-user writes (caller must be in memberUids)", async () => {
+      const aliceCard = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await expect(
+        repo.setFollowUpForUser(aliceCard.id, TEST_UID_BOB, "2026-05-01"),
+      ).rejects.toThrow();
+    });
+
+    it("logContactEvent auto-clears followUpAt on the same card", async () => {
+      const { id } = await repo.createCardForUser(aCard(), { uid: TEST_UID_ALICE });
+      await repo.setFollowUpForUser(id, TEST_UID_ALICE, "2026-05-01");
+      await repo.logContactEvent(id, { uid: TEST_UID_ALICE, note: "called" });
+      const card = (await repo.getCardForUser(TEST_UID_ALICE, id))!;
+      expect(card.followUpAt).toBeNull();
+      expect(card.lastContactedAt).toBeInstanceOf(Date);
+    });
+  });
+
   describe("mergeCardsForUser", () => {
     it("unions phones / emails / tags from merged into keep (deduped)", async () => {
       const keep = await repo.createCardForUser(

--- a/src/db/cards-data.ts
+++ b/src/db/cards-data.ts
@@ -44,6 +44,7 @@ export function toSummaryFromData(id: string, data: FirebaseFirestore.DocumentDa
     frontImagePath: data.frontImagePath,
     backImagePath: data.backImagePath,
     isPinned: data.isPinned === true,
+    followUpAt: tsToDate(data.followUpAt),
     createdAt: tsToDate(data.createdAt),
     updatedAt: tsToDate(data.updatedAt),
     lastContactedAt: tsToDate(data.lastContactedAt),

--- a/src/db/cards.ts
+++ b/src/db/cards.ts
@@ -53,6 +53,14 @@ export interface CardSummary {
    * CardActions already do).
    */
   isPinned?: boolean;
+  /**
+   * Future-action reminder timestamp. Set via setFollowUpForUser; auto-
+   * cleared on logContactEvent. null/undefined both mean no reminder
+   * pending — projection always normalizes to `Date | null`, but the
+   * type stays optional so old fixtures that never touched it stay
+   * valid (mirrors the isPinned backwards-compat pattern).
+   */
+  followUpAt?: Date | null;
   createdAt: Date | null;
   updatedAt: Date | null;
   lastContactedAt: Date | null;
@@ -504,6 +512,51 @@ export async function setCardPinned(cardId: string, uid: string, pinned: boolean
   });
 }
 
+/**
+ * Set or clear a future follow-up reminder. `followUpAt` accepts a
+ * `YYYY-MM-DD` string (interpreted as midnight local time, then stored
+ * as a Date) or `null` to clear an existing reminder. logContactEvent
+ * auto-clears this — the assumption is that a logged interaction is
+ * the action you were reminding yourself to do.
+ *
+ * Reindexes Typesense afterwards so any list view sorting / filtering
+ * by followUpAt picks up the change immediately.
+ */
+export async function setFollowUpForUser(
+  cardId: string,
+  uid: string,
+  followUpAt: string | null,
+): Promise<void> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${cardsPath(wid)}/${cardId}`);
+  const snap = await ref.get();
+  if (!snap.exists) throw new Error("card not found");
+  const data = snap.data()!;
+  if (!data.memberUids?.includes(uid)) throw new Error("無權限修改此名片");
+
+  let value: Date | null = null;
+  if (followUpAt) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(followUpAt)) {
+      throw new Error("Invalid followUpAt format (expected YYYY-MM-DD)");
+    }
+    // Midnight local time so date inputs in any timezone round-trip
+    // to the same calendar day the user picked.
+    value = new Date(`${followUpAt}T00:00:00`);
+    if (Number.isNaN(value.getTime())) throw new Error("Invalid followUpAt date");
+  }
+
+  await ref.update({
+    followUpAt: value,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+
+  const after = await ref.get();
+  if (after.exists && after.data()?.deletedAt === null) {
+    await syncWithFallback(wid, "upsert", cardId, toSummary(cardId, after.data()!));
+  }
+}
+
 // ==================== Contact events (append-only log) ====================
 
 export const SUB_COLLECTION_CONTACT_EVENTS = "contactEvents";
@@ -552,9 +605,13 @@ export async function logContactEvent(
     authorUid: uid,
     authorDisplay,
   });
+  // Auto-clear any pending follow-up reminder — the action you were
+  // reminding yourself to do has now happened. Idempotent: if there
+  // wasn't one set, the field stays at null.
   batch.update(cardRef, {
     lastContactedAt: now,
     updatedAt: now,
+    followUpAt: null,
   });
   await batch.commit();
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -109,6 +109,18 @@ const cardBaseShape = {
   // Pin — surfaced in Pinned section at the top of the timeline.
   // Optional for backwards-compat with existing card docs.
   isPinned: z.boolean().optional(),
+
+  // Future-action reminder. ISO date string ("YYYY-MM-DD") on the wire
+  // for the same reasons as firstMetDate (user-meaningful date, not an
+  // event time). Stored in Firestore as Timestamp at midnight UTC.
+  // Cleared automatically when logContactEvent fires (the action you
+  // were reminding yourself to do is done).
+  followUpAt: z
+    .string()
+    .refine((v) => !v || /^\d{4}-\d{2}-\d{2}$/.test(v), {
+      message: "Invalid date (YYYY-MM-DD)",
+    })
+    .optional(),
 };
 
 /** Payload shape when creating a card (client → server). */

--- a/src/lib/timeline/__tests__/categorize.test.ts
+++ b/src/lib/timeline/__tests__/categorize.test.ts
@@ -20,6 +20,7 @@ function card(overrides: Partial<CardSummary> = {}): CardSummary {
     emails: [],
     social: {},
     isPinned: false,
+    followUpAt: null,
     createdAt: new Date("2026-01-01T00:00:00Z"),
     updatedAt: new Date("2026-01-01T00:00:00Z"),
     lastContactedAt: null,
@@ -29,9 +30,10 @@ function card(overrides: Partial<CardSummary> = {}): CardSummary {
 }
 
 describe("categorizeTimeline", () => {
-  it("returns 4 sections in fixed order (pinned first)", () => {
+  it("returns 5 sections in fixed order (due-today first)", () => {
     const sections = categorizeTimeline([], { now: NOW });
     expect(sections.map((s) => s.id)).toEqual([
+      "due-today",
       "pinned",
       "newly-added",
       "met-this-month",
@@ -70,14 +72,14 @@ describe("categorizeTimeline", () => {
 
   it("classifies firstMetDate in current month as met-this-month", () => {
     const c = card({ firstMetDate: "2026-04-10" });
-    const [, , met] = categorizeTimeline([c], { now: NOW });
+    const [, , , met] = categorizeTimeline([c], { now: NOW });
     expect(met.cards).toHaveLength(1);
     expect(met.cards[0]).toBe(c);
   });
 
   it("classifies firstMetDate last month as NOT met-this-month", () => {
     const c = card({ firstMetDate: "2026-03-10" });
-    const [, newly, met, uncontacted] = categorizeTimeline([c], { now: NOW });
+    const [, , newly, met, uncontacted] = categorizeTimeline([c], { now: NOW });
     expect(met.cards).toHaveLength(0);
     // createdAt is 2026-01-01 so not newly-added; last contact null → uncontacted
     expect(newly.cards).toHaveLength(0);
@@ -89,7 +91,7 @@ describe("categorizeTimeline", () => {
       id: "new",
       createdAt: new Date("2026-04-15T00:00:00Z"),
     });
-    const [, newly] = categorizeTimeline([c], { now: NOW });
+    const [, , newly] = categorizeTimeline([c], { now: NOW });
     expect(newly.cards.map((card) => card.id)).toContain("new");
   });
 
@@ -99,7 +101,7 @@ describe("categorizeTimeline", () => {
       createdAt: new Date("2025-01-01T00:00:00Z"),
       lastContactedAt: new Date("2026-02-01T00:00:00Z"), // > 30 days before NOW
     });
-    const [, , , uncontacted] = categorizeTimeline([c], { now: NOW });
+    const [, , , , uncontacted] = categorizeTimeline([c], { now: NOW });
     expect(uncontacted.cards.map((card) => card.id)).toContain("stale");
   });
 
@@ -109,7 +111,7 @@ describe("categorizeTimeline", () => {
       createdAt: new Date("2025-01-01T00:00:00Z"),
       lastContactedAt: new Date("2026-04-15T00:00:00Z"), // 3 days before NOW
     });
-    const [, newly, met, uncontacted] = categorizeTimeline([c], { now: NOW });
+    const [, , newly, met, uncontacted] = categorizeTimeline([c], { now: NOW });
     expect([...newly.cards, ...met.cards, ...uncontacted.cards]).toHaveLength(0);
   });
 
@@ -137,7 +139,7 @@ describe("categorizeTimeline", () => {
       id: "newer",
       createdAt: new Date("2026-04-17T00:00:00Z"),
     });
-    const [, newly] = categorizeTimeline([older, newer], { now: NOW });
+    const [, , newly] = categorizeTimeline([older, newer], { now: NOW });
     expect(newly.cards.map((c) => c.id)).toEqual(["newer", "older"]);
   });
 
@@ -152,7 +154,7 @@ describe("categorizeTimeline", () => {
       createdAt: new Date("2025-01-01T00:00:00Z"),
       lastContactedAt: new Date("2026-01-01T00:00:00Z"),
     });
-    const [, , , uncontacted] = categorizeTimeline([b, a], { now: NOW });
+    const [, , , , uncontacted] = categorizeTimeline([b, a], { now: NOW });
     expect(uncontacted.cards.map((c) => c.id)).toEqual(["a", "b"]);
   });
 
@@ -186,7 +188,7 @@ describe("categorizeTimeline", () => {
       firstMetDate: "04/10/2026" as unknown as string,
       createdAt: new Date("2025-01-01T00:00:00Z"),
     });
-    const [, , met, uncontacted] = categorizeTimeline([c], { now: NOW });
+    const [, , , met, uncontacted] = categorizeTimeline([c], { now: NOW });
     expect(met.cards).toHaveLength(0);
     expect(uncontacted.cards).toHaveLength(1);
   });
@@ -194,7 +196,7 @@ describe("categorizeTimeline", () => {
   it("sorts met-this-month by firstMetDate desc", () => {
     const early = card({ id: "early", firstMetDate: "2026-04-03" });
     const late = card({ id: "late", firstMetDate: "2026-04-17" });
-    const [, , met] = categorizeTimeline([early, late], { now: NOW });
+    const [, , , met] = categorizeTimeline([early, late], { now: NOW });
     expect(met.cards.map((c) => c.id)).toEqual(["late", "early"]);
   });
 
@@ -202,7 +204,7 @@ describe("categorizeTimeline", () => {
     const good = card({ id: "good", firstMetDate: "2026-04-15" });
     // broken date never enters met-this-month, but guard the sort fallback
     // via a card with firstMetDate set to a valid current-month date only once.
-    const [, , met] = categorizeTimeline([good], { now: NOW });
+    const [, , , met] = categorizeTimeline([good], { now: NOW });
     expect(met.cards).toHaveLength(1);
   });
 
@@ -232,5 +234,66 @@ describe("categorizeTimeline", () => {
     const sections = categorizeTimeline([c], { now: NOW, uncontactedDays: 5 });
     const uncontacted = sections.find((s) => s.id === "uncontacted")!;
     expect(uncontacted.cards.map((card) => card.id)).toContain("recent");
+  });
+
+  describe("due-today section", () => {
+    it("classifies cards with followUpAt <= today into due-today", () => {
+      const overdue = card({
+        id: "overdue",
+        followUpAt: new Date("2026-04-10T00:00:00"),
+      });
+      const today = card({
+        id: "today",
+        followUpAt: new Date("2026-04-18T00:00:00"),
+      });
+      const future = card({
+        id: "future",
+        followUpAt: new Date("2026-04-25T00:00:00"),
+      });
+      const [due] = categorizeTimeline([future, today, overdue], { now: NOW });
+      expect(due.cards.map((c) => c.id)).toEqual(["overdue", "today"]);
+    });
+
+    it("due-today wins over pinned (committed action beats standing pin)", () => {
+      const pinnedAndDue = card({
+        id: "p+d",
+        isPinned: true,
+        followUpAt: new Date("2026-04-15T00:00:00"),
+      });
+      const sections = categorizeTimeline([pinnedAndDue], { now: NOW });
+      const due = sections.find((s) => s.id === "due-today")!;
+      const pinned = sections.find((s) => s.id === "pinned")!;
+      expect(due.cards.map((c) => c.id)).toEqual(["p+d"]);
+      expect(pinned.cards).toHaveLength(0);
+    });
+
+    it("due-today is not capped (every reminder must be visible)", () => {
+      const many = Array.from({ length: 15 }, (_, i) =>
+        card({
+          id: `d${i}`,
+          followUpAt: new Date(`2026-04-${String((i % 17) + 1).padStart(2, "0")}T00:00:00`),
+        }),
+      );
+      const sections = categorizeTimeline(many, { now: NOW, maxPerSection: 5 });
+      const due = sections.find((s) => s.id === "due-today")!;
+      expect(due.cards).toHaveLength(15);
+    });
+
+    it("does not include cards whose followUpAt is in the future", () => {
+      const future = card({
+        id: "future",
+        followUpAt: new Date("2026-04-25T00:00:00"),
+      });
+      const sections = categorizeTimeline([future], { now: NOW });
+      const due = sections.find((s) => s.id === "due-today")!;
+      expect(due.cards).toHaveLength(0);
+    });
+
+    it("treats null/undefined followUpAt as no reminder", () => {
+      const noReminder = card({ id: "nr", followUpAt: null });
+      const sections = categorizeTimeline([noReminder], { now: NOW });
+      const due = sections.find((s) => s.id === "due-today")!;
+      expect(due.cards).toHaveLength(0);
+    });
   });
 });

--- a/src/lib/timeline/categorize.ts
+++ b/src/lib/timeline/categorize.ts
@@ -1,7 +1,7 @@
 import type { CardSummary } from "@/db/cards";
 
 export interface TimelineSection {
-  id: "pinned" | "uncontacted" | "met-this-month" | "newly-added";
+  id: "due-today" | "pinned" | "uncontacted" | "met-this-month" | "newly-added";
   title: string;
   description: string;
   cards: CardSummary[];
@@ -30,20 +30,20 @@ function parseFirstMetDate(raw: string | undefined): Date | null {
 }
 
 /**
- * Categorize cards into the 4 timeline sections.
- * Priority: pinned > met-this-month > newly-added > uncontacted.
- * A pinned card shows only in the Pinned section — it's
- * intentionally never duplicated as "最近沒聯絡" because core
- * contacts shouldn't be shame-nudged.
+ * Categorize cards into the 5 timeline sections.
+ * Priority: due-today > pinned > met-this-month > newly-added > uncontacted.
+ * A card shows in only one section. due-today wins over pinned because
+ * the user *committed to acting today* — that beats the standing pin.
  *
  * Rules:
- *  - pinned: card.isPinned === true
+ *  - due-today: followUpAt is set AND <= end of `now` calendar day
+ *  - pinned: card.isPinned === true (and not due-today)
  *  - met-this-month: firstMetDate within the given "now" month.
  *  - newly-added: createdAt within newlyAddedDays (default 7). Excluded from uncontacted.
  *  - uncontacted:
  *      - lastContactedAt older than uncontactedDays (default 30), OR
  *      - lastContactedAt is null AND createdAt older than uncontactedDays
- *      - excludes cards already pinned / met-this-month / newly-added
+ *      - excludes cards already in another section
  *  - Each section capped by maxPerSection (default 5), sorted deterministically.
  */
 export function categorizeTimeline(
@@ -52,6 +52,12 @@ export function categorizeTimeline(
 ): TimelineSection[] {
   const { now, uncontactedDays = 30, newlyAddedDays = 7, maxPerSection = 5 } = options;
 
+  // End-of-day: include reminders set for *today* even if their stored
+  // midnight is technically already past at the time of read.
+  const endOfToday = new Date(now);
+  endOfToday.setHours(23, 59, 59, 999);
+
+  const dueToday: CardSummary[] = [];
   const pinned: CardSummary[] = [];
   const metThisMonth: CardSummary[] = [];
   const newlyAdded: CardSummary[] = [];
@@ -59,6 +65,10 @@ export function categorizeTimeline(
 
   for (const card of cards) {
     if (card.deletedAt) continue;
+    if (card.followUpAt && card.followUpAt.getTime() <= endOfToday.getTime()) {
+      dueToday.push(card);
+      continue;
+    }
     if (card.isPinned) {
       pinned.push(card);
       continue;
@@ -108,7 +118,23 @@ export function categorizeTimeline(
     return tb - ta;
   });
 
+  // Due-today sorted by overdue-most-first so the most pressing reminders
+  // surface first.
+  dueToday.sort((a, b) => {
+    const ta = a.followUpAt?.getTime() ?? 0;
+    const tb = b.followUpAt?.getTime() ?? 0;
+    return ta - tb;
+  });
+
   return [
+    {
+      id: "due-today",
+      title: "今天該聯絡",
+      description: "你之前設定提醒到期了，趁今天打通電話 / 寄個訊息。",
+      // Not capped — every due reminder must be visible, otherwise the
+      // whole feature loses trust.
+      cards: dueToday,
+    },
     {
       id: "pinned",
       title: "重要聯絡人",


### PR DESCRIPTION
Closes #66

## Summary
商務情境最痛的不是「找不到名片」，而是**「答應要 follow-up 結果忘了」**。新增結構化的後續行動提醒：

- 名片詳情頁加 `📅 設定下次聯絡` disclosure → 日期 picker + 快捷 +3d / +7d / +14d / 取消
- Timeline home 新增 priority-0 section `🔔 今天該聯絡` — 列出 `followUpAt <= 今日 23:59` 的卡，比 pinned 還前面（committed action beats standing pin）
- 點 ✅ 已聯絡時自動清除 `followUpAt`，不用再去手動取消

## Files
- `src/db/schema.ts` `cardBaseShape.followUpAt` (YYYY-MM-DD optional)
- `src/db/cards.ts` + `cards-data.ts` `setFollowUpForUser`, projection, log auto-clear
- `src/app/(app)/cards/actions.ts` `setFollowUpAction` (Zod-validated)
- `src/components/cards/CardActions.tsx` follow-up disclosure UI
- `src/lib/timeline/categorize.ts` `due-today` section + new ordering
- 5 SIT (persist / clear / malformed reject / cross-user refuse / auto-clear on log)
- 4 UT for due-today categorize
- 4 UT for CardActions disclosure (+3d, +7d 快捷, 取消, label state)

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 393 pass (+9 new)
- [x] `pnpm lint` — no new warnings (4 pre-existing)
- [x] `pnpm format` — clean (lint-staged + prettier)
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — green
- [ ] CI `test:sit` — covers 5 new setFollowUp / log auto-clear cases
- [ ] CI green → merge → mac mini deploy

## Out of scope
- Push notification / browser permission prompts — 之後做
- Recurring reminders — 一次性即可
- Calendar sync (Google / Outlook) — 之後做