### PR TITLE
feat(companies): 整公司 vCard 一鍵匯出

### DIFF
--- a/src/app/(app)/companies/[slug]/company.module.css
+++ b/src/app/(app)/companies/[slug]/company.module.css
@@ -56,6 +56,35 @@
   margin: var(--space-xs) 0 0;
 }
 
+.headerActions {
+  display: flex;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+.exportBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+  border: var(--border-hair) solid var(--color-accent-ink);
+  color: var(--color-accent-ink);
+  background: transparent;
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+}
+
+.exportBtn:hover {
+  background: var(--color-accent-ink);
+  color: var(--color-paper);
+}
+
 .cardList {
   list-style: none;
   padding: 0;

--- a/src/app/(app)/companies/[slug]/page.tsx
+++ b/src/app/(app)/companies/[slug]/page.tsx
@@ -64,6 +64,15 @@ export default async function CompanyDetailPage({ params }: PageProps) {
           {group.cards.length} 位聯絡人 · {totalContacted} 位有互動紀錄
           {sharedEvents.length > 0 && <> · 認識場合：{sharedEvents.join("、")}</>}
         </p>
+        <div className={styles.headerActions}>
+          <a
+            href={`/api/companies/${encodeURIComponent(group.slug)}/vcard`}
+            className={styles.exportBtn}
+            download
+          >
+            📤 匯出全部 {group.cards.length} 位 vCard
+          </a>
+        </div>
       </header>
 
       <ul className={styles.cardList}>

--- a/src/app/api/companies/[slug]/vcard/route.ts
+++ b/src/app/api/companies/[slug]/vcard/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+
+import { listCardsForUser, listContactEventsForUser } from "@/db/cards";
+import { findCompanyBySlug } from "@/lib/companies/group";
+import { readSession } from "@/lib/firebase/session";
+import { toVcard } from "@/lib/vcard/export";
+
+export const dynamic = "force-dynamic";
+
+const SCAN_LIMIT = 500;
+const PER_CARD_EVENT_LIMIT = 5; // smaller than single-card export so the bundle stays compact
+
+function safeFilename(base: string, count: number): string {
+  const safe = base.replace(/[^A-Za-z0-9_\-\u3400-\u9fff]+/g, "_").slice(0, 60) || "company";
+  return `${safe}-${count}-cards.vcf`;
+}
+
+/**
+ * Bulk vCard export for an entire company. Concatenates each member
+ * card's vCard into a single .vcf — the multi-vCard format that Apple
+ * Contacts / Outlook / Google Contacts all import in one shot. Useful
+ * when a business user wants to hand "the entire ACME contact list"
+ * to a colleague or import to a CRM.
+ *
+ * Per-card events capped at 5 (vs 10 for single-card) to keep the
+ * bundle byte size reasonable when companies have 10+ members.
+ */
+export async function GET(_request: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const user = await readSession();
+  if (!user) return new NextResponse("Unauthorized", { status: 401 });
+
+  const { slug: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug);
+
+  const cards = await listCardsForUser(user.uid, {
+    limit: SCAN_LIMIT,
+    orderBy: "createdAt",
+    order: "desc",
+  });
+  const group = findCompanyBySlug(cards, slug);
+  if (!group) return new NextResponse("Not Found", { status: 404 });
+
+  // Fetch contact events for each card in parallel — bounded by group
+  // size, which is naturally small (typical company has 1-10 cards).
+  const eventLists = await Promise.all(
+    group.cards.map((c) => listContactEventsForUser(c.id, user.uid, PER_CARD_EVENT_LIMIT)),
+  );
+
+  const blocks = group.cards.map((card, i) =>
+    toVcard(card, { events: eventLists[i], eventLimit: PER_CARD_EVENT_LIMIT }),
+  );
+  // toVcard already emits CRLF + trailing \r\n per block; concatenation
+  // gives the multi-vCard structure that RFC 6350 specifies.
+  const body = blocks.join("");
+  const filename = safeFilename(group.displayName, group.cards.length);
+
+  return new NextResponse(body, {
+    headers: {
+      "Content-Type": "text/vcard; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/lib/vcard/__tests__/export.test.ts
+++ b/src/lib/vcard/__tests__/export.test.ts
@@ -354,3 +354,42 @@ describe("vcardFilename", () => {
     expect(filename).toMatch(/^[A-Za-z0-9_\-]+\.vcf$/);
   });
 });
+
+describe("multi-card vcard concatenation", () => {
+  it("N concatenated cards yield exactly N BEGIN:VCARD blocks", () => {
+    const cards = [
+      makeCard({ nameZh: "陳玉涵", whyRemember: "first" }),
+      makeCard({ nameZh: "王小明", whyRemember: "second" }),
+      makeCard({ nameZh: "李大同", whyRemember: "third" }),
+    ];
+    const body = cards.map((c) => toVcard(c)).join("");
+    const beginCount = body.match(/BEGIN:VCARD/g)?.length ?? 0;
+    const endCount = body.match(/END:VCARD/g)?.length ?? 0;
+    expect(beginCount).toBe(3);
+    expect(endCount).toBe(3);
+    expect(body).toContain("first");
+    expect(body).toContain("second");
+    expect(body).toContain("third");
+  });
+
+  it("concatenated cards each end with CRLF so the next BEGIN is on a fresh line", () => {
+    const a = toVcard(makeCard({ nameZh: "A", whyRemember: "x" }));
+    const b = toVcard(makeCard({ nameZh: "B", whyRemember: "y" }));
+    expect(a.endsWith("\r\n")).toBe(true);
+    // After joining, the boundary is "END:VCARD\r\nBEGIN:VCARD" — no
+    // missing CRLF and no doubled blank line.
+    const combined = a + b;
+    expect(combined).toContain("END:VCARD\r\nBEGIN:VCARD");
+  });
+
+  it("each block stays self-contained (FN field unique to that card)", () => {
+    const cards = [
+      makeCard({ nameZh: "First", whyRemember: "x" }),
+      makeCard({ nameZh: "Second", whyRemember: "y" }),
+    ];
+    const body = cards.map((c) => toVcard(c)).join("");
+    // FN: lines should appear exactly once per card.
+    expect(body.match(/FN:First/g)?.length).toBe(1);
+    expect(body.match(/FN:Second/g)?.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #74

## Summary
商務情境：「秘書，麻煩把 ACME 那邊所有人的聯絡方式建到 CRM / 寄給 IT 開白名單」。原本要一張一張匯出，整公司 5-10 人就很煩。

- 新 `/api/companies/[slug]/vcard` route handler 把同公司所有未刪卡 concatenate 成一個 multi-vCard `.vcf` 檔
- `/companies/[slug]` header 加「📤 匯出全部 N 位 vCard」link 直接觸發下載
- Multi-vCard 格式 = N 個 BEGIN..END 串接，符合 RFC 6350，Apple Contacts / Outlook / Google Contacts 一次 import 全部

## Files
- `src/app/api/companies/[slug]/vcard/route.ts` (+70) — auth → findCompanyBySlug → parallel-fetch events → concat toVcard
- `src/app/(app)/companies/[slug]/page.tsx` + `company.module.css` — 加 export button
- `src/lib/vcard/__tests__/export.test.ts` — 3 新 UT (BEGIN count / CRLF boundary / FN uniqueness)

## Implementation notes
- 重用既有 `findCompanyBySlug` + `toVcard` — 沒有複製 vcard build 邏輯
- Per-card events 限 5 筆 (vs 單卡 10 筆) 避免 10+ 人 bundle 過大
- 用 `Promise.all` 並行抓 events，群組大小天然小（典型公司 1-10 卡）
- decodeURIComponent on slug — `/companies/智威科技` 在 URL 是 encoded

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 438 pass (+3 new)
- [x] `pnpm lint` — clean (4 unrelated pre-existing)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — `/api/companies/[slug]/vcard` registered
- [ ] CI green → merge → mac mini deploy