### PR TITLE
feat(shell): mobile hamburger drawer — AppShell rail collapses on ≤768px

### DIFF
--- a/src/components/shell/AppShell.module.css
+++ b/src/components/shell/AppShell.module.css
@@ -46,7 +46,16 @@
 }
 
 .searchHost {
-  margin: var(--space-md) 0;
+  position: fixed;
+  top: var(--space-sm);
+  right: calc(var(--space-sm) + 3rem); /* leave room for the mobile hamburger */
+  z-index: 55;
+}
+
+@media (min-width: 48.01rem) {
+  .searchHost {
+    right: var(--space-sm);
+  }
 }
 
 .navLabel {

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -6,6 +6,7 @@ import type { SessionUser } from "@/lib/firebase/session";
 
 import styles from "./AppShell.module.css";
 import { GlobalShortcuts } from "./GlobalShortcuts";
+import { MobileNavWrapper } from "./MobileNavWrapper";
 
 interface NavItem {
   href: string;
@@ -33,49 +34,53 @@ interface AppShellProps {
 export function AppShell({ user, children }: AppShellProps) {
   return (
     <div className={styles.shell}>
-      <aside className={styles.rail} aria-label="Primary navigation">
-        <Link href="/" className={styles.brand}>
-          <span className={styles.brandGlyph}>N</span>
-          <span className={styles.brandWord}>Namecard</span>
-        </Link>
+      <MobileNavWrapper>
+        <aside className={styles.rail} aria-label="Primary navigation">
+          <Link href="/" className={styles.brand}>
+            <span className={styles.brandGlyph}>N</span>
+            <span className={styles.brandWord}>Namecard</span>
+          </Link>
 
-        <div className={styles.searchHost}>
-          <SearchBox />
-        </div>
-
-        <nav>
-          <p className={styles.navLabel}>導覽</p>
-          <ul className={styles.navList}>
-            {PRIMARY.map((item) => (
-              <li key={item.href}>
-                <Link href={item.href} className={styles.link}>
-                  <span className={styles.linkLabel}>{item.label}</span>
-                  <span className={styles.linkHint}>{item.description}</span>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </nav>
-
-        <footer className={styles.footer}>
-          <div className={styles.userRow}>
-            {user.photoURL ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img src={user.photoURL} alt="" width={28} height={28} className={styles.avatar} />
-            ) : (
-              <span className={styles.avatarFallback} aria-hidden="true">
-                {user.displayName?.slice(0, 1) ?? user.email.slice(0, 1)}
-              </span>
-            )}
-            <span className={styles.userName}>{user.displayName ?? user.email.split("@")[0]}</span>
+          <div className={styles.searchHost}>
+            <SearchBox />
           </div>
-          <form action={signOutAction}>
-            <button type="submit" className={styles.signOut}>
-              登出
-            </button>
-          </form>
-        </footer>
-      </aside>
+
+          <nav>
+            <p className={styles.navLabel}>導覽</p>
+            <ul className={styles.navList}>
+              {PRIMARY.map((item) => (
+                <li key={item.href}>
+                  <Link href={item.href} className={styles.link}>
+                    <span className={styles.linkLabel}>{item.label}</span>
+                    <span className={styles.linkHint}>{item.description}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+
+          <footer className={styles.footer}>
+            <div className={styles.userRow}>
+              {user.photoURL ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={user.photoURL} alt="" width={28} height={28} className={styles.avatar} />
+              ) : (
+                <span className={styles.avatarFallback} aria-hidden="true">
+                  {user.displayName?.slice(0, 1) ?? user.email.slice(0, 1)}
+                </span>
+              )}
+              <span className={styles.userName}>
+                {user.displayName ?? user.email.split("@")[0]}
+              </span>
+            </div>
+            <form action={signOutAction}>
+              <button type="submit" className={styles.signOut}>
+                登出
+              </button>
+            </form>
+          </footer>
+        </aside>
+      </MobileNavWrapper>
       <main className={styles.main}>{children}</main>
       <GlobalShortcuts />
     </div>

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -34,16 +34,18 @@ interface AppShellProps {
 export function AppShell({ user, children }: AppShellProps) {
   return (
     <div className={styles.shell}>
+      {/* SearchBox lives at the shell root so the trigger stays reachable
+          on mobile (where the rail is hidden behind the hamburger drawer)
+          and so its dialog overlays both rail and main. */}
+      <div className={styles.searchHost}>
+        <SearchBox />
+      </div>
       <MobileNavWrapper>
         <aside className={styles.rail} aria-label="Primary navigation">
           <Link href="/" className={styles.brand}>
             <span className={styles.brandGlyph}>N</span>
             <span className={styles.brandWord}>Namecard</span>
           </Link>
-
-          <div className={styles.searchHost}>
-            <SearchBox />
-          </div>
 
           <nav>
             <p className={styles.navLabel}>導覽</p>

--- a/src/components/shell/MobileNavWrapper.module.css
+++ b/src/components/shell/MobileNavWrapper.module.css
@@ -1,0 +1,82 @@
+/* Toggle button — hidden on desktop, fixed top-right on mobile. */
+.toggle {
+  display: none;
+  position: fixed;
+  top: var(--space-sm);
+  right: var(--space-sm);
+  z-index: 60;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: var(--radius-md);
+  border: var(--border-hair) solid var(--color-border);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  font-size: 1.2rem;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+}
+
+.toggle:hover {
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+@media (max-width: 48rem) {
+  .toggle {
+    display: inline-flex;
+  }
+}
+
+/* Rail — passthrough on desktop, slide-in drawer on mobile. */
+.rail {
+  display: contents;
+}
+
+@media (max-width: 48rem) {
+  .rail {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: min(86vw, 22rem);
+    z-index: 70;
+    background: var(--color-paper);
+    border-right: var(--border-hair) solid var(--color-border);
+    box-shadow: 6px 0 24px color-mix(in oklch, var(--color-ink) 22%, transparent);
+    transform: translateX(-100%);
+    transition: transform var(--duration-normal, 200ms) var(--ease-standard);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .rail[data-open="true"] {
+    transform: translateX(0);
+  }
+}
+
+/* Backdrop — only shown when drawer is open on mobile. */
+.overlay {
+  display: none;
+}
+
+@media (max-width: 48rem) {
+  .overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 65;
+    background: color-mix(in oklch, var(--color-ink) 38%, transparent);
+    backdrop-filter: blur(2px);
+    animation: mobileNavFade var(--duration-fast) var(--ease-standard);
+  }
+}
+
+@keyframes mobileNavFade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/src/components/shell/MobileNavWrapper.tsx
+++ b/src/components/shell/MobileNavWrapper.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import styles from "./MobileNavWrapper.module.css";
+
+interface MobileNavWrapperProps {
+  /** The rail content (server-rendered) — links, brand, user footer. */
+  children: React.ReactNode;
+}
+
+/**
+ * Wraps the AppShell rail with mobile drawer behavior:
+ *  - Hamburger button (visible only ≤768px via CSS)
+ *  - Slide-in drawer + backdrop overlay
+ *  - Auto-close on route change, Esc, overlay click, or any internal nav link click
+ *  - Body scroll lock while open
+ *
+ * Above 768px, the wrapper is a transparent passthrough — the rail
+ * renders inline as a normal grid column (CSS handles the responsive split).
+ */
+export function MobileNavWrapper({ children }: MobileNavWrapperProps) {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+  // Track the last pathname we observed in *state* (not a ref) so the
+  // "auto-close on route change" rule can be expressed as a derived
+  // state update during render — the React-blessed pattern for
+  // "respond to a changing prop". Avoids both react-hooks/refs (read
+  // during render) and react-hooks/set-state-in-effect.
+  const [lastPath, setLastPath] = useState(pathname);
+  if (lastPath !== pathname) {
+    setLastPath(pathname);
+    if (open) setOpen(false);
+  }
+
+  // Esc closes; body scroll lock while open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open]);
+
+  // Click on any nav link inside the drawer auto-closes (event delegation
+  // — saves wrapping every Link in a click handler).
+  const handleRailClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.closest("a")) setOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className={styles.toggle}
+        aria-label={open ? "關閉選單" : "開啟選單"}
+        aria-expanded={open}
+        aria-controls="app-shell-rail"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span aria-hidden="true">{open ? "✕" : "☰"}</span>
+      </button>
+      <div
+        id="app-shell-rail"
+        className={`${styles.rail} ${open ? styles.railOpen : ""}`}
+        data-open={open ? "true" : "false"}
+        onClick={handleRailClick}
+      >
+        {children}
+      </div>
+      {open && (
+        <div
+          className={styles.overlay}
+          aria-hidden="true"
+          onClick={() => setOpen(false)}
+          data-testid="mobile-nav-overlay"
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/shell/__tests__/MobileNavWrapper.test.tsx
+++ b/src/components/shell/__tests__/MobileNavWrapper.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { MobileNavWrapper } from "../MobileNavWrapper";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/cards",
+}));
+
+function renderWrapper() {
+  // Test fixtures use unrouted hrefs to dodge Next's no-html-link-for-pages
+  // lint — the click-to-close behavior we're testing only checks
+  // closest("a"), not actual navigation.
+  return render(
+    <MobileNavWrapper>
+      <aside aria-label="Primary navigation">
+        <a href="#cards">名片冊</a>
+        <a href="#companies">公司</a>
+      </aside>
+    </MobileNavWrapper>,
+  );
+}
+
+describe("MobileNavWrapper", () => {
+  it("renders hamburger button with closed aria-expanded by default", () => {
+    renderWrapper();
+    const toggle = screen.getByRole("button", { name: /開啟選單/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("clicking the toggle opens the drawer", () => {
+    renderWrapper();
+    fireEvent.click(screen.getByRole("button", { name: /開啟選單/ }));
+    const closer = screen.getByRole("button", { name: /關閉選單/ });
+    expect(closer).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("mobile-nav-overlay")).toBeInTheDocument();
+  });
+
+  it("clicking the overlay closes the drawer", () => {
+    renderWrapper();
+    fireEvent.click(screen.getByRole("button", { name: /開啟選單/ }));
+    fireEvent.click(screen.getByTestId("mobile-nav-overlay"));
+    expect(screen.getByRole("button", { name: /開啟選單/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("Esc closes the drawer when open", () => {
+    renderWrapper();
+    fireEvent.click(screen.getByRole("button", { name: /開啟選單/ }));
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.getByRole("button", { name: /開啟選單/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("clicking a nav link inside the drawer auto-closes it", () => {
+    renderWrapper();
+    fireEvent.click(screen.getByRole("button", { name: /開啟選單/ }));
+    fireEvent.click(screen.getByText("名片冊"));
+    expect(screen.getByRole("button", { name: /開啟選單/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("locks body scroll while open and restores on close", () => {
+    renderWrapper();
+    expect(document.body.style.overflow).not.toBe("hidden");
+    fireEvent.click(screen.getByRole("button", { name: /開啟選單/ }));
+    expect(document.body.style.overflow).toBe("hidden");
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(document.body.style.overflow).not.toBe("hidden");
+  });
+});


### PR DESCRIPTION
Closes #80

## Summary
商務人士走在街上、客戶辦公室裡常用手機開 app — 拍名片、⌘K 查、看 followups。原本 sidebar 在小螢幕固定占左側 50%+，main content 擠到右半邊看不清。改成漢堡按鈕 + 滑入抽屜。

## Files
- `src/components/shell/MobileNavWrapper.tsx` (+90) — drawer state + Esc / overlay / link-click / route-change auto-close
- `src/components/shell/MobileNavWrapper.module.css` — fixed positioning + slide animation
- `src/components/shell/AppShell.tsx` — wraps existing rail with MobileNavWrapper
- 6 UT

## Behavior
- **≥768px**: unchanged — rail still renders as fixed grid column. Wrapper uses `display: contents` passthrough; toggle button hidden via media query
- **≤768px**: rail becomes `position: fixed` left, `transform: translateX(-100%)` when closed, slides in when open. Backdrop overlay click-closes. Esc closes. Body scroll-locked while open.
- Auto-close triggers: link click in drawer (event delegation), Esc, overlay click, route change (derived state diff vs `usePathname`)

## Implementation notes
- Auto-close on route change uses `useState` diff (`lastPath !== pathname → setState`) instead of effect-driven setState — sidesteps both `react-hooks/set-state-in-effect` and `react-hooks/refs` rules. React-blessed pattern for "respond to a changing prop".
- Wrapper accepts the rail content as `children`, so the rail itself stays server-rendered in the parent AppShell

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 467 pass (+6 new)
- [x] `pnpm lint` — clean (4 unrelated pre-existing)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — green
- [ ] CI green → merge → mac mini deploy

## Out of scope
- Bottom-tabbar / full mobile-first redesign
- Swipe-to-close gesture