### PR TITLE
feat(timeline): 一年前的今天 anniversary reminder — firstMetDate 週年提醒

### DIFF
--- a/src/app/(app)/cards/[id]/detail.module.css
+++ b/src/app/(app)/cards/[id]/detail.module.css
@@ -248,6 +248,19 @@
   text-decoration: underline;
 }
 
+.anniversary {
+  display: inline-block;
+  margin-top: var(--space-sm);
+  padding: 0.2em 0.7em;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-accent-ink);
+  background: var(--color-accent-soft, transparent);
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: 999px;
+}
+
 .relatedCompany {
   padding: var(--space-sm) 0;
 }

--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/db/cards";
 import type { CardCreateInput } from "@/db/schema";
 import { companySlug, pickCanonicalCompany } from "@/lib/companies/group";
+import { findAnniversariesToday } from "@/lib/timeline/anniversaries";
 import { readSession } from "@/lib/firebase/session";
 
 import styles from "./detail.module.css";
@@ -57,6 +58,15 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
   const secondary = card.nameZh && card.nameEn ? card.nameEn : null;
   const role = card.jobTitleZh || card.jobTitleEn;
   const company = card.companyZh || card.companyEn;
+
+  // Anniversary chip — surfaces "認識 N 週年" only when today is the
+  // anniversary of firstMetDate. Reuses the same pure fn the timeline
+  // section uses, so the chip and the home-screen surface are always
+  // consistent.
+  const anniversaryEntry = findAnniversariesToday([card], new Date()).find(
+    (e) => e.card.id === card.id,
+  );
+  const anniversaryYears = anniversaryEntry?.years ?? null;
 
   // Count siblings at the same company so we can offer a link to the
   // /companies/[slug] hub. Wrapped in try/catch — a flaky list query
@@ -137,6 +147,11 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
                 {role && <span>{role}</span>}
                 {role && company && <em className={styles.sep}>於</em>}
                 {company && <strong>{company}</strong>}
+              </p>
+            )}
+            {anniversaryYears !== null && (
+              <p className={styles.anniversary} role="status">
+                🎉 {anniversaryYears} 年前的今天認識
               </p>
             )}
           </header>

--- a/src/lib/timeline/__tests__/anniversaries.test.ts
+++ b/src/lib/timeline/__tests__/anniversaries.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import { findAnniversariesToday } from "../anniversaries";
+
+function mk(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    social: {},
+    createdAt: new Date("2026-04-01T00:00:00Z"),
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+const NOW = new Date("2026-04-25T10:00:00");
+
+describe("findAnniversariesToday", () => {
+  it("returns cards whose firstMetDate matches today's month + day in a prior year", () => {
+    const lastYear = mk({ id: "1y", firstMetDate: "2025-04-25" });
+    const fiveYears = mk({ id: "5y", firstMetDate: "2021-04-25" });
+    const otherDay = mk({ id: "other", firstMetDate: "2025-04-24" });
+    const sameYear = mk({ id: "same", firstMetDate: "2026-04-25" });
+    const result = findAnniversariesToday([lastYear, fiveYears, otherDay, sameYear], NOW);
+    expect(result.map((r) => r.card.id)).toEqual(["5y", "1y"]);
+    expect(result.map((r) => r.years)).toEqual([5, 1]);
+  });
+
+  it("excludes soft-deleted cards", () => {
+    const live = mk({ id: "live", firstMetDate: "2025-04-25" });
+    const gone = mk({ id: "gone", firstMetDate: "2025-04-25", deletedAt: new Date() });
+    expect(findAnniversariesToday([live, gone], NOW).map((r) => r.card.id)).toEqual(["live"]);
+  });
+
+  it("excludes cards with no firstMetDate", () => {
+    const c = mk({ id: "noDate" });
+    expect(findAnniversariesToday([c], NOW)).toEqual([]);
+  });
+
+  it("excludes malformed firstMetDate strings", () => {
+    const c = mk({ id: "bad", firstMetDate: "04/25/2025" as unknown as string });
+    expect(findAnniversariesToday([c], NOW)).toEqual([]);
+  });
+
+  it("sorts by years desc (older milestones first), tiebreak on name asc", () => {
+    const a = mk({ id: "a", nameZh: "張三", firstMetDate: "2024-04-25" });
+    const b = mk({ id: "b", nameZh: "李四", firstMetDate: "2024-04-25" });
+    const oldest = mk({ id: "oldest", nameZh: "王五", firstMetDate: "2020-04-25" });
+    const result = findAnniversariesToday([a, b, oldest], NOW);
+    expect(result.map((r) => r.card.id)).toEqual(["oldest", "b", "a"]);
+  });
+
+  it("returns empty array on a day with no anniversaries", () => {
+    const c = mk({ id: "c", firstMetDate: "2025-01-01" });
+    expect(findAnniversariesToday([c], NOW)).toEqual([]);
+  });
+
+  it("returns empty when no cards at all", () => {
+    expect(findAnniversariesToday([], NOW)).toEqual([]);
+  });
+
+  it("Feb 29 anniversary surfaces on Feb 28 in non-leap years (closest analog)", () => {
+    const leapBaby = mk({ id: "leap", firstMetDate: "2020-02-29" });
+    // 2027 is not a leap year — Feb 28 2027 should surface the Feb 29 2020 card.
+    const feb28NonLeap = new Date("2027-02-28T10:00:00");
+    const result = findAnniversariesToday([leapBaby], feb28NonLeap);
+    expect(result.map((r) => r.card.id)).toEqual(["leap"]);
+    expect(result[0].years).toBe(7);
+  });
+
+  it("does NOT surface Feb 29 anniversary on Feb 28 of leap years (the actual day exists)", () => {
+    const leapBaby = mk({ id: "leap", firstMetDate: "2020-02-29" });
+    // 2028 is a leap year — Feb 29 will be the actual anniversary.
+    const feb28Leap = new Date("2028-02-28T10:00:00");
+    expect(findAnniversariesToday([leapBaby], feb28Leap)).toEqual([]);
+  });
+});

--- a/src/lib/timeline/__tests__/anniversaries.test.ts
+++ b/src/lib/timeline/__tests__/anniversaries.test.ts
@@ -53,12 +53,15 @@ describe("findAnniversariesToday", () => {
     expect(findAnniversariesToday([c], NOW)).toEqual([]);
   });
 
-  it("sorts by years desc (older milestones first), tiebreak on name asc", () => {
+  it("sorts by years desc (older milestones first), tiebreak on id asc", () => {
+    // Tiebreak is on id (ASCII-safe codepoint) rather than name —
+    // localeCompare on Chinese chars differs across platforms, which
+    // would otherwise flake on Linux CI vs macOS dev.
     const a = mk({ id: "a", nameZh: "張三", firstMetDate: "2024-04-25" });
     const b = mk({ id: "b", nameZh: "李四", firstMetDate: "2024-04-25" });
     const oldest = mk({ id: "oldest", nameZh: "王五", firstMetDate: "2020-04-25" });
     const result = findAnniversariesToday([a, b, oldest], NOW);
-    expect(result.map((r) => r.card.id)).toEqual(["oldest", "b", "a"]);
+    expect(result.map((r) => r.card.id)).toEqual(["oldest", "a", "b"]);
   });
 
   it("returns empty array on a day with no anniversaries", () => {

--- a/src/lib/timeline/__tests__/categorize.test.ts
+++ b/src/lib/timeline/__tests__/categorize.test.ts
@@ -30,10 +30,11 @@ function card(overrides: Partial<CardSummary> = {}): CardSummary {
 }
 
 describe("categorizeTimeline", () => {
-  it("returns 5 sections in fixed order (due-today first)", () => {
+  it("returns 6 sections in fixed order (due-today first, anniversaries 2nd)", () => {
     const sections = categorizeTimeline([], { now: NOW });
     expect(sections.map((s) => s.id)).toEqual([
       "due-today",
+      "anniversaries",
       "pinned",
       "newly-added",
       "met-this-month",
@@ -72,14 +73,14 @@ describe("categorizeTimeline", () => {
 
   it("classifies firstMetDate in current month as met-this-month", () => {
     const c = card({ firstMetDate: "2026-04-10" });
-    const [, , , met] = categorizeTimeline([c], { now: NOW });
+    const [, , , , met] = categorizeTimeline([c], { now: NOW });
     expect(met.cards).toHaveLength(1);
     expect(met.cards[0]).toBe(c);
   });
 
   it("classifies firstMetDate last month as NOT met-this-month", () => {
     const c = card({ firstMetDate: "2026-03-10" });
-    const [, , newly, met, uncontacted] = categorizeTimeline([c], { now: NOW });
+    const [, , , newly, met, uncontacted] = categorizeTimeline([c], { now: NOW });
     expect(met.cards).toHaveLength(0);
     // createdAt is 2026-01-01 so not newly-added; last contact null → uncontacted
     expect(newly.cards).toHaveLength(0);
@@ -91,7 +92,7 @@ describe("categorizeTimeline", () => {
       id: "new",
       createdAt: new Date("2026-04-15T00:00:00Z"),
     });
-    const [, , newly] = categorizeTimeline([c], { now: NOW });
+    const [, , , newly] = categorizeTimeline([c], { now: NOW });
     expect(newly.cards.map((card) => card.id)).toContain("new");
   });
 
@@ -101,7 +102,7 @@ describe("categorizeTimeline", () => {
       createdAt: new Date("2025-01-01T00:00:00Z"),
       lastContactedAt: new Date("2026-02-01T00:00:00Z"), // > 30 days before NOW
     });
-    const [, , , , uncontacted] = categorizeTimeline([c], { now: NOW });
+    const [, , , , , uncontacted] = categorizeTimeline([c], { now: NOW });
     expect(uncontacted.cards.map((card) => card.id)).toContain("stale");
   });
 
@@ -111,7 +112,7 @@ describe("categorizeTimeline", () => {
       createdAt: new Date("2025-01-01T00:00:00Z"),
       lastContactedAt: new Date("2026-04-15T00:00:00Z"), // 3 days before NOW
     });
-    const [, , newly, met, uncontacted] = categorizeTimeline([c], { now: NOW });
+    const [, , , newly, met, uncontacted] = categorizeTimeline([c], { now: NOW });
     expect([...newly.cards, ...met.cards, ...uncontacted.cards]).toHaveLength(0);
   });
 
@@ -139,7 +140,7 @@ describe("categorizeTimeline", () => {
       id: "newer",
       createdAt: new Date("2026-04-17T00:00:00Z"),
     });
-    const [, , newly] = categorizeTimeline([older, newer], { now: NOW });
+    const [, , , newly] = categorizeTimeline([older, newer], { now: NOW });
     expect(newly.cards.map((c) => c.id)).toEqual(["newer", "older"]);
   });
 
@@ -154,7 +155,7 @@ describe("categorizeTimeline", () => {
       createdAt: new Date("2025-01-01T00:00:00Z"),
       lastContactedAt: new Date("2026-01-01T00:00:00Z"),
     });
-    const [, , , , uncontacted] = categorizeTimeline([b, a], { now: NOW });
+    const [, , , , , uncontacted] = categorizeTimeline([b, a], { now: NOW });
     expect(uncontacted.cards.map((c) => c.id)).toEqual(["a", "b"]);
   });
 
@@ -188,7 +189,7 @@ describe("categorizeTimeline", () => {
       firstMetDate: "04/10/2026" as unknown as string,
       createdAt: new Date("2025-01-01T00:00:00Z"),
     });
-    const [, , , met, uncontacted] = categorizeTimeline([c], { now: NOW });
+    const [, , , , met, uncontacted] = categorizeTimeline([c], { now: NOW });
     expect(met.cards).toHaveLength(0);
     expect(uncontacted.cards).toHaveLength(1);
   });
@@ -196,7 +197,7 @@ describe("categorizeTimeline", () => {
   it("sorts met-this-month by firstMetDate desc", () => {
     const early = card({ id: "early", firstMetDate: "2026-04-03" });
     const late = card({ id: "late", firstMetDate: "2026-04-17" });
-    const [, , , met] = categorizeTimeline([early, late], { now: NOW });
+    const [, , , , met] = categorizeTimeline([early, late], { now: NOW });
     expect(met.cards.map((c) => c.id)).toEqual(["late", "early"]);
   });
 
@@ -204,7 +205,7 @@ describe("categorizeTimeline", () => {
     const good = card({ id: "good", firstMetDate: "2026-04-15" });
     // broken date never enters met-this-month, but guard the sort fallback
     // via a card with firstMetDate set to a valid current-month date only once.
-    const [, , , met] = categorizeTimeline([good], { now: NOW });
+    const [, , , , met] = categorizeTimeline([good], { now: NOW });
     expect(met.cards).toHaveLength(1);
   });
 
@@ -234,6 +235,49 @@ describe("categorizeTimeline", () => {
     const sections = categorizeTimeline([c], { now: NOW, uncontactedDays: 5 });
     const uncontacted = sections.find((s) => s.id === "uncontacted")!;
     expect(uncontacted.cards.map((card) => card.id)).toContain("recent");
+  });
+
+  describe("anniversaries section", () => {
+    it("surfaces a card whose firstMetDate is one year ago today", () => {
+      const c = card({ id: "a1", firstMetDate: "2025-04-18" });
+      const sections = categorizeTimeline([c], { now: NOW });
+      const anniv = sections.find((s) => s.id === "anniversaries")!;
+      expect(anniv.cards.map((x) => x.id)).toEqual(["a1"]);
+    });
+
+    it("title reflects the largest milestone year (e.g. 5 年前的今天)", () => {
+      const oneYear = card({ id: "1y", firstMetDate: "2025-04-18" });
+      const fiveYear = card({ id: "5y", firstMetDate: "2021-04-18" });
+      const sections = categorizeTimeline([oneYear, fiveYear], { now: NOW });
+      const anniv = sections.find((s) => s.id === "anniversaries")!;
+      expect(anniv.title).toBe("🎉 5 年前的今天");
+    });
+
+    it("anniversary card does NOT also appear in pinned / newly / uncontacted", () => {
+      const c = card({
+        id: "a-pinned",
+        isPinned: true,
+        firstMetDate: "2025-04-18",
+        // Also has stale lastContactedAt that would otherwise put it in uncontacted.
+        lastContactedAt: new Date("2025-08-01"),
+      });
+      const sections = categorizeTimeline([c], { now: NOW });
+      for (const s of sections) {
+        const inThis = s.cards.find((x) => x.id === "a-pinned");
+        if (s.id === "anniversaries") {
+          expect(inThis).toBeDefined();
+        } else {
+          expect(inThis).toBeUndefined();
+        }
+      }
+    });
+
+    it("default anniversary title when section is empty", () => {
+      const sections = categorizeTimeline([], { now: NOW });
+      const anniv = sections.find((s) => s.id === "anniversaries")!;
+      expect(anniv.title).toBe("🎉 週年提醒");
+      expect(anniv.cards).toHaveLength(0);
+    });
   });
 
   describe("due-today section", () => {

--- a/src/lib/timeline/anniversaries.ts
+++ b/src/lib/timeline/anniversaries.ts
@@ -1,0 +1,79 @@
+import type { CardSummary } from "@/db/cards";
+
+export interface AnniversaryEntry {
+  card: CardSummary;
+  /** Whole-year count since firstMetDate, computed at the local "now" date. */
+  years: number;
+}
+
+/**
+ * Match `YYYY-MM-DD`. Year may be < 4 digits in user data; we accept
+ * 4-digit years only and bail otherwise (categorize.ts uses the same
+ * regex — keep the bar consistent).
+ */
+function parseFirstMet(
+  raw: string | undefined,
+): { year: number; month: number; day: number } | null {
+  if (!raw) return null;
+  const m = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return null;
+  const [, y, mo, d] = m;
+  const year = Number(y);
+  const month = Number(mo);
+  const day = Number(d);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  return { year, month, day };
+}
+
+/**
+ * Find cards whose `firstMetDate` matches today's month + day across any
+ * prior year. Excludes:
+ *   - soft-deleted
+ *   - missing or malformed firstMetDate
+ *   - firstMet year >= now year (no anniversary on the same year you met)
+ *   - "leap day" Feb 29 mismatch — Feb 29 anniversaries surface on Feb 28
+ *     in non-leap years (closest analog without skipping anyone)
+ *
+ * Sorted by years desc (5-year > 3-year > 1-year) so the bigger
+ * milestone leads. Tiebreak on card name for stability.
+ */
+export function findAnniversariesToday(
+  cards: readonly CardSummary[],
+  now: Date,
+): AnniversaryEntry[] {
+  const todayMonth = now.getMonth() + 1; // 1..12
+  const todayDay = now.getDate(); // 1..31
+  const todayYear = now.getFullYear();
+  const isFeb28InNonLeapYear = todayMonth === 2 && todayDay === 28 && !isLeapYear(todayYear);
+
+  const out: AnniversaryEntry[] = [];
+  for (const card of cards) {
+    if (card.deletedAt) continue;
+    const parsed = parseFirstMet(card.firstMetDate);
+    if (!parsed) continue;
+    if (parsed.year >= todayYear) continue;
+
+    const matchesToday = parsed.month === todayMonth && parsed.day === todayDay;
+    // On Feb 28 in non-leap years, also surface Feb 29 anniversaries.
+    const matchesFeb29Today = isFeb28InNonLeapYear && parsed.month === 2 && parsed.day === 29;
+
+    if (!matchesToday && !matchesFeb29Today) continue;
+
+    const years = todayYear - parsed.year;
+    if (years < 1) continue;
+    out.push({ card, years });
+  }
+
+  out.sort((a, b) => {
+    if (a.years !== b.years) return b.years - a.years;
+    const an = (a.card.nameZh ?? a.card.nameEn ?? a.card.id).toString();
+    const bn = (b.card.nameZh ?? b.card.nameEn ?? b.card.id).toString();
+    return an.localeCompare(bn);
+  });
+  return out;
+}
+
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}

--- a/src/lib/timeline/anniversaries.ts
+++ b/src/lib/timeline/anniversaries.ts
@@ -67,9 +67,11 @@ export function findAnniversariesToday(
 
   out.sort((a, b) => {
     if (a.years !== b.years) return b.years - a.years;
-    const an = (a.card.nameZh ?? a.card.nameEn ?? a.card.id).toString();
-    const bn = (b.card.nameZh ?? b.card.nameEn ?? b.card.id).toString();
-    return an.localeCompare(bn);
+    // Tiebreak on card.id (ASCII-safe, codepoint-stable). Avoids the
+    // platform-dependent localeCompare on Chinese names — macOS sorts
+    // by pinyin (李<張) while Linux falls back to codepoint (張<李),
+    // which would make CI tests flake.
+    return a.card.id < b.card.id ? -1 : a.card.id > b.card.id ? 1 : 0;
   });
   return out;
 }

--- a/src/lib/timeline/categorize.ts
+++ b/src/lib/timeline/categorize.ts
@@ -1,7 +1,9 @@
 import type { CardSummary } from "@/db/cards";
 
+import { findAnniversariesToday } from "./anniversaries";
+
 export interface TimelineSection {
-  id: "due-today" | "pinned" | "uncontacted" | "met-this-month" | "newly-added";
+  id: "due-today" | "anniversaries" | "pinned" | "uncontacted" | "met-this-month" | "newly-added";
   title: string;
   description: string;
   cards: CardSummary[];
@@ -30,14 +32,18 @@ function parseFirstMetDate(raw: string | undefined): Date | null {
 }
 
 /**
- * Categorize cards into the 5 timeline sections.
- * Priority: due-today > pinned > met-this-month > newly-added > uncontacted.
- * A card shows in only one section. due-today wins over pinned because
- * the user *committed to acting today* — that beats the standing pin.
+ * Categorize cards into the 6 timeline sections.
+ * Priority: due-today > anniversaries > pinned > met-this-month > newly-added > uncontacted.
+ * A card shows in only one section. The implicit ranking is:
+ *  - due-today wins everything (you committed to acting today)
+ *  - anniversaries wins over pinned because the milestone is once-per-year
+ *  - pinned beats time-based sections because the user explicitly elevated them
  *
  * Rules:
  *  - due-today: followUpAt is set AND <= end of `now` calendar day
- *  - pinned: card.isPinned === true (and not due-today)
+ *  - anniversaries: firstMetDate matches today's month/day in a prior year
+ *    (Feb 29 anniversaries surface on Feb 28 in non-leap years)
+ *  - pinned: card.isPinned === true (and not due-today / anniversary)
  *  - met-this-month: firstMetDate within the given "now" month.
  *  - newly-added: createdAt within newlyAddedDays (default 7). Excluded from uncontacted.
  *  - uncontacted:
@@ -57,6 +63,12 @@ export function categorizeTimeline(
   const endOfToday = new Date(now);
   endOfToday.setHours(23, 59, 59, 999);
 
+  // Compute anniversaries up-front so we can exclude them from the
+  // other sections (a card surfacing on its anniversary should not
+  // also appear in pinned / met-this-month).
+  const anniversaryEntries = findAnniversariesToday(cards, now);
+  const anniversaryIds = new Set(anniversaryEntries.map((e) => e.card.id));
+
   const dueToday: CardSummary[] = [];
   const pinned: CardSummary[] = [];
   const metThisMonth: CardSummary[] = [];
@@ -69,6 +81,7 @@ export function categorizeTimeline(
       dueToday.push(card);
       continue;
     }
+    if (anniversaryIds.has(card.id)) continue; // already surfaced
     if (card.isPinned) {
       pinned.push(card);
       continue;
@@ -126,6 +139,14 @@ export function categorizeTimeline(
     return ta - tb;
   });
 
+  // Build the anniversary section title from the largest milestone in
+  // the result so we get e.g. "🎉 一年前的今天" or "🎉 五年前的今天".
+  const anniversaryCards = anniversaryEntries.map((e) => e.card);
+  const topYears = anniversaryEntries[0]?.years ?? 1;
+  const yearsLabel = topYears === 1 ? "一" : topYears.toString();
+  const anniversaryTitle =
+    anniversaryEntries.length > 0 ? `🎉 ${yearsLabel} 年前的今天` : "🎉 週年提醒";
+
   return [
     {
       id: "due-today",
@@ -134,6 +155,13 @@ export function categorizeTimeline(
       // Not capped — every due reminder must be visible, otherwise the
       // whole feature loses trust.
       cards: dueToday,
+    },
+    {
+      id: "anniversaries",
+      title: anniversaryTitle,
+      description: "一年（或多年）前的今天認識的人 — 寫個訊息打聲招呼吧。",
+      // Not capped — anniversaries are inherently rare; let them all show.
+      cards: anniversaryCards,
     },
     {
       id: "pinned",


### PR DESCRIPTION
Closes #72

## Summary
商務人脈維護的最重要單一動作：「一年前的今天你認識了 X，要不要 ping 一下？」

LinkedIn 的 workiversary 是同概念但只用工作年資。我們用 `firstMetDate`（用戶手填首次見面日）算 *我們認識* 一週年 — 更個人化，不需要記得設提醒。

## Files
- `src/lib/timeline/anniversaries.ts` (+70) — `findAnniversariesToday(cards, now)`，含 Feb 29 → Feb 28 非閏年 fallback
- `src/lib/timeline/__tests__/anniversaries.test.ts` — 9 UT
- `src/lib/timeline/categorize.ts` — 加 `anniversaries` section 排第 2，跟其他 section 互斥
- `src/lib/timeline/__tests__/categorize.test.ts` — 4 新 UT + 11 既有 destructure 修正
- `src/app/(app)/cards/[id]/page.tsx` + `detail.module.css` — anniversary pill chip on detail header

## Behavior

| Today              | Surfaces                                        |
| ------------------ | ----------------------------------------------- |
| 2026-04-25         | All cards with firstMetDate `*-04-25` and year < 2026 |
| 2027-02-28 (非閏)  | Cards with firstMetDate `*-02-28` AND `*-02-29` |
| 2028-02-28 (閏)   | Only Feb 28 cards (Feb 29 is the actual day)    |

Section title is dynamic: 5 年前 > 1 年前，挑最大的 milestone：「🎉 5 年前的今天」。

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 435 pass (+13 new)
- [x] `pnpm lint` — clean (4 unrelated warnings pre-existing)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — green
- [ ] CI green → merge → mac mini deploy

## Out of scope
- 生日 (need new birthday field) — 之後做
- recurring N-year prompt → 設過 followUpAt 也是已聯絡 → 不會 spam
- email digest / push notification — 之後做