### PR TITLE
feat(companies): /companies hub — 同公司聯絡人聚合視角

### DIFF
--- a/src/app/(app)/cards/[id]/detail.module.css
+++ b/src/app/(app)/cards/[id]/detail.module.css
@@ -248,6 +248,26 @@
   text-decoration: underline;
 }
 
+.relatedCompany {
+  padding: var(--space-sm) 0;
+}
+
+.relatedCompanyLink {
+  display: inline-block;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-accent-ink);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--color-accent-ink);
+  padding-bottom: 0.1em;
+}
+
+.relatedCompanyLink:hover {
+  color: var(--color-ink);
+  border-bottom-style: solid;
+}
+
 .timestamps {
   display: flex;
   flex-direction: column;

--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -5,8 +5,14 @@ import { CardActions } from "@/components/cards/CardActions";
 import { ContactEventList } from "@/components/cards/ContactEventList";
 import { RelatedByEvent } from "@/components/cards/RelatedByEvent";
 import { TagSuggestionsBanner } from "@/components/tags/TagSuggestionsBanner";
-import { getCardForUser, getCardsBySharedEvent, listContactEventsForUser } from "@/db/cards";
+import {
+  getCardForUser,
+  getCardsBySharedEvent,
+  listCardsForUser,
+  listContactEventsForUser,
+} from "@/db/cards";
 import type { CardCreateInput } from "@/db/schema";
+import { companySlug, pickCanonicalCompany } from "@/lib/companies/group";
 import { readSession } from "@/lib/firebase/session";
 
 import styles from "./detail.module.css";
@@ -51,6 +57,27 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
   const secondary = card.nameZh && card.nameEn ? card.nameEn : null;
   const role = card.jobTitleZh || card.jobTitleEn;
   const company = card.companyZh || card.companyEn;
+
+  // Count siblings at the same company so we can offer a link to the
+  // /companies/[slug] hub. Wrapped in try/catch — a flaky list query
+  // should not 500 the whole detail page; the link just won't render.
+  let companySiblingCount = 0;
+  let companyHrefSlug: string | null = null;
+  const canonicalCompany = pickCanonicalCompany(card);
+  if (canonicalCompany) {
+    try {
+      const all = await listCardsForUser(user.uid, { limit: 500 });
+      const wantedKey = canonicalCompany.toLowerCase().trim();
+      companySiblingCount = all.filter((c) => {
+        if (c.id === card.id || c.deletedAt) return false;
+        const co = pickCanonicalCompany(c).toLowerCase().trim();
+        return co === wantedKey;
+      }).length;
+      if (companySiblingCount > 0) companyHrefSlug = companySlug(canonicalCompany);
+    } catch (err) {
+      console.error("[card detail] company-sibling count failed:", err);
+    }
+  }
   const primaryPhone = card.phones.find((p) => p.primary) ?? card.phones[0];
   const primaryEmail = card.emails.find((e) => e.primary) ?? card.emails[0];
 
@@ -218,6 +245,17 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
 
           {card.firstMetEventTag && sharedEventCards.length > 0 && (
             <RelatedByEvent eventTag={card.firstMetEventTag} cards={sharedEventCards} />
+          )}
+
+          {companyHrefSlug && companySiblingCount > 0 && (
+            <section className={styles.relatedCompany} aria-label="同公司聯絡人">
+              <Link
+                href={`/companies/${encodeURIComponent(companyHrefSlug)}`}
+                className={styles.relatedCompanyLink}
+              >
+                同公司還有 {companySiblingCount} 位 →
+              </Link>
+            </section>
           )}
 
           <footer className={styles.timestamps}>

--- a/src/app/(app)/companies/[slug]/company.module.css
+++ b/src/app/(app)/companies/[slug]/company.module.css
@@ -1,0 +1,151 @@
+.article {
+  max-width: var(--content-max);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.crumbs {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+}
+
+.crumbs a {
+  color: var(--color-ink-muted);
+  text-decoration: none;
+}
+
+.crumbs a:hover {
+  color: var(--color-ink);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding-bottom: var(--space-md);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h1);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+  color: var(--color-ink);
+}
+
+.lead {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  margin: var(--space-xs) 0 0;
+}
+
+.cardList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.cardRow {
+  display: flex;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+  align-items: flex-start;
+}
+
+.cardRow:hover {
+  border-color: var(--color-accent-ink);
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.cardMain {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25em;
+}
+
+.cardName {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-ink);
+  margin: 0;
+}
+
+.cardRole {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.why {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-ink);
+  margin: 0.25em 0 0;
+  line-height: var(--leading-relaxed);
+  max-width: 60ch;
+}
+
+.cardSide {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.2em;
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+  flex-shrink: 0;
+  min-width: 9rem;
+  text-align: right;
+}
+
+.pin,
+.followUp {
+  font-size: var(--text-caption);
+}
+
+.followUp {
+  color: var(--color-accent-ink);
+}
+
+.lastTouch {
+  font-family: var(--font-mono, var(--font-sans));
+}
+
+.contact {
+  font-family: var(--font-mono, var(--font-sans));
+  color: var(--color-ink);
+}

--- a/src/app/(app)/companies/[slug]/page.tsx
+++ b/src/app/(app)/companies/[slug]/page.tsx
@@ -1,0 +1,109 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { listCardsForUser } from "@/db/cards";
+import { findCompanyBySlug } from "@/lib/companies/group";
+import { readSession } from "@/lib/firebase/session";
+
+import styles from "./company.module.css";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+const SCAN_LIMIT = 500;
+
+export async function generateMetadata({ params }: PageProps) {
+  const { slug } = await params;
+  const decoded = decodeURIComponent(slug);
+  return { title: decoded || "公司" };
+}
+
+function cardName(card: { nameZh?: string; nameEn?: string }): string {
+  return card.nameZh || card.nameEn || "（未命名）";
+}
+
+function formatYmd(date: Date | null | undefined): string {
+  if (!date) return "—";
+  return date.toLocaleDateString("zh-Hant", { year: "numeric", month: "2-digit", day: "2-digit" });
+}
+
+export default async function CompanyDetailPage({ params }: PageProps) {
+  const user = await readSession();
+  if (!user) return null;
+  const { slug: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug);
+
+  const cards = await listCardsForUser(user.uid, {
+    limit: SCAN_LIMIT,
+    orderBy: "createdAt",
+    order: "desc",
+  });
+  const group = findCompanyBySlug(cards, slug);
+  if (!group) notFound();
+
+  const totalContacted = group.cards.filter((c) => c.lastContactedAt).length;
+  const sharedEvents = Array.from(
+    new Set(group.cards.map((c) => c.firstMetEventTag).filter(Boolean) as string[]),
+  );
+
+  return (
+    <article className={styles.article}>
+      <nav aria-label="Breadcrumbs" className={styles.crumbs}>
+        <Link href="/cards">名片冊</Link>
+        <span aria-hidden="true"> · </span>
+        <Link href="/companies">公司</Link>
+        <span aria-hidden="true"> · </span>
+        <span>{group.displayName}</span>
+      </nav>
+
+      <header className={styles.header}>
+        <p className={styles.kicker}>公司</p>
+        <h1 className={styles.title}>{group.displayName}</h1>
+        <p className={styles.lead}>
+          {group.cards.length} 位聯絡人 · {totalContacted} 位有互動紀錄
+          {sharedEvents.length > 0 && <> · 認識場合：{sharedEvents.join("、")}</>}
+        </p>
+      </header>
+
+      <ul className={styles.cardList}>
+        {group.cards.map((card) => {
+          const role = card.jobTitleZh || card.jobTitleEn;
+          const dept = card.department;
+          const phone = card.phones?.[0]?.value;
+          const email = card.emails?.[0]?.value;
+          return (
+            <li key={card.id}>
+              <Link href={`/cards/${card.id}`} className={styles.cardRow}>
+                <div className={styles.cardMain}>
+                  <h2 className={styles.cardName}>{cardName(card)}</h2>
+                  {(role || dept) && (
+                    <p className={styles.cardRole}>{[role, dept].filter(Boolean).join(" · ")}</p>
+                  )}
+                  {card.whyRemember && <p className={styles.why}>{card.whyRemember}</p>}
+                </div>
+                <div className={styles.cardSide}>
+                  {card.isPinned && (
+                    <span className={styles.pin} title="重要聯絡人">
+                      📍
+                    </span>
+                  )}
+                  {card.followUpAt && (
+                    <span className={styles.followUp} title="待聯絡">
+                      📅 {card.followUpAt.toISOString().slice(5, 10)}
+                    </span>
+                  )}
+                  <span className={styles.lastTouch}>
+                    上次互動：{formatYmd(card.lastContactedAt)}
+                  </span>
+                  {phone && <span className={styles.contact}>{phone}</span>}
+                  {email && <span className={styles.contact}>{email}</span>}
+                </div>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </article>
+  );
+}

--- a/src/app/(app)/companies/companies.module.css
+++ b/src/app/(app)/companies/companies.module.css
@@ -1,0 +1,153 @@
+.article {
+  max-width: var(--content-max);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.crumbs {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+}
+
+.crumbs a {
+  color: var(--color-ink-muted);
+  text-decoration: none;
+}
+
+.crumbs a:hover {
+  color: var(--color-ink);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding-bottom: var(--space-md);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h2);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+}
+
+.title em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-accent);
+}
+
+.lead {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  line-height: var(--leading-relaxed);
+  margin: var(--space-xs) 0 0;
+  max-width: 56ch;
+}
+
+.empty {
+  padding: var(--space-2xl) var(--space-md);
+  text-align: center;
+}
+
+.backLink {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  letter-spacing: var(--tracking-wide);
+  text-decoration: none;
+}
+
+.backLink:hover {
+  text-decoration: underline;
+}
+
+.companyList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.companyRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.companyRow:hover {
+  border-color: var(--color-accent-ink);
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.companyMain {
+  flex: 1;
+  min-width: 0;
+}
+
+.companyName {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-ink);
+}
+
+.companyMeta {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0.2em 0 0;
+}
+
+.headPreview {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  text-align: right;
+  gap: 0.15em;
+  min-width: 0;
+}
+
+.headName {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink);
+  font-weight: 500;
+}
+
+.headRole {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+}

--- a/src/app/(app)/companies/page.tsx
+++ b/src/app/(app)/companies/page.tsx
@@ -1,0 +1,96 @@
+import Link from "next/link";
+
+import { listCardsForUser } from "@/db/cards";
+import { groupCardsByCompany } from "@/lib/companies/group";
+import { readSession } from "@/lib/firebase/session";
+
+import styles from "./companies.module.css";
+
+export const metadata = {
+  title: "公司",
+};
+
+const SCAN_LIMIT = 500;
+
+function formatYmd(date: Date | null | undefined): string {
+  if (!date) return "—";
+  return date.toLocaleDateString("zh-Hant", { year: "numeric", month: "2-digit", day: "2-digit" });
+}
+
+function cardName(card: { nameZh?: string; nameEn?: string }): string {
+  return card.nameZh || card.nameEn || "（未命名）";
+}
+
+export default async function CompaniesPage() {
+  const user = await readSession();
+  if (!user) return null;
+
+  const cards = await listCardsForUser(user.uid, {
+    limit: SCAN_LIMIT,
+    orderBy: "createdAt",
+    order: "desc",
+  });
+  const groups = groupCardsByCompany(cards);
+
+  return (
+    <article className={styles.article}>
+      <nav aria-label="Breadcrumbs" className={styles.crumbs}>
+        <Link href="/cards">名片冊</Link>
+        <span aria-hidden="true"> · </span>
+        <span>公司</span>
+      </nav>
+
+      <header className={styles.header}>
+        <p className={styles.kicker}>公司視角</p>
+        <h1 className={styles.title}>
+          <em>{groups.length}</em> 家公司
+        </h1>
+        {groups.length > 0 ? (
+          <p className={styles.lead}>
+            按最近互動排序。點進去看同公司的所有人、彼此職位、互動歷史。
+          </p>
+        ) : (
+          <p className={styles.lead}>
+            還沒有名片標註公司資訊。建立名片時填入公司名稱，這裡會自動聚合。
+          </p>
+        )}
+      </header>
+
+      {groups.length === 0 ? (
+        <section className={styles.empty}>
+          <Link href="/cards/new" className={styles.backLink}>
+            建立第一張名片 →
+          </Link>
+        </section>
+      ) : (
+        <ul className={styles.companyList}>
+          {groups.map((group) => {
+            const head = group.cards[0];
+            const headRole = head?.jobTitleZh || head?.jobTitleEn;
+            return (
+              <li key={group.slug}>
+                <Link
+                  href={`/companies/${encodeURIComponent(group.slug)}`}
+                  className={styles.companyRow}
+                >
+                  <div className={styles.companyMain}>
+                    <h2 className={styles.companyName}>{group.displayName}</h2>
+                    <p className={styles.companyMeta}>
+                      {group.cards.length} 位 · 最近：{formatYmd(group.mostRecentTouch)}
+                    </p>
+                  </div>
+                  {head && (
+                    <div className={styles.headPreview}>
+                      <span className={styles.headName}>{cardName(head)}</span>
+                      {headRole && <span className={styles.headRole}>{headRole}</span>}
+                    </div>
+                  )}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </article>
+  );
+}

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -18,6 +18,7 @@ const PRIMARY: NavItem[] = [
   { href: "/followups", label: "追蹤", description: "誰該 ping 了" },
   { href: "/cards", label: "名片冊", description: "畫廊 · 清單" },
   { href: "/cards/new", label: "新增", description: "手動建立一張" },
+  { href: "/companies", label: "公司", description: "同公司聯絡人聚合" },
   { href: "/tags", label: "標籤", description: "分類 · 重新命名" },
   { href: "/import", label: "匯入", description: "vCard / CSV / LinkedIn" },
   { href: "/workspace/members", label: "成員", description: "邀請 · 權限" },

--- a/src/lib/companies/__tests__/group.test.ts
+++ b/src/lib/companies/__tests__/group.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import {
+  companySlug,
+  findCompanyBySlug,
+  groupCardsByCompany,
+  pickCanonicalCompany,
+} from "../group";
+
+function mk(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    social: {},
+    createdAt: new Date("2026-04-01T00:00:00Z"),
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe("pickCanonicalCompany", () => {
+  it("prefers companyZh over companyEn when both present", () => {
+    const c = mk({ companyZh: "智威科技", companyEn: "ACME" });
+    expect(pickCanonicalCompany(c)).toBe("智威科技");
+  });
+
+  it("falls back to companyEn when companyZh empty", () => {
+    expect(pickCanonicalCompany(mk({ companyEn: "ACME" }))).toBe("ACME");
+  });
+
+  it("returns empty string when neither set", () => {
+    expect(pickCanonicalCompany(mk())).toBe("");
+  });
+
+  it("trims whitespace", () => {
+    expect(pickCanonicalCompany(mk({ companyEn: "  ACME  " }))).toBe("ACME");
+  });
+});
+
+describe("companySlug", () => {
+  it("lowercases ASCII and collapses spaces to dashes", () => {
+    expect(companySlug("Acme Tech Inc")).toBe("acme-tech-inc");
+  });
+
+  it("strips punctuation but keeps CJK characters", () => {
+    expect(companySlug("智威科技 (台灣)")).toBe("智威科技-台灣");
+  });
+
+  it("collapses repeated dashes and trims edge dashes", () => {
+    expect(companySlug("Foo - Bar")).toBe("foo-bar");
+    expect(companySlug("--Hello--")).toBe("hello");
+  });
+
+  it("normalizes slashes", () => {
+    expect(companySlug("R&D / 設計部")).toBe("rd-設計部");
+  });
+});
+
+describe("groupCardsByCompany", () => {
+  it("clusters case/whitespace variants under one slug", () => {
+    const a = mk({ id: "a", companyEn: "ACME" });
+    const b = mk({ id: "b", companyEn: "acme " });
+    const c = mk({ id: "c", companyEn: "Acme" });
+    const groups = groupCardsByCompany([a, b, c]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].cards.map((x) => x.id).sort()).toEqual(["a", "b", "c"]);
+    expect(groups[0].slug).toBe("acme");
+  });
+
+  it("excludes cards with no company name", () => {
+    const noCo = mk({ id: "noCo" });
+    const withCo = mk({ id: "x", companyEn: "ACME" });
+    const groups = groupCardsByCompany([noCo, withCo]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].cards.map((x) => x.id)).toEqual(["x"]);
+  });
+
+  it("excludes soft-deleted cards", () => {
+    const live = mk({ id: "live", companyEn: "ACME" });
+    const gone = mk({ id: "gone", companyEn: "ACME", deletedAt: new Date() });
+    const groups = groupCardsByCompany([live, gone]);
+    expect(groups[0].cards.map((c) => c.id)).toEqual(["live"]);
+  });
+
+  it("sorts cards within group by lastContactedAt desc", () => {
+    const stale = mk({
+      id: "stale",
+      companyEn: "ACME",
+      lastContactedAt: new Date("2026-01-01"),
+    });
+    const fresh = mk({
+      id: "fresh",
+      companyEn: "ACME",
+      lastContactedAt: new Date("2026-04-01"),
+    });
+    const groups = groupCardsByCompany([stale, fresh]);
+    expect(groups[0].cards.map((c) => c.id)).toEqual(["fresh", "stale"]);
+  });
+
+  it("sorts groups by most-recent-touch desc", () => {
+    const oldCo = mk({
+      id: "old",
+      companyEn: "OldCorp",
+      lastContactedAt: new Date("2026-01-01"),
+    });
+    const freshCo = mk({
+      id: "fresh",
+      companyEn: "FreshCorp",
+      lastContactedAt: new Date("2026-04-01"),
+    });
+    const groups = groupCardsByCompany([oldCo, freshCo]);
+    expect(groups.map((g) => g.displayName)).toEqual(["FreshCorp", "OldCorp"]);
+  });
+
+  it("falls back to createdAt when no lastContactedAt", () => {
+    const a = mk({
+      id: "a",
+      companyEn: "A Co",
+      createdAt: new Date("2026-04-10"),
+      lastContactedAt: null,
+    });
+    const b = mk({
+      id: "b",
+      companyEn: "B Co",
+      createdAt: new Date("2026-04-01"),
+      lastContactedAt: null,
+    });
+    const groups = groupCardsByCompany([a, b]);
+    expect(groups.map((g) => g.displayName)).toEqual(["A Co", "B Co"]);
+  });
+
+  it("uses the first-seen variant as displayName", () => {
+    const first = mk({ id: "first", companyEn: "ACME Tech" });
+    const variant = mk({ id: "variant", companyEn: "acme tech" });
+    const groups = groupCardsByCompany([first, variant]);
+    expect(groups[0].displayName).toBe("ACME Tech");
+  });
+});
+
+describe("findCompanyBySlug", () => {
+  it("returns matching group case-insensitively", () => {
+    const a = mk({ id: "a", companyEn: "ACME" });
+    const found = findCompanyBySlug([a], "acme");
+    expect(found?.cards.map((c) => c.id)).toEqual(["a"]);
+  });
+
+  it("returns null when no group matches", () => {
+    expect(findCompanyBySlug([], "missing")).toBeNull();
+    expect(findCompanyBySlug([mk({ companyEn: "ACME" })], "other")).toBeNull();
+  });
+});

--- a/src/lib/companies/group.ts
+++ b/src/lib/companies/group.ts
@@ -1,0 +1,118 @@
+import type { CardSummary } from "@/db/cards";
+
+export interface CompanyGroup {
+  /** Stable URL slug derived from the canonical company name. */
+  slug: string;
+  /** Display name — first non-empty companyZh wins, else companyEn. */
+  displayName: string;
+  /**
+   * Cards in this company, ordered by last touch (lastContactedAt → createdAt) desc.
+   * The first card is the "primary contact" surfacer for /companies index.
+   */
+  cards: CardSummary[];
+  /** Most-recent activity for sorting at the index level. */
+  mostRecentTouch: Date | null;
+}
+
+/**
+ * Pick the canonical "company" string for grouping. Trims and prefers
+ * the Chinese name when both exist (consistent with how the rest of
+ * the UI prefers nameZh over nameEn).
+ */
+export function pickCanonicalCompany(card: CardSummary): string {
+  const zh = (card.companyZh ?? "").trim();
+  const en = (card.companyEn ?? "").trim();
+  return zh || en;
+}
+
+/**
+ * Stable lowercase + trimmed key used to coalesce variants like
+ * "ACME" / "acme " / "Acme" into one bucket.
+ */
+function companyKey(name: string): string {
+  return name.toLowerCase().trim();
+}
+
+/**
+ * URL-safe slug. We intentionally keep CJK characters (slugs in
+ * Next dynamic routes accept Unicode) so 「智威科技」 stays readable in
+ * the URL. ASCII whitespace and punctuation collapse to single dashes.
+ */
+export function companySlug(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[\s/]+/g, "-")
+    .replace(/[.,;:!?()[\]{}<>"'`*+&%$#@|\\]+/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Cluster cards by company. Cards with no company name are dropped
+ * (they're not "company contacts" — they live in /cards general view).
+ * Soft-deleted cards are excluded.
+ *
+ * Each group's cards are sorted by `lastContactedAt` desc with
+ * `createdAt` as tiebreak so the top of the list is "most relevant"
+ * — useful for both the /companies index card preview and the
+ * /companies/[slug] page.
+ */
+export function groupCardsByCompany(cards: readonly CardSummary[]): CompanyGroup[] {
+  const buckets = new Map<string, { displayName: string; cards: CardSummary[] }>();
+
+  for (const card of cards) {
+    if (card.deletedAt) continue;
+    const canonical = pickCanonicalCompany(card);
+    if (!canonical) continue;
+    const key = companyKey(canonical);
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.cards.push(card);
+    } else {
+      buckets.set(key, { displayName: canonical, cards: [card] });
+    }
+  }
+
+  const groups: CompanyGroup[] = [];
+  for (const bucket of buckets.values()) {
+    bucket.cards.sort((a, b) => {
+      const ta = a.lastContactedAt?.getTime() ?? a.createdAt?.getTime() ?? 0;
+      const tb = b.lastContactedAt?.getTime() ?? b.createdAt?.getTime() ?? 0;
+      return tb - ta;
+    });
+    const head = bucket.cards[0];
+    const mostRecentTouch = head?.lastContactedAt ?? head?.createdAt ?? null;
+    groups.push({
+      slug: companySlug(bucket.displayName),
+      displayName: bucket.displayName,
+      cards: bucket.cards,
+      mostRecentTouch,
+    });
+  }
+
+  // Most-recently-touched company first; tiebreak on slug for stability.
+  groups.sort((a, b) => {
+    const ta = a.mostRecentTouch?.getTime() ?? 0;
+    const tb = b.mostRecentTouch?.getTime() ?? 0;
+    if (ta !== tb) return tb - ta;
+    return a.slug.localeCompare(b.slug);
+  });
+  return groups;
+}
+
+/**
+ * Find a single company group by slug. Returns null if no live card
+ * matches. O(N) over the cards list — fine for the 200/500-card cap
+ * the rest of the app uses.
+ */
+export function findCompanyBySlug(
+  cards: readonly CardSummary[],
+  slug: string,
+): CompanyGroup | null {
+  const wanted = slug.toLowerCase();
+  for (const group of groupCardsByCompany(cards)) {
+    if (group.slug === wanted) return group;
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #68

## Summary
商務人士每天遇到「ACME 那邊我還見過誰？」既有 search 是平行卡列表，無法呈現「公司是核心 entity」的關係。新增公司視角：

- `/companies` — 索引頁列所有公司、卡數、最近互動、首位聯絡人
- `/companies/[slug]` — 同公司所有卡，含職位／為什麼記得／互動歷史／提醒
- 名片詳情頁加「同公司還有 N 位 →」入口
- AppShell nav 加 `公司` 項

## Files
- `src/lib/companies/group.ts` (+115) — `groupCardsByCompany` / `companySlug` / `findCompanyBySlug` / `pickCanonicalCompany`
- `src/lib/companies/__tests__/group.test.ts` — 17 UT
- `src/app/(app)/companies/{page,companies.module}.tsx/css` — index
- `src/app/(app)/companies/[slug]/{page,company.module}.tsx/css` — detail
- `src/app/(app)/cards/[id]/page.tsx` + detail.module.css — sibling count + link
- `src/components/shell/AppShell.tsx` — nav entry

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 410 pass (+17 new)
- [x] `pnpm lint` — clean (4 unrelated pre-existing)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — `/companies` and `/companies/[slug]` registered
- [ ] CI green → merge → mac mini deploy

## Out of scope
- Company logo / fact card (要外接 API)
- Company-level CRM 欄位 (industry / size) — 從名片 derive 即可