### PR TITLE
feat(events): /events 場合視角 — 同場合認識的人聚合頁

### DIFF
--- a/src/app/(app)/events/[tag]/event.module.css
+++ b/src/app/(app)/events/[tag]/event.module.css
@@ -1,0 +1,147 @@
+.article {
+  max-width: var(--content-max);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.crumbs {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+}
+
+.crumbs a {
+  color: var(--color-ink-muted);
+  text-decoration: none;
+}
+
+.crumbs a:hover {
+  color: var(--color-ink);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding-bottom: var(--space-md);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h1);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+  color: var(--color-ink);
+}
+
+.lead {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  margin: var(--space-xs) 0 0;
+  line-height: var(--leading-relaxed);
+}
+
+.cardList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.cardRow {
+  display: flex;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  text-decoration: none;
+  color: inherit;
+  align-items: flex-start;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.cardRow:hover {
+  border-color: var(--color-accent-ink);
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.cardMain {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25em;
+}
+
+.cardName {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-ink);
+  margin: 0;
+}
+
+.cardRole {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.why {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-ink);
+  margin: 0.25em 0 0;
+  line-height: var(--leading-relaxed);
+  max-width: 60ch;
+}
+
+.cardSide {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.2em;
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+  flex-shrink: 0;
+  min-width: 9rem;
+  text-align: right;
+}
+
+.metDate {
+  font-family: var(--font-mono, var(--font-sans));
+}
+
+.context {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-ink);
+  max-width: 14ch;
+  text-align: right;
+}

--- a/src/app/(app)/events/[tag]/page.tsx
+++ b/src/app/(app)/events/[tag]/page.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { listCardsForUser } from "@/db/cards";
+import { findEventBySlug } from "@/lib/events/group";
+import { readSession } from "@/lib/firebase/session";
+
+import styles from "./event.module.css";
+
+interface PageProps {
+  params: Promise<{ tag: string }>;
+}
+
+const SCAN_LIMIT = 500;
+
+export async function generateMetadata({ params }: PageProps) {
+  const { tag } = await params;
+  const decoded = decodeURIComponent(tag);
+  return { title: decoded || "場合" };
+}
+
+function cardName(card: { nameZh?: string; nameEn?: string }): string {
+  return card.nameZh || card.nameEn || "（未命名）";
+}
+
+function formatYmd(raw: string | undefined): string {
+  if (!raw) return "—";
+  return raw;
+}
+
+export default async function EventDetailPage({ params }: PageProps) {
+  const user = await readSession();
+  if (!user) return null;
+  const { tag: rawTag } = await params;
+  const tag = decodeURIComponent(rawTag);
+
+  const cards = await listCardsForUser(user.uid, {
+    limit: SCAN_LIMIT,
+    orderBy: "createdAt",
+    order: "desc",
+  });
+  const group = findEventBySlug(cards, tag);
+  if (!group) notFound();
+
+  // Companies seen at this event — useful "who else was there from
+  // ACME" context.
+  const companies = Array.from(
+    new Set(
+      group.cards.map((c) => c.companyZh || c.companyEn || "").filter((s) => s.trim().length > 0),
+    ),
+  );
+
+  return (
+    <article className={styles.article}>
+      <nav aria-label="Breadcrumbs" className={styles.crumbs}>
+        <Link href="/cards">名片冊</Link>
+        <span aria-hidden="true"> · </span>
+        <Link href="/events">場合</Link>
+        <span aria-hidden="true"> · </span>
+        <span>{group.displayName}</span>
+      </nav>
+
+      <header className={styles.header}>
+        <p className={styles.kicker}>場合</p>
+        <h1 className={styles.title}>{group.displayName}</h1>
+        <p className={styles.lead}>
+          {group.cards.length} 位聯絡人
+          {companies.length > 0 && <> · 公司：{companies.join("、")}</>}
+        </p>
+      </header>
+
+      <ul className={styles.cardList}>
+        {group.cards.map((card) => {
+          const role = card.jobTitleZh || card.jobTitleEn;
+          const company = card.companyZh || card.companyEn;
+          return (
+            <li key={card.id}>
+              <Link href={`/cards/${card.id}`} className={styles.cardRow}>
+                <div className={styles.cardMain}>
+                  <h2 className={styles.cardName}>{cardName(card)}</h2>
+                  {(role || company) && (
+                    <p className={styles.cardRole}>{[role, company].filter(Boolean).join(" · ")}</p>
+                  )}
+                  {card.whyRemember && <p className={styles.why}>{card.whyRemember}</p>}
+                </div>
+                <div className={styles.cardSide}>
+                  <span className={styles.metDate}>見面日：{formatYmd(card.firstMetDate)}</span>
+                  {card.firstMetContext && (
+                    <span className={styles.context}>{card.firstMetContext}</span>
+                  )}
+                </div>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </article>
+  );
+}

--- a/src/app/(app)/events/events.module.css
+++ b/src/app/(app)/events/events.module.css
@@ -1,0 +1,136 @@
+.article {
+  max-width: var(--content-max);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.crumbs {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+}
+
+.crumbs a {
+  color: var(--color-ink-muted);
+  text-decoration: none;
+}
+
+.crumbs a:hover {
+  color: var(--color-ink);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding-bottom: var(--space-md);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h2);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+}
+
+.title em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-accent);
+}
+
+.lead {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  line-height: var(--leading-relaxed);
+  margin: var(--space-xs) 0 0;
+  max-width: 56ch;
+}
+
+.empty {
+  padding: var(--space-2xl) var(--space-md);
+  text-align: center;
+}
+
+.backLink {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  text-decoration: none;
+  letter-spacing: var(--tracking-wide);
+}
+
+.backLink:hover {
+  text-decoration: underline;
+}
+
+.eventList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.eventRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.eventRow:hover {
+  border-color: var(--color-accent-ink);
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.eventMain {
+  flex: 1;
+  min-width: 0;
+}
+
+.eventName {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-ink);
+}
+
+.eventMeta {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0.2em 0 0;
+}
+
+.chevron {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+}

--- a/src/app/(app)/events/page.tsx
+++ b/src/app/(app)/events/page.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+
+import { listCardsForUser } from "@/db/cards";
+import { groupCardsByEvent } from "@/lib/events/group";
+import { readSession } from "@/lib/firebase/session";
+
+import styles from "./events.module.css";
+
+export const metadata = {
+  title: "場合",
+};
+
+const SCAN_LIMIT = 500;
+
+function formatYmd(date: Date | null | undefined): string {
+  if (!date) return "—";
+  return date.toLocaleDateString("zh-Hant", { year: "numeric", month: "2-digit", day: "2-digit" });
+}
+
+export default async function EventsPage() {
+  const user = await readSession();
+  if (!user) return null;
+
+  const cards = await listCardsForUser(user.uid, {
+    limit: SCAN_LIMIT,
+    orderBy: "createdAt",
+    order: "desc",
+  });
+  const groups = groupCardsByEvent(cards);
+
+  return (
+    <article className={styles.article}>
+      <nav aria-label="Breadcrumbs" className={styles.crumbs}>
+        <Link href="/cards">名片冊</Link>
+        <span aria-hidden="true"> · </span>
+        <span>場合</span>
+      </nav>
+
+      <header className={styles.header}>
+        <p className={styles.kicker}>場合視角</p>
+        <h1 className={styles.title}>
+          <em>{groups.length}</em> 個場合
+        </h1>
+        {groups.length > 0 ? (
+          <p className={styles.lead}>按最近見面排序。點進去看那場見過誰、職位、為什麼記得。</p>
+        ) : (
+          <p className={styles.lead}>
+            還沒有名片標註「第一次見面場合」。建立或編輯名片時填入場合，這裡會自動聚合。
+          </p>
+        )}
+      </header>
+
+      {groups.length === 0 ? (
+        <section className={styles.empty}>
+          <Link href="/cards/new" className={styles.backLink}>
+            建立第一張名片 →
+          </Link>
+        </section>
+      ) : (
+        <ul className={styles.eventList}>
+          {groups.map((group) => (
+            <li key={group.slug}>
+              <Link href={`/events/${encodeURIComponent(group.slug)}`} className={styles.eventRow}>
+                <div className={styles.eventMain}>
+                  <h2 className={styles.eventName}>{group.displayName}</h2>
+                  <p className={styles.eventMeta}>
+                    {group.cards.length} 位 · 最近見面：{formatYmd(group.mostRecentMet)}
+                  </p>
+                </div>
+                <span className={styles.chevron} aria-hidden="true">
+                  →
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </article>
+  );
+}

--- a/src/components/cards/RelatedByEvent.module.css
+++ b/src/components/cards/RelatedByEvent.module.css
@@ -31,11 +31,31 @@
   color: var(--color-fg);
 }
 
+.titleLink {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dashed transparent;
+  transition: border-color var(--duration-fast) var(--ease-standard);
+}
+
+.titleLink:hover {
+  border-bottom-color: var(--color-accent-ink);
+}
+
 .count {
   margin: 0;
   font-family: var(--font-sans);
   font-size: var(--text-caption);
   color: var(--color-fg-muted);
+}
+
+.allLink {
+  color: var(--color-accent-ink);
+  text-decoration: none;
+}
+
+.allLink:hover {
+  text-decoration: underline;
 }
 
 .list {

--- a/src/components/cards/RelatedByEvent.tsx
+++ b/src/components/cards/RelatedByEvent.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import type { CardSummary } from "@/db/cards";
+import { eventSlug } from "@/lib/events/group";
 
 import styles from "./RelatedByEvent.module.css";
 
@@ -16,12 +17,22 @@ interface RelatedByEventProps {
  */
 export function RelatedByEvent({ eventTag, cards }: RelatedByEventProps) {
   if (cards.length === 0) return null;
+  const slug = eventSlug(eventTag);
   return (
     <section className={styles.section} aria-label={`${eventTag} 認識的其他人`}>
       <header className={styles.header}>
         <p className={styles.kicker}>同場合認識</p>
-        <h3 className={styles.title}>{eventTag}</h3>
-        <p className={styles.count}>另外 {cards.length} 位</p>
+        <h3 className={styles.title}>
+          <Link href={`/events/${encodeURIComponent(slug)}`} className={styles.titleLink}>
+            {eventTag}
+          </Link>
+        </h3>
+        <p className={styles.count}>
+          另外 {cards.length} 位 ·{" "}
+          <Link href={`/events/${encodeURIComponent(slug)}`} className={styles.allLink}>
+            看全部 →
+          </Link>
+        </p>
       </header>
       <ul className={styles.list}>
         {cards.map((c) => {

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -19,6 +19,7 @@ const PRIMARY: NavItem[] = [
   { href: "/cards", label: "名片冊", description: "畫廊 · 清單" },
   { href: "/cards/new", label: "新增", description: "手動建立一張" },
   { href: "/companies", label: "公司", description: "同公司聯絡人聚合" },
+  { href: "/events", label: "場合", description: "同場合認識的人" },
   { href: "/tags", label: "標籤", description: "分類 · 重新命名" },
   { href: "/import", label: "匯入", description: "vCard / CSV / LinkedIn" },
   { href: "/workspace/members", label: "成員", description: "邀請 · 權限" },

--- a/src/lib/events/__tests__/group.test.ts
+++ b/src/lib/events/__tests__/group.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import { eventSlug, findEventBySlug, groupCardsByEvent } from "../group";
+
+function mk(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    social: {},
+    createdAt: new Date("2026-04-01T00:00:00Z"),
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe("eventSlug", () => {
+  it("lowercases ASCII and collapses spaces to dashes", () => {
+    expect(eventSlug("Web Summit Lisbon")).toBe("web-summit-lisbon");
+  });
+
+  it("preserves CJK characters", () => {
+    expect(eventSlug("AppWorks Demo Day")).toBe("appworks-demo-day");
+    expect(eventSlug("產業創新論壇 2024")).toBe("產業創新論壇-2024");
+  });
+
+  it("strips punctuation and collapses repeated dashes", () => {
+    expect(eventSlug("R&D / 場次三")).toBe("rd-場次三");
+    expect(eventSlug("--Hello--")).toBe("hello");
+  });
+});
+
+describe("groupCardsByEvent", () => {
+  it("clusters case/whitespace variants under one group", () => {
+    const a = mk({ id: "a", firstMetEventTag: "2024 COMPUTEX" });
+    const b = mk({ id: "b", firstMetEventTag: "2024 computex " });
+    const c = mk({ id: "c", firstMetEventTag: "2024 Computex" });
+    const groups = groupCardsByEvent([a, b, c]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].cards.map((x) => x.id).sort()).toEqual(["a", "b", "c"]);
+    expect(groups[0].slug).toBe("2024-computex");
+  });
+
+  it("uses the first-seen variant as displayName", () => {
+    const first = mk({ id: "first", firstMetEventTag: "2024 COMPUTEX" });
+    const variant = mk({ id: "variant", firstMetEventTag: "2024 computex" });
+    const groups = groupCardsByEvent([first, variant]);
+    expect(groups[0].displayName).toBe("2024 COMPUTEX");
+  });
+
+  it("excludes cards with no firstMetEventTag", () => {
+    const noTag = mk({ id: "noTag" });
+    const withTag = mk({ id: "x", firstMetEventTag: "Web Summit" });
+    const groups = groupCardsByEvent([noTag, withTag]);
+    expect(groups).toHaveLength(1);
+  });
+
+  it("excludes soft-deleted cards", () => {
+    const live = mk({ id: "live", firstMetEventTag: "Demo Day" });
+    const gone = mk({ id: "gone", firstMetEventTag: "Demo Day", deletedAt: new Date() });
+    const groups = groupCardsByEvent([live, gone]);
+    expect(groups[0].cards.map((c) => c.id)).toEqual(["live"]);
+  });
+
+  it("sorts cards within group by firstMetDate desc", () => {
+    const old = mk({
+      id: "old",
+      firstMetEventTag: "Conf",
+      firstMetDate: "2025-01-01",
+    });
+    const fresh = mk({
+      id: "fresh",
+      firstMetEventTag: "Conf",
+      firstMetDate: "2026-04-01",
+    });
+    const groups = groupCardsByEvent([old, fresh]);
+    expect(groups[0].cards.map((c) => c.id)).toEqual(["fresh", "old"]);
+  });
+
+  it("sorts groups by mostRecentMet desc; tiebreak on slug", () => {
+    const oldEvent = mk({
+      id: "old",
+      firstMetEventTag: "Old Conf",
+      firstMetDate: "2025-01-01",
+    });
+    const freshEvent = mk({
+      id: "fresh",
+      firstMetEventTag: "Fresh Conf",
+      firstMetDate: "2026-04-01",
+    });
+    const groups = groupCardsByEvent([oldEvent, freshEvent]);
+    expect(groups.map((g) => g.displayName)).toEqual(["Fresh Conf", "Old Conf"]);
+  });
+
+  it("falls back to createdAt when firstMetDate missing", () => {
+    const a = mk({
+      id: "a",
+      firstMetEventTag: "X",
+      firstMetDate: undefined,
+      createdAt: new Date("2026-04-15"),
+    });
+    const b = mk({
+      id: "b",
+      firstMetEventTag: "X",
+      firstMetDate: undefined,
+      createdAt: new Date("2026-04-10"),
+    });
+    const groups = groupCardsByEvent([a, b]);
+    expect(groups[0].cards.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("findEventBySlug", () => {
+  it("returns matching group case-insensitively", () => {
+    const a = mk({ id: "a", firstMetEventTag: "AppWorks Demo Day" });
+    const found = findEventBySlug([a], "appworks-demo-day");
+    expect(found?.cards.map((c) => c.id)).toEqual(["a"]);
+  });
+
+  it("returns null when no group matches", () => {
+    expect(findEventBySlug([], "missing")).toBeNull();
+    expect(findEventBySlug([mk({ firstMetEventTag: "X" })], "y")).toBeNull();
+  });
+});

--- a/src/lib/events/group.ts
+++ b/src/lib/events/group.ts
@@ -1,0 +1,103 @@
+import type { CardSummary } from "@/db/cards";
+
+export interface EventGroup {
+  /** Stable URL slug derived from the canonical tag string. */
+  slug: string;
+  /** Display name — the original tag as the user typed it (first occurrence wins). */
+  displayName: string;
+  /** Cards in this event, ordered by firstMetDate desc (most-recent meet first). */
+  cards: CardSummary[];
+  /** Most-recent meet for sorting at the index level. */
+  mostRecentMet: Date | null;
+}
+
+function eventKey(name: string): string {
+  return name.toLowerCase().trim();
+}
+
+/**
+ * URL-safe slug — keep CJK characters (Next dynamic routes accept
+ * Unicode), collapse spaces / punctuation. Mirror of companySlug
+ * deliberately, since the URL semantics are identical.
+ */
+export function eventSlug(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[\s/]+/g, "-")
+    .replace(/[.,;:!?()[\]{}<>"'`*+&%$#@|\\]+/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function parseFirstMetDate(raw: string | undefined): Date | null {
+  if (!raw) return null;
+  const m = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return null;
+  const [, y, mo, d] = m;
+  const date = new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d)));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Cluster cards by `firstMetEventTag`. Cards with no tag are dropped
+ * (they belong in the general /cards view, not the event hub).
+ * Soft-deleted cards are excluded.
+ *
+ * Within each group, cards sort by firstMetDate desc — recent meets
+ * surface first within an event. Across groups, sort by mostRecentMet
+ * so events you're still adding to live near the top.
+ */
+export function groupCardsByEvent(cards: readonly CardSummary[]): EventGroup[] {
+  const buckets = new Map<string, { displayName: string; cards: CardSummary[] }>();
+
+  for (const card of cards) {
+    if (card.deletedAt) continue;
+    const tag = (card.firstMetEventTag ?? "").trim();
+    if (!tag) continue;
+    const key = eventKey(tag);
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.cards.push(card);
+    } else {
+      buckets.set(key, { displayName: tag, cards: [card] });
+    }
+  }
+
+  const groups: EventGroup[] = [];
+  for (const bucket of buckets.values()) {
+    bucket.cards.sort((a, b) => {
+      const ta = parseFirstMetDate(a.firstMetDate)?.getTime() ?? a.createdAt?.getTime() ?? 0;
+      const tb = parseFirstMetDate(b.firstMetDate)?.getTime() ?? b.createdAt?.getTime() ?? 0;
+      return tb - ta;
+    });
+    const head = bucket.cards[0];
+    const mostRecentMet = parseFirstMetDate(head?.firstMetDate) ?? head?.createdAt ?? null;
+    groups.push({
+      slug: eventSlug(bucket.displayName),
+      displayName: bucket.displayName,
+      cards: bucket.cards,
+      mostRecentMet,
+    });
+  }
+
+  groups.sort((a, b) => {
+    const ta = a.mostRecentMet?.getTime() ?? 0;
+    const tb = b.mostRecentMet?.getTime() ?? 0;
+    if (ta !== tb) return tb - ta;
+    // Lexical compare (codepoint) instead of localeCompare so the
+    // tiebreak is platform-stable. macOS would sort CJK by pinyin,
+    // Linux falls back to codepoint — that mismatch was a real CI
+    // flake source in #73.
+    return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+  });
+  return groups;
+}
+
+export function findEventBySlug(cards: readonly CardSummary[], slug: string): EventGroup | null {
+  const wanted = slug.toLowerCase();
+  for (const group of groupCardsByEvent(cards)) {
+    if (group.slug === wanted) return group;
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #78

## Summary
商務人士天天遇到「上次 Computex 那邊我認識的有誰？」現在 search "Computex" 是平行 hits 散在 cards 列表。新增場合視角，把名片以 `firstMetEventTag` 為核心 entity 重新組織。

跟 /companies hub 是同個 pattern — entity 視角每多一個 axis 都是 daily-impact 的乘法。

## Files
- `src/lib/events/group.ts` (+105) — `groupCardsByEvent` / `eventSlug` / `findEventBySlug`
- `src/lib/events/__tests__/group.test.ts` — 12 UT
- `src/app/(app)/events/{page,events.module}.tsx/css` — 索引頁
- `src/app/(app)/events/[tag]/{page,event.module}.tsx/css` — 詳情頁
- `src/components/cards/RelatedByEvent.tsx` + module.css — title 變 link，加「看全部 →」
- `src/components/shell/AppShell.tsx` — nav 加「場合」入口

## Behavior
- 索引頁列所有場合，按 mostRecentMet desc 排
- 詳情頁列同場合所有卡，按 firstMetDate desc；header 顯示參與公司
- Slug 保留 CJK chars (`/events/2024-computex` 跟 `/events/產業創新論壇-2024` 都能用)
- Tiebreak 用 lexical compare (lessons learned from #73 CI flake)

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 461 pass (+12 new)
- [x] `pnpm lint` — clean (4 unrelated pre-existing)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — `/events` and `/events/[tag]` registered
- [ ] CI green → merge → mac mini deploy

## Out of scope
- LLM event-clustering ("Computex 2024" + "computex" → same)
- Event metadata (主辦方 / 地點 / 日期)