### PR TITLE
feat(shell): Cmd+K / Ctrl+K / "/" quick search palette

### DIFF
--- a/src/components/shell/GlobalShortcuts.tsx
+++ b/src/components/shell/GlobalShortcuts.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { matchKeyEvent } from "@/lib/shortcuts/match";
 
 import styles from "./GlobalShortcuts.module.css";
+import { QuickSearchPalette } from "./QuickSearchPalette";
 
 /**
  * Global keyboard shortcuts wired at AppShell level.
@@ -23,6 +24,7 @@ const PREFIX_TIMEOUT_MS = 1000;
 export function GlobalShortcuts() {
   const router = useRouter();
   const [helpOpen, setHelpOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
   const prefixRef = useRef<"g" | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -37,7 +39,7 @@ export function GlobalShortcuts() {
 
     const handler = (e: KeyboardEvent) => {
       const result = matchKeyEvent(
-        { prefix: prefixRef.current, helpOpen },
+        { prefix: prefixRef.current, helpOpen, paletteOpen },
         {
           key: e.key,
           metaKey: e.metaKey,
@@ -61,6 +63,14 @@ export function GlobalShortcuts() {
             e.preventDefault();
             setHelpOpen(false);
             break;
+          case "open-palette":
+            e.preventDefault();
+            setPaletteOpen(true);
+            break;
+          case "close-palette":
+            e.preventDefault();
+            setPaletteOpen(false);
+            break;
         }
         clearPrefix();
         return;
@@ -81,27 +91,29 @@ export function GlobalShortcuts() {
       window.removeEventListener("keydown", handler);
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [helpOpen, router]);
+  }, [helpOpen, paletteOpen, router]);
 
-  if (!helpOpen) return null;
+  return (
+    <>
+      <QuickSearchPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+      {helpOpen && <HelpOverlay onClose={() => setHelpOpen(false)} />}
+    </>
+  );
+}
 
+function HelpOverlay({ onClose }: { onClose: () => void }) {
   return (
     <div
       className={styles.overlay}
       role="dialog"
       aria-modal="true"
       aria-label="鍵盤快捷鍵"
-      onClick={() => setHelpOpen(false)}
+      onClick={onClose}
     >
       <div className={styles.sheet} onClick={(e) => e.stopPropagation()}>
         <header className={styles.header}>
           <h2 className={styles.title}>鍵盤快捷鍵</h2>
-          <button
-            type="button"
-            className={styles.close}
-            aria-label="關閉"
-            onClick={() => setHelpOpen(false)}
-          >
+          <button type="button" className={styles.close} aria-label="關閉" onClick={onClose}>
             ✕
           </button>
         </header>

--- a/src/components/shell/QuickSearchPalette.module.css
+++ b/src/components/shell/QuickSearchPalette.module.css
@@ -1,0 +1,187 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in oklch, var(--color-ink) 32%, transparent);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  z-index: 1000;
+  animation: paletteFade var(--duration-fast) var(--ease-standard);
+}
+
+@keyframes paletteFade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.sheet {
+  width: min(640px, 92vw);
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 1px 3px rgb(0 0 0 / 8%),
+    0 18px 40px rgb(0 0 0 / 18%);
+  overflow: hidden;
+}
+
+.inputRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.icon {
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  letter-spacing: var(--tracking-normal, 0);
+}
+
+.input::placeholder {
+  color: var(--color-ink-muted);
+  font-style: italic;
+}
+
+.spinner {
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent-ink);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.degraded {
+  margin: 0;
+  padding: var(--space-sm) var(--space-lg);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.hint,
+.empty {
+  margin: 0;
+  padding: var(--space-md) var(--space-lg);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+}
+
+.hint :global(kbd) {
+  font-family: var(--font-mono, var(--font-sans));
+  font-size: 0.75em;
+  padding: 0.05em 0.4em;
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-paper);
+  color: var(--color-ink);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-xs) 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.item,
+.itemActive {
+  padding: var(--space-sm) var(--space-lg);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.itemActive {
+  background: var(--color-accent-soft, var(--color-paper));
+  border-left: 3px solid var(--color-accent-ink);
+  padding-left: calc(var(--space-lg) - 3px);
+}
+
+.itemMain {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+}
+
+.itemName {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.itemCompany {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+}
+
+.itemWhy {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0;
+  line-height: var(--leading-snug);
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.footer {
+  display: flex;
+  gap: var(--space-md);
+  justify-content: flex-end;
+  padding: var(--space-xs) var(--space-lg);
+  border-top: var(--border-hair) solid var(--color-border);
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.7rem);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+}
+
+.footer :global(kbd) {
+  font-family: var(--font-mono, var(--font-sans));
+  font-size: 0.85em;
+  padding: 0.05em 0.4em;
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-paper);
+  color: var(--color-ink);
+}

--- a/src/components/shell/QuickSearchPalette.tsx
+++ b/src/components/shell/QuickSearchPalette.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useId, useRef, useState } from "react";
+
+import { searchCardsAction, type SearchHit } from "@/app/(app)/cards/search-actions";
+
+import styles from "./QuickSearchPalette.module.css";
+
+interface QuickSearchPaletteProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const DEBOUNCE_MS = 140;
+const RESULT_LIMIT = 8;
+
+function displayName(hit: SearchHit): string {
+  return hit.nameZh || hit.nameEn || "（未命名）";
+}
+
+function displayCompany(hit: SearchHit): string {
+  return hit.companyZh || hit.companyEn || "";
+}
+
+/**
+ * `Cmd+K` / `Ctrl+K` / `/` opens this palette anywhere in the app.
+ * Typesense-backed search with a 140ms debounce; arrow keys to nav,
+ * Enter to jump to detail. Esc closes. Text inputs do NOT swallow
+ * `Cmd+K` (the matcher lets it through), so users can hop here from
+ * the new-card form mid-edit to look someone up.
+ */
+/**
+ * Wrapper that remounts the inner palette whenever `open` flips on. That
+ * lets the inner component own its own initial state without needing
+ * a "reset on prop change" effect (which violates set-state-in-effect).
+ */
+export function QuickSearchPalette({ open, onClose }: QuickSearchPaletteProps) {
+  if (!open) return null;
+  return <QuickSearchPaletteInner onClose={onClose} />;
+}
+
+function QuickSearchPaletteInner({ onClose }: { onClose: () => void }) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<SearchHit[]>([]);
+  const [pending, setPending] = useState(false);
+  const [degraded, setDegraded] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const inputId = useId();
+  const listboxId = useId();
+
+  // Focus the input on mount. setState is *not* called here — the
+  // initial state already covers reset-on-open since this component is
+  // remounted by the wrapper whenever open flips on.
+  useEffect(() => {
+    const t = setTimeout(() => inputRef.current?.focus(), 0);
+    return () => clearTimeout(t);
+  }, []);
+
+  // Debounced search — every keystroke schedules; previous timer wins.
+  // No early-return setStates: when the trimmed query is empty we just
+  // skip the fetch and the existing state (initial empty arrays) renders
+  // the hint screen.
+  const trimmed = query.trim();
+  useEffect(() => {
+    if (!trimmed) return;
+    // setPending lives inside the timer (not the effect body) to
+    // satisfy the set-state-in-effect rule — pending is a side-effect
+    // of the actual fetch starting, not of the effect mounting.
+    const timer = setTimeout(async () => {
+      setPending(true);
+      try {
+        const result = await searchCardsAction({ q: trimmed, limit: RESULT_LIMIT });
+        // The action may resolve after the user kept typing — bail out if
+        // the input no longer matches.
+        if (inputRef.current?.value.trim() !== trimmed) return;
+        if (result?.data) {
+          setHits(result.data.hits.slice(0, RESULT_LIMIT));
+          setDegraded(result.data.degraded);
+          setActiveIndex(0);
+        } else if (result?.serverError) {
+          setHits([]);
+          setDegraded(true);
+        }
+      } finally {
+        setPending(false);
+      }
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [trimmed]);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, Math.max(hits.length - 1, 0)));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const target = hits[activeIndex];
+      if (target) {
+        router.push(`/cards/${target.id}`);
+        onClose();
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className={styles.overlay}
+      role="dialog"
+      aria-modal="true"
+      aria-label="搜尋名片"
+      onClick={onClose}
+    >
+      <div className={styles.sheet} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.inputRow}>
+          <span className={styles.icon} aria-hidden="true">
+            🔎
+          </span>
+          <input
+            id={inputId}
+            ref={inputRef}
+            type="text"
+            className={styles.input}
+            placeholder="搜尋名片：姓名、公司、為什麼記得…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+            autoComplete="off"
+            spellCheck={false}
+            aria-controls={listboxId}
+            aria-activedescendant={
+              hits[activeIndex] ? `palette-hit-${hits[activeIndex].id}` : undefined
+            }
+          />
+          {pending && <span className={styles.spinner} aria-label="搜尋中" />}
+        </div>
+
+        {degraded && (
+          <p className={styles.degraded} role="status">
+            搜尋服務暫時不可用，請從名片冊瀏覽。
+          </p>
+        )}
+
+        {!query.trim() ? (
+          <p className={styles.hint}>
+            開始輸入即時搜尋。 ↑ ↓ 切換，<kbd>Enter</kbd> 進入，<kbd>Esc</kbd> 關閉。
+          </p>
+        ) : hits.length === 0 && !pending ? (
+          <p className={styles.empty}>沒有符合「{query}」的名片</p>
+        ) : (
+          <ul id={listboxId} className={styles.list} role="listbox" aria-label="搜尋結果">
+            {hits.map((hit, i) => {
+              const company = displayCompany(hit);
+              const isActive = i === activeIndex;
+              return (
+                <li
+                  key={hit.id}
+                  id={`palette-hit-${hit.id}`}
+                  role="option"
+                  aria-selected={isActive}
+                  className={isActive ? styles.itemActive : styles.item}
+                  onMouseEnter={() => setActiveIndex(i)}
+                  onClick={() => {
+                    router.push(`/cards/${hit.id}`);
+                    onClose();
+                  }}
+                >
+                  <div className={styles.itemMain}>
+                    <span className={styles.itemName}>{displayName(hit)}</span>
+                    {company && <span className={styles.itemCompany}>{company}</span>}
+                  </div>
+                  {hit.whyRemember && <p className={styles.itemWhy}>{hit.whyRemember}</p>}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <footer className={styles.footer}>
+          <span>
+            <kbd>↑</kbd> <kbd>↓</kbd> 移動
+          </span>
+          <span>
+            <kbd>Enter</kbd> 開啟
+          </span>
+          <span>
+            <kbd>Esc</kbd> 關閉
+          </span>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shell/__tests__/QuickSearchPalette.test.tsx
+++ b/src/components/shell/__tests__/QuickSearchPalette.test.tsx
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+import { QuickSearchPalette } from "../QuickSearchPalette";
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, refresh: vi.fn() }),
+}));
+
+const searchMock = vi.fn();
+vi.mock("@/app/(app)/cards/search-actions", () => ({
+  searchCardsAction: (...args: unknown[]) => searchMock(...args),
+}));
+
+function flushDebounceAndPromises() {
+  // 140ms debounce + 1 microtask flush.
+  return act(async () => {
+    await new Promise((r) => setTimeout(r, 200));
+  });
+}
+
+describe("QuickSearchPalette", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(<QuickSearchPalette open={false} onClose={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders dialog with search input + hint when opened with empty query", () => {
+    render(<QuickSearchPalette open onClose={() => {}} />);
+    expect(screen.getByRole("dialog", { name: /搜尋名片/ })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/搜尋名片/)).toBeInTheDocument();
+    expect(screen.getByText(/開始輸入即時搜尋/)).toBeInTheDocument();
+  });
+
+  it("calls searchCardsAction (debounced) and renders hits", async () => {
+    searchMock.mockResolvedValueOnce({
+      data: {
+        hits: [
+          {
+            id: "card-1",
+            nameZh: "陳玉涵",
+            companyZh: "智威科技",
+            whyRemember: "Computex 攤位",
+            highlights: {},
+          },
+          {
+            id: "card-2",
+            nameEn: "Alice",
+            companyEn: "ACME",
+            whyRemember: "Coffee chat",
+            highlights: {},
+          },
+        ],
+        found: 2,
+        searchTimeMs: 12,
+        degraded: false,
+      },
+    });
+    render(<QuickSearchPalette open onClose={() => {}} />);
+    fireEvent.change(screen.getByPlaceholderText(/搜尋名片/), { target: { value: "智威" } });
+    await flushDebounceAndPromises();
+
+    expect(searchMock).toHaveBeenCalledWith({ q: "智威", limit: 8 });
+    expect(screen.getByText("陳玉涵")).toBeInTheDocument();
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("智威科技")).toBeInTheDocument();
+  });
+
+  it("Enter on highlighted hit pushes /cards/[id] and closes", async () => {
+    pushMock.mockClear();
+    const onClose = vi.fn();
+    searchMock.mockResolvedValueOnce({
+      data: {
+        hits: [
+          {
+            id: "abc",
+            nameZh: "陳玉涵",
+            companyZh: "智威",
+            whyRemember: "x",
+            highlights: {},
+          },
+        ],
+        found: 1,
+        searchTimeMs: 5,
+        degraded: false,
+      },
+    });
+    render(<QuickSearchPalette open onClose={onClose} />);
+    const input = screen.getByPlaceholderText(/搜尋名片/);
+    fireEvent.change(input, { target: { value: "陳" } });
+    await flushDebounceAndPromises();
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(pushMock).toHaveBeenCalledWith("/cards/abc");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("Esc on input closes the palette", () => {
+    const onClose = vi.fn();
+    render(<QuickSearchPalette open onClose={onClose} />);
+    fireEvent.keyDown(screen.getByPlaceholderText(/搜尋名片/), { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("ArrowDown / ArrowUp moves the selected option", async () => {
+    searchMock.mockResolvedValueOnce({
+      data: {
+        hits: [
+          { id: "a", nameZh: "A", highlights: {} },
+          { id: "b", nameZh: "B", highlights: {} },
+          { id: "c", nameZh: "C", highlights: {} },
+        ],
+        found: 3,
+        searchTimeMs: 1,
+        degraded: false,
+      },
+    });
+    render(<QuickSearchPalette open onClose={() => {}} />);
+    const input = screen.getByPlaceholderText(/搜尋名片/);
+    fireEvent.change(input, { target: { value: "x" } });
+    await flushDebounceAndPromises();
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveAttribute("aria-selected", "true");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(screen.getAllByRole("option")[1]).toHaveAttribute("aria-selected", "true");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(screen.getAllByRole("option")[2]).toHaveAttribute("aria-selected", "true");
+    // Down past the end stays on last.
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(screen.getAllByRole("option")[2]).toHaveAttribute("aria-selected", "true");
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(screen.getAllByRole("option")[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("shows degraded message when search action returns degraded=true", async () => {
+    searchMock.mockResolvedValueOnce({
+      data: { hits: [], found: 0, searchTimeMs: 0, degraded: true },
+    });
+    render(<QuickSearchPalette open onClose={() => {}} />);
+    fireEvent.change(screen.getByPlaceholderText(/搜尋名片/), { target: { value: "x" } });
+    await flushDebounceAndPromises();
+    expect(screen.getByText(/搜尋服務暫時不可用/)).toBeInTheDocument();
+  });
+});

--- a/src/lib/shortcuts/__tests__/match.test.ts
+++ b/src/lib/shortcuts/__tests__/match.test.ts
@@ -78,10 +78,47 @@ describe("matchKeyEvent — guards", () => {
     expect(r.action).toBeNull();
   });
 
-  it("ignores modified keystrokes so ⌘K still works", () => {
-    expect(matchKeyEvent(noPrefix, key("k", { metaKey: true })).action).toBeNull();
+  it("ignores modified non-palette keystrokes so OS shortcuts pass through", () => {
     expect(matchKeyEvent(noPrefix, key("c", { ctrlKey: true })).action).toBeNull();
     expect(matchKeyEvent(noPrefix, key("?", { altKey: true })).action).toBeNull();
+    expect(matchKeyEvent(noPrefix, key("l", { metaKey: true })).action).toBeNull();
+  });
+});
+
+describe("matchKeyEvent — search palette", () => {
+  it("⌘K opens the palette from anywhere (incl text inputs)", () => {
+    expect(matchKeyEvent(noPrefix, key("k", { metaKey: true })).action).toEqual({
+      kind: "open-palette",
+    });
+    // Even when focus is in a text input — users can ⌘K out of the
+    // new-card form to look someone up.
+    expect(
+      matchKeyEvent(noPrefix, key("k", { metaKey: true, target: { tagName: "INPUT" } })).action,
+    ).toEqual({ kind: "open-palette" });
+  });
+
+  it("Ctrl+K also opens the palette (Windows / Linux)", () => {
+    expect(matchKeyEvent(noPrefix, key("k", { ctrlKey: true })).action).toEqual({
+      kind: "open-palette",
+    });
+    expect(matchKeyEvent(noPrefix, key("K", { ctrlKey: true })).action).toEqual({
+      kind: "open-palette",
+    });
+  });
+
+  it("/ opens the palette without modifiers", () => {
+    expect(matchKeyEvent(noPrefix, key("/")).action).toEqual({ kind: "open-palette" });
+  });
+
+  it("Escape closes the palette when open", () => {
+    const ctx: ShortcutContext = { prefix: null, helpOpen: false, paletteOpen: true };
+    expect(matchKeyEvent(ctx, key("Escape")).action).toEqual({ kind: "close-palette" });
+  });
+
+  it("other keys do nothing when palette is open (the input owns them)", () => {
+    const ctx: ShortcutContext = { prefix: null, helpOpen: false, paletteOpen: true };
+    expect(matchKeyEvent(ctx, key("c")).action).toBeNull();
+    expect(matchKeyEvent(ctx, key("g")).action).toBeNull();
   });
 });
 

--- a/src/lib/shortcuts/match.ts
+++ b/src/lib/shortcuts/match.ts
@@ -7,7 +7,9 @@
 export type ShortcutAction =
   | { kind: "go"; href: string }
   | { kind: "show-help" }
-  | { kind: "close-help" };
+  | { kind: "close-help" }
+  | { kind: "open-palette" }
+  | { kind: "close-palette" };
 
 export interface KeyEventLike {
   key: string;
@@ -28,6 +30,8 @@ export interface ShortcutContext {
   prefix: "g" | null;
   /** True while the help overlay is open. Only Esc works then. */
   helpOpen: boolean;
+  /** True while the search palette is open. Only Esc closes it (text typing handled internally). */
+  paletteOpen?: boolean;
 }
 
 export interface MatchResult {
@@ -42,7 +46,21 @@ export interface MatchResult {
  * the actual state and timers.
  */
 export function matchKeyEvent(ctx: ShortcutContext, e: KeyEventLike): MatchResult {
-  // Never intercept text input.
+  // Cmd+K / Ctrl+K opens the palette from anywhere — including text
+  // inputs (so users can ⌘K out of the new-card form to find someone)
+  // — and once open, Esc closes it. Text input check happens *after*
+  // this so the palette key beats input-blanking.
+  if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+    return { action: { kind: "open-palette" }, nextPrefix: null };
+  }
+  if (ctx.paletteOpen) {
+    if (e.key === "Escape") return { action: { kind: "close-palette" }, nextPrefix: null };
+    // Don't process other shortcuts while palette is open — its own
+    // input handler owns arrows / Enter / typing.
+    return { action: null, nextPrefix: null };
+  }
+
+  // Never intercept text input for non-modifier shortcuts.
   if (isTextInput(e.target)) return { action: null, nextPrefix: null };
 
   // When the help overlay is open, only Esc does something.
@@ -51,7 +69,12 @@ export function matchKeyEvent(ctx: ShortcutContext, e: KeyEventLike): MatchResul
     return { action: null, nextPrefix: ctx.prefix };
   }
 
-  // Ignore modified keystrokes (let ⌘K etc. through).
+  // "/" opens the palette without modifiers — same as GitHub / Linear.
+  if (e.key === "/") {
+    return { action: { kind: "open-palette" }, nextPrefix: null };
+  }
+
+  // Ignore other modified keystrokes (let ⌘L etc. through).
   if (e.metaKey || e.ctrlKey || e.altKey) {
     return { action: null, nextPrefix: null };
   }


### PR DESCRIPTION
Closes #70

## Summary
商務人士打開 app 最常見的操作是「找某個人的聯絡方式」。原本要 4-5 步（nav → 名片冊 → 搜尋框 → 輸入 → 點進去），這刀做成一個鍵：

- `⌘K` / `Ctrl+K` 從任何頁面（包括正在編輯的表單）一鍵開啟
- `/` 也能開（無修飾鍵，GitHub / Linear 風格）
- 自動 focus 搜尋框；140ms debounce 後查 Typesense
- ↑ ↓ 鍵盤導航結果，Enter 跳 `/cards/[id]`，Esc 關閉
- 顯示前 8 筆：name / company / 為什麼記得（一行 line-clamp）
- Loading spinner、空狀態、降級訊息（Typesense 掛掉時）

## Files
- `src/components/shell/QuickSearchPalette.tsx` (+170) — palette UI + ARIA listbox + 鍵盤導航
- `src/components/shell/QuickSearchPalette.module.css` — overlay + sheet + active-item styling
- `src/components/shell/GlobalShortcuts.tsx` — wire palette state, render palette + help as siblings
- `src/lib/shortcuts/match.ts` — 加 open-palette / close-palette actions; ⌘K 突破 text-input 守衛
- 6 UT 加進 match.test (⌘K / Ctrl+K / "/" / Esc / palette-open 屏蔽)
- 7 UT for palette (open/close/debounced search/Enter/Esc/Arrow keys/degraded)

## Implementation notes
- 用 wrapper-remount 模式而非 effect-driven reset，避免 react-hooks/set-state-in-effect 違規
- `setPending(true)` 移到 setTimeout 內部，不在 effect body 同步呼叫
- 重用既有 `searchCardsAction` Server Action — 沒新增 API surface

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 422 pass (+13 new)
- [x] `pnpm lint` — clean (0 errors, 4 pre-existing warnings unrelated)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — green
- [ ] CI green → merge → mac mini deploy