### PR TITLE
feat(cards): inline edit on /cards/[id] — 名字 / 職位 / 公司 / 為什麼記得

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { CardActions } from "@/components/cards/CardActions";
+import { CardInlineEdit } from "@/components/cards/CardInlineEdit";
 import { ContactEventList } from "@/components/cards/ContactEventList";
 import { RelatedByEvent } from "@/components/cards/RelatedByEvent";
 import { TagSuggestionsBanner } from "@/components/tags/TagSuggestionsBanner";
@@ -55,9 +56,8 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
   }
 
   const primary = card.nameZh || card.nameEn || "（未命名）";
-  const secondary = card.nameZh && card.nameEn ? card.nameEn : null;
-  const role = card.jobTitleZh || card.jobTitleEn;
-  const company = card.companyZh || card.companyEn;
+  // The header now renders nameEn / role / company through CardInlineEdit
+  // directly from card.* — no need for derived display strings.
 
   // Anniversary chip — surfaces "認識 N 週年" only when today is the
   // anniversary of firstMetDate. Reuses the same pure fn the timeline
@@ -140,15 +140,45 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
         <main className={styles.main}>
           <header className={styles.header}>
             <p className={styles.kicker}>名片</p>
-            <h1 className={styles.name}>{primary}</h1>
-            {secondary && <p className={styles.nameEn}>{secondary}</p>}
-            {(role || company) && (
-              <p className={styles.subtitle}>
-                {role && <span>{role}</span>}
-                {role && company && <em className={styles.sep}>於</em>}
-                {company && <strong>{company}</strong>}
-              </p>
-            )}
+            <h1 className={styles.name}>
+              <CardInlineEdit
+                cardId={card.id}
+                field="nameZh"
+                value={card.nameZh}
+                placeholder="（中文姓名）"
+                ariaLabel="中文姓名"
+                maxLength={100}
+              />
+            </h1>
+            <p className={styles.nameEn}>
+              <CardInlineEdit
+                cardId={card.id}
+                field="nameEn"
+                value={card.nameEn}
+                placeholder="（English name）"
+                ariaLabel="英文姓名"
+                maxLength={100}
+              />
+            </p>
+            <p className={styles.subtitle}>
+              <CardInlineEdit
+                cardId={card.id}
+                field="jobTitleZh"
+                value={card.jobTitleZh}
+                placeholder="（職稱）"
+                ariaLabel="職稱（中文）"
+                maxLength={100}
+              />
+              <em className={styles.sep}>於</em>
+              <CardInlineEdit
+                cardId={card.id}
+                field="companyZh"
+                value={card.companyZh}
+                placeholder="（公司）"
+                ariaLabel="公司（中文）"
+                maxLength={100}
+              />
+            </p>
             {anniversaryYears !== null && (
               <p className={styles.anniversary} role="status">
                 🎉 {anniversaryYears} 年前的今天認識
@@ -156,12 +186,20 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
             )}
           </header>
 
-          {card.whyRemember && (
-            <section className={styles.why}>
-              <p className={styles.whyLabel}>為什麼記得這個人</p>
-              <blockquote className={styles.whyBody}>{card.whyRemember}</blockquote>
-            </section>
-          )}
+          <section className={styles.why}>
+            <p className={styles.whyLabel}>為什麼記得這個人</p>
+            <blockquote className={styles.whyBody}>
+              <CardInlineEdit
+                cardId={card.id}
+                field="whyRemember"
+                value={card.whyRemember}
+                placeholder="（寫一句話：為什麼記得這個人）"
+                ariaLabel="為什麼記得這個人"
+                multiline
+                maxLength={500}
+              />
+            </blockquote>
+          </section>
 
           {(card.firstMetContext || card.firstMetDate || card.firstMetEventTag) && (
             <section className={styles.context}>

--- a/src/components/cards/CardInlineEdit.tsx
+++ b/src/components/cards/CardInlineEdit.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { updateCardAction } from "@/app/(app)/cards/actions";
+import type { CardUpdateInput } from "@/db/schema";
+
+import { InlineEditField } from "./InlineEditField";
+
+type EditableField =
+  | "nameZh"
+  | "nameEn"
+  | "jobTitleZh"
+  | "jobTitleEn"
+  | "companyZh"
+  | "companyEn"
+  | "department"
+  | "whyRemember";
+
+interface CardInlineEditProps {
+  cardId: string;
+  field: EditableField;
+  value: string | undefined;
+  placeholder: string;
+  ariaLabel: string;
+  multiline?: boolean;
+  maxLength?: number;
+  className?: string;
+}
+
+/**
+ * Thin Server-Action wrapper around <InlineEditField>. Lives next to
+ * its sibling because the detail page is an RSC and can't host
+ * useState directly. Only one field changes per save — `updateCardAction`
+ * already accepts partial cardUpdateSchema input.
+ */
+export function CardInlineEdit({
+  cardId,
+  field,
+  value,
+  placeholder,
+  ariaLabel,
+  multiline,
+  maxLength,
+  className,
+}: CardInlineEditProps) {
+  const router = useRouter();
+  const [optimistic, setOptimistic] = useState<string | undefined>(undefined);
+
+  const displayed = optimistic ?? value;
+
+  const handleSave = async (next: string) => {
+    // For whyRemember (required, min 1 char), reject empty values up
+    // front. For other optional fields, empty means "clear".
+    if (field === "whyRemember" && !next) {
+      throw new Error("「為什麼記得」不能為空");
+    }
+    setOptimistic(next);
+    const patch: CardUpdateInput = { [field]: next || undefined };
+    const result = await updateCardAction({ id: cardId, input: patch });
+    if (result?.serverError) {
+      setOptimistic(undefined);
+      throw new Error(result.serverError);
+    }
+    if (result?.validationErrors) {
+      setOptimistic(undefined);
+      throw new Error("輸入格式有問題");
+    }
+    // Refresh so the server-rendered shell picks up the new value;
+    // optimistic stays until the refetch completes so there's no flash.
+    router.refresh();
+  };
+
+  return (
+    <InlineEditField
+      value={displayed}
+      onSave={handleSave}
+      placeholder={placeholder}
+      ariaLabel={ariaLabel}
+      multiline={multiline}
+      maxLength={maxLength}
+      className={className}
+    />
+  );
+}

--- a/src/components/cards/InlineEditField.module.css
+++ b/src/components/cards/InlineEditField.module.css
@@ -1,0 +1,95 @@
+.display {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3em;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  padding: 0 0.2em;
+  margin: 0 -0.2em;
+  position: relative;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    box-shadow var(--duration-fast) var(--ease-standard);
+}
+
+.display:hover,
+.display:focus-visible {
+  background: var(--color-accent-soft, color-mix(in oklch, var(--color-accent) 12%, transparent));
+  outline: none;
+}
+
+.display:focus-visible {
+  box-shadow: 0 0 0 2px var(--color-accent-ink);
+}
+
+.displayEmpty {
+  color: var(--color-ink-muted);
+  font-style: italic;
+}
+
+.pencil {
+  font-size: 0.7em;
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--ease-standard);
+}
+
+.display:hover .pencil,
+.display:focus-visible .pencil {
+  opacity: 0.6;
+}
+
+.editing {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+}
+
+.input {
+  font: inherit;
+  color: inherit;
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-sm);
+  padding: 0.1em 0.3em;
+  outline: none;
+  min-width: 8ch;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--color-accent-ink) 35%, transparent);
+}
+
+.input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+textarea.input {
+  resize: vertical;
+  min-height: 4em;
+}
+
+.spinner {
+  width: 0.9em;
+  height: 0.9em;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent-ink);
+  border-radius: 50%;
+  animation: inlineSpin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes inlineSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.error {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-error, #b00020);
+  margin-left: 0.4em;
+}

--- a/src/components/cards/InlineEditField.tsx
+++ b/src/components/cards/InlineEditField.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useId, useRef, useState } from "react";
+
+import styles from "./InlineEditField.module.css";
+
+interface InlineEditFieldProps {
+  /** Current value. Empty / undefined renders as the placeholder. */
+  value: string | undefined;
+  /** Called with the trimmed new value when the user commits via Enter / blur. */
+  onSave: (value: string) => Promise<void>;
+  /** Inline placeholder shown when value is empty. */
+  placeholder: string;
+  /** ARIA label for screen readers ("名字"、"職稱" 等). */
+  ariaLabel: string;
+  /** Render as <textarea> instead of <input>. Adds Cmd/Ctrl+Enter to commit. */
+  multiline?: boolean;
+  /** Soft cap; the input enforces it via maxLength. */
+  maxLength?: number;
+  /** Style override hook for parent (e.g. h1 / blockquote vs span). */
+  className?: string;
+  /** Disable the inline edit affordance entirely (still renders the value). */
+  disabled?: boolean;
+}
+
+/**
+ * Hover-to-reveal inline editor. Click to edit, Enter / blur to save,
+ * Esc to cancel. Multiline mode uses Cmd/Ctrl+Enter so plain Enter
+ * keeps inserting newlines.
+ *
+ * Nothing is shown unless this component is in either `display` or
+ * `editing` mode — the wrapper is always rendered, so screen readers
+ * still see the value via aria-label.
+ */
+export function InlineEditField({
+  value,
+  onSave,
+  placeholder,
+  ariaLabel,
+  multiline = false,
+  maxLength = 200,
+  className,
+  disabled = false,
+}: InlineEditFieldProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+  const fieldId = useId();
+
+  const startEdit = () => {
+    if (disabled || pending) return;
+    setDraft(value ?? "");
+    setEditing(true);
+    setError(null);
+    // Move focus + cursor to end on next tick.
+    setTimeout(() => {
+      const el = inputRef.current;
+      if (!el) return;
+      el.focus();
+      const end = el.value.length;
+      try {
+        el.setSelectionRange(end, end);
+      } catch {
+        // setSelectionRange is unsupported on some input types — ignore.
+      }
+    }, 0);
+  };
+
+  const commit = async () => {
+    const next = draft.trim();
+    const current = (value ?? "").trim();
+    if (next === current) {
+      setEditing(false);
+      return;
+    }
+    setPending(true);
+    setError(null);
+    try {
+      await onSave(next);
+      setEditing(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "儲存失敗");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const cancel = () => {
+    setEditing(false);
+    setError(null);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      cancel();
+      return;
+    }
+    if (e.key === "Enter") {
+      // Multi-line: only Cmd/Ctrl+Enter commits, plain Enter inserts newline.
+      if (multiline && !(e.metaKey || e.ctrlKey)) return;
+      e.preventDefault();
+      void commit();
+    }
+  };
+
+  if (editing) {
+    const InputTag = multiline ? "textarea" : "input";
+    return (
+      <span className={styles.editing}>
+        <InputTag
+          id={fieldId}
+          ref={inputRef as never}
+          className={`${styles.input} ${className ?? ""}`}
+          value={draft}
+          onChange={(e) => setDraft((e.target as HTMLInputElement).value)}
+          onBlur={() => void commit()}
+          onKeyDown={handleKeyDown}
+          maxLength={maxLength}
+          aria-label={ariaLabel}
+          disabled={pending}
+          rows={multiline ? 3 : undefined}
+        />
+        {pending && <span className={styles.spinner} aria-label="儲存中" />}
+        {error && (
+          <span role="alert" className={styles.error}>
+            {error}
+          </span>
+        )}
+      </span>
+    );
+  }
+
+  const display = value && value.trim() ? value : placeholder;
+  const isEmpty = !value || !value.trim();
+
+  return (
+    <span
+      className={`${styles.display} ${isEmpty ? styles.displayEmpty : ""} ${className ?? ""}`}
+      onClick={startEdit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          startEdit();
+        }
+      }}
+      role={disabled ? undefined : "button"}
+      tabIndex={disabled ? undefined : 0}
+      aria-label={`${ariaLabel}：${value || placeholder}（點擊編輯）`}
+      title={disabled ? undefined : "點擊編輯"}
+    >
+      {display}
+      {!disabled && (
+        <span className={styles.pencil} aria-hidden="true">
+          ✏️
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/cards/__tests__/InlineEditField.test.tsx
+++ b/src/components/cards/__tests__/InlineEditField.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+import { InlineEditField } from "../InlineEditField";
+
+function setup(overrides: Partial<Parameters<typeof InlineEditField>[0]> = {}) {
+  const onSave = overrides.onSave ?? vi.fn().mockResolvedValue(undefined);
+  const utils = render(
+    <InlineEditField
+      value="Initial"
+      onSave={onSave}
+      placeholder="placeholder"
+      ariaLabel="名稱"
+      {...overrides}
+    />,
+  );
+  return { onSave, ...utils };
+}
+
+describe("InlineEditField", () => {
+  it("renders the value as a clickable button by default", () => {
+    setup();
+    expect(screen.getByRole("button", { name: /Initial/ })).toBeInTheDocument();
+  });
+
+  it("renders placeholder when value is empty", () => {
+    setup({ value: undefined });
+    expect(screen.getByRole("button", { name: /placeholder/ })).toBeInTheDocument();
+  });
+
+  it("clicking the display swaps to an input with the current value", () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: /Initial/ }));
+    const input = screen.getByLabelText("名稱") as HTMLInputElement;
+    expect(input.value).toBe("Initial");
+  });
+
+  it("Enter commits the new value via onSave", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    setup({ onSave });
+    fireEvent.click(screen.getByRole("button", { name: /Initial/ }));
+    const input = screen.getByLabelText("名稱") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Renamed" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await vi.waitFor(() => expect(onSave).toHaveBeenCalledWith("Renamed"));
+  });
+
+  it("blur commits the value (matches click-outside UX)", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    setup({ onSave });
+    fireEvent.click(screen.getByRole("button", { name: /Initial/ }));
+    const input = screen.getByLabelText("名稱") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Blurred" } });
+    fireEvent.blur(input);
+    await vi.waitFor(() => expect(onSave).toHaveBeenCalledWith("Blurred"));
+  });
+
+  it("Escape cancels without calling onSave", async () => {
+    const onSave = vi.fn();
+    setup({ onSave });
+    fireEvent.click(screen.getByRole("button", { name: /Initial/ }));
+    const input = screen.getByLabelText("名稱") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Discarded" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onSave).not.toHaveBeenCalled();
+    // Restored display.
+    expect(screen.getByRole("button", { name: /Initial/ })).toBeInTheDocument();
+  });
+
+  it("does NOT call onSave when value is unchanged (trim-equal)", async () => {
+    const onSave = vi.fn();
+    setup({ onSave });
+    fireEvent.click(screen.getByRole("button", { name: /Initial/ }));
+    const input = screen.getByLabelText("名稱") as HTMLInputElement;
+    // Add trailing whitespace — trim should match original.
+    fireEvent.change(input, { target: { value: "Initial  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("shows error message when onSave rejects", async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error("network kaboom"));
+    setup({ onSave });
+    fireEvent.click(screen.getByRole("button", { name: /Initial/ }));
+    const input = screen.getByLabelText("名稱") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Renamed" } });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent("network kaboom");
+    // Stays in editing mode so the user can retry.
+    expect(screen.getByLabelText("名稱")).toBeInTheDocument();
+  });
+
+  it("respects maxLength on the input", () => {
+    setup({ maxLength: 5 });
+    fireEvent.click(screen.getByRole("button", { name: /Initial/ }));
+    const input = screen.getByLabelText("名稱") as HTMLInputElement;
+    expect(input.maxLength).toBe(5);
+  });
+
+  it("multiline mode renders a textarea and Cmd+Enter commits", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    setup({ multiline: true, onSave });
+    fireEvent.click(screen.getByRole("button", { name: /Initial/ }));
+    const textarea = screen.getByLabelText("名稱") as HTMLTextAreaElement;
+    expect(textarea.tagName).toBe("TEXTAREA");
+    fireEvent.change(textarea, { target: { value: "line1\nline2" } });
+    // Plain Enter should NOT commit in multiline mode.
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSave).not.toHaveBeenCalled();
+    // Cmd+Enter commits.
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    await vi.waitFor(() => expect(onSave).toHaveBeenCalledWith("line1\nline2"));
+  });
+
+  it("disabled prop hides the pencil + skips edit mode", () => {
+    setup({ disabled: true });
+    // No button role — just plain text.
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #76

## Summary
商務人士看到名片寫錯（OCR 拼錯名字、缺翻譯、忘補職位）目前要 click 編輯 → 修一字 → save → back，4 步。Inline edit 讓 hover 點一下、改、blur 就 save，1 步。

## Files
- `src/components/cards/InlineEditField.tsx` (+150) — display→edit→commit primitive
- `src/components/cards/InlineEditField.module.css` — hover-pencil + edit-state styling
- `src/components/cards/CardInlineEdit.tsx` (+70) — Server Action wrapper (`updateCardAction`)
- `src/app/(app)/cards/[id]/page.tsx` — 5 fields wired (nameZh, nameEn, jobTitleZh, companyZh, whyRemember)
- 11 UT (display, click→edit, Enter / blur commit, Esc cancel, trim-equal noop, error state, maxLength, multiline Cmd+Enter, disabled)

## UX details
- Multiline (whyRemember) uses Cmd/Ctrl+Enter to commit so plain Enter still inserts newline
- Trim-equal comparison skips no-op updates (typing then accidentally hitting Enter doesn't fire)
- Optimistic state stays until `router.refresh()` completes — no flash of old value
- Error throws stay in editing mode so user can fix + retry
- ESC restores display + clears any error

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 449 pass (+11 new)
- [x] `pnpm lint` — clean (4 unrelated pre-existing)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — green
- [ ] CI green → merge → mac mini deploy

## Out of scope
- Inline edit phones/emails (multi-value 需更複雜 UI；現有編輯頁適合)
- Inline edit tags (已有 TagSuggestionsBanner 機制)