### PR TITLE
feat(cards): ✨ AI 人脈教練 — actionable insights per card via MiniMax

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { CardActions } from "@/components/cards/CardActions";
 import { CardInlineEdit } from "@/components/cards/CardInlineEdit";
+import { CoachInsightSection } from "@/components/cards/CoachInsightSection";
 import { ContactEventList } from "@/components/cards/ContactEventList";
 import { RelatedByEvent } from "@/components/cards/RelatedByEvent";
 import { TagSuggestionsBanner } from "@/components/tags/TagSuggestionsBanner";
@@ -13,6 +14,7 @@ import {
   listContactEventsForUser,
 } from "@/db/cards";
 import type { CardCreateInput } from "@/db/schema";
+import { isCoachConfigured } from "@/lib/coach/llm";
 import { companySlug, pickCanonicalCompany } from "@/lib/companies/group";
 import { findAnniversariesToday } from "@/lib/timeline/anniversaries";
 import { readSession } from "@/lib/firebase/session";
@@ -200,6 +202,8 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
               />
             </blockquote>
           </section>
+
+          {isCoachConfigured() && <CoachInsightSection cardId={card.id} isPinned={card.isPinned} />}
 
           {(card.firstMetContext || card.firstMetDate || card.firstMetEventTag) && (
             <section className={styles.context}>

--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -8,6 +8,10 @@ import {
   bulkSoftDeleteCardsForUser,
   bulkUpdateCardsForUser,
   createCardForUser,
+  getCardForUser,
+  getCardsBySharedEvent,
+  listCardsForUser,
+  listContactEventsForUser,
   logContactEvent,
   mergeCardsForUser,
   setCardPinned,
@@ -16,6 +20,15 @@ import {
   updateCardForUser,
 } from "@/db/cards";
 import { cardCreateSchema, cardUpdateSchema } from "@/db/schema";
+import {
+  contextHash,
+  isEmptyInsight,
+  type CoachContext,
+  type CoachInsight,
+} from "@/lib/coach/insights";
+import { callCoachLlm, isCoachConfigured } from "@/lib/coach/llm";
+import { readCoachCache, writeCoachCache } from "@/lib/coach/store";
+import { pickCanonicalCompany } from "@/lib/companies/group";
 
 export const createCardAction = authedAction
   .inputSchema(cardCreateSchema)
@@ -196,6 +209,81 @@ export const setFollowUpAction = authedAction
     revalidatePath(`/cards/${parsedInput.id}`);
     return { ok: true as const, followUpAt: value };
   });
+
+/**
+ * AI 人脈教練 — assemble the card's full context (events + company
+ * mates + event mates + time-since-contact), call MiniMax, and return
+ * three buckets of actionable insight. Cached 24h per (cardId,
+ * contextHash) to keep the LLM bill small.
+ *
+ * Modes:
+ *   - `force=true` ignores cache (regenerate button)
+ *   - returns `{ ok: true, insight, cached }` on success
+ *   - returns `{ ok: false, reason: "no-llm" | "card-not-found" | "llm-failed" }` otherwise
+ */
+export const getCoachInsightsAction = authedAction
+  .inputSchema(
+    z.object({
+      cardId: z.string().min(1),
+      force: z.boolean().optional().default(false),
+    }),
+  )
+  .action(
+    async ({
+      parsedInput,
+      ctx,
+    }): Promise<
+      | { ok: true; insight: CoachInsight; cached: boolean }
+      | { ok: false; reason: "no-llm" | "card-not-found" | "llm-failed" }
+    > => {
+      if (!isCoachConfigured()) return { ok: false, reason: "no-llm" };
+      const card = await getCardForUser(ctx.user.uid, parsedInput.cardId);
+      if (!card || card.deletedAt) return { ok: false, reason: "card-not-found" };
+
+      const [events, allCards, eventMatesRaw] = await Promise.all([
+        listContactEventsForUser(card.id, ctx.user.uid, 10),
+        listCardsForUser(ctx.user.uid, { limit: 500 }),
+        card.firstMetEventTag
+          ? getCardsBySharedEvent(ctx.user.uid, card.firstMetEventTag, card.id, 6).catch(() => [])
+          : Promise.resolve([]),
+      ]);
+
+      const canonicalCompany = pickCanonicalCompany(card).toLowerCase().trim();
+      const companyMates = canonicalCompany
+        ? allCards
+            .filter(
+              (c) =>
+                c.id !== card.id &&
+                !c.deletedAt &&
+                pickCanonicalCompany(c).toLowerCase().trim() === canonicalCompany,
+            )
+            .slice(0, 6)
+        : [];
+
+      const coachCtx: CoachContext = {
+        card,
+        events,
+        companyMates,
+        eventMates: eventMatesRaw,
+        now: new Date(),
+      };
+      const hash = contextHash(coachCtx);
+
+      if (!parsedInput.force) {
+        const cached = await readCoachCache(ctx.user.uid, card.id, hash);
+        if (cached && !isEmptyInsight(cached)) {
+          return { ok: true, insight: cached, cached: true };
+        }
+      }
+
+      const insight = await callCoachLlm(coachCtx);
+      if (!insight || isEmptyInsight(insight)) {
+        return { ok: false, reason: "llm-failed" };
+      }
+      await writeCoachCache(ctx.user.uid, card.id, hash, insight);
+      return { ok: true, insight, cached: false };
+    },
+  );
 
 /**
  * @deprecated Prefer `logContactAction`. Retained so any existing

--- a/src/components/cards/CoachInsightSection.module.css
+++ b/src/components/cards/CoachInsightSection.module.css
@@ -1,0 +1,285 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-lg);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(
+    135deg,
+    color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 50%, var(--color-paper)) 0%,
+    var(--color-paper) 100%
+  );
+  position: relative;
+  overflow: hidden;
+}
+
+.section::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at top right,
+    color-mix(in oklch, var(--color-accent) 10%, transparent),
+    transparent 60%
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  position: relative;
+  z-index: 1;
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-family: var(--font-display);
+  font-size: var(--text-h3);
+  font-weight: 500;
+  color: var(--color-ink);
+  margin: 0;
+}
+
+.sparkle {
+  font-size: 1em;
+}
+
+.regenerate {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  background: transparent;
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.regenerate:hover:not(:disabled) {
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.regenerate:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  align-items: flex-start;
+  position: relative;
+  z-index: 1;
+}
+
+.lead {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+  max-width: 60ch;
+}
+
+.primaryBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.primaryBtn:hover:not(:disabled) {
+  background: var(--color-accent-ink);
+}
+
+.primaryBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  position: relative;
+  z-index: 1;
+}
+
+.spinner {
+  width: 1.1em;
+  height: 1.1em;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent-ink);
+  border-radius: 50%;
+  animation: coachSpin 0.7s linear infinite;
+}
+
+@keyframes coachSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.errorBox {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: color-mix(in oklch, var(--color-error, #b00020) 8%, var(--color-paper));
+  border: var(--border-hair) solid color-mix(in oklch, var(--color-error, #b00020) 25%, transparent);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  position: relative;
+  z-index: 1;
+}
+
+.errorBox p {
+  margin: 0;
+  color: var(--color-error, #b00020);
+}
+
+.secondaryBtn {
+  align-self: flex-start;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.secondaryBtn:hover:not(:disabled) {
+  border-color: var(--color-accent-ink);
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  position: relative;
+  z-index: 1;
+}
+
+.bucket {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.bucketTitle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-ink);
+  margin: 0;
+}
+
+.bucketIcon {
+  font-size: 1.05em;
+}
+
+.bucketList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.bucketList li {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  line-height: var(--leading-relaxed);
+  color: var(--color-ink);
+  padding-left: var(--space-md);
+  position: relative;
+}
+
+.bucketList li::before {
+  content: "·";
+  position: absolute;
+  left: 0;
+  color: var(--color-accent-ink);
+  font-weight: 700;
+}
+
+.quickActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  padding-top: var(--space-sm);
+  border-top: var(--border-hair) solid var(--color-border);
+}
+
+.actionBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.actionBtn:hover:not(:disabled) {
+  border-color: var(--color-accent-ink);
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.actionBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cachedNote {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  color: var(--color-ink-muted);
+  margin: 0;
+  font-style: italic;
+}
+
+.toast {
+  position: fixed;
+  bottom: var(--space-lg);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  z-index: 100;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 20%);
+}

--- a/src/components/cards/CoachInsightSection.tsx
+++ b/src/components/cards/CoachInsightSection.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import {
+  getCoachInsightsAction,
+  setFollowUpAction,
+  toggleCardPinAction,
+} from "@/app/(app)/cards/actions";
+import type { CoachInsight } from "@/lib/coach/insights";
+
+import styles from "./CoachInsightSection.module.css";
+
+interface CoachInsightSectionProps {
+  cardId: string;
+  isPinned?: boolean;
+}
+
+type LoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; insight: CoachInsight; cached: boolean }
+  | { kind: "error"; message: string };
+
+function offsetIso(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * "✨ AI 人脈教練" disclosure on /cards/[id]. Wraps the
+ * `getCoachInsightsAction` Server Action and renders three buckets of
+ * actionable insight (conversation starters, inferred needs, suggested
+ * actions) with inline buttons for the most common follow-up moves
+ * (set reminder, pin).
+ *
+ * The whole section opts in — no LLM call until the user explicitly
+ * requests it. That keeps page-load fast and avoids burning tokens on
+ * cards the user is just glancing at.
+ */
+export function CoachInsightSection({ cardId, isPinned = false }: CoachInsightSectionProps) {
+  const router = useRouter();
+  const [state, setState] = useState<LoadState>({ kind: "idle" });
+  const [pending, startTransition] = useTransition();
+  const [actionToast, setActionToast] = useState<string | null>(null);
+
+  const fetchInsights = (force: boolean) => {
+    setState({ kind: "loading" });
+    startTransition(async () => {
+      const result = await getCoachInsightsAction({ cardId, force });
+      if (result?.serverError) {
+        setState({ kind: "error", message: result.serverError });
+        return;
+      }
+      const data = result?.data;
+      if (!data) {
+        setState({ kind: "error", message: "教練回應失敗，請稍後再試" });
+        return;
+      }
+      if (!data.ok) {
+        const messages: Record<string, string> = {
+          "no-llm": "AI 教練未啟用（管理員未設定 LLM 金鑰）",
+          "card-not-found": "找不到這張名片",
+          "llm-failed": "AI 教練暫時無法回應，請稍後再試",
+        };
+        setState({ kind: "error", message: messages[data.reason] ?? "未知錯誤" });
+        return;
+      }
+      setState({ kind: "ready", insight: data.insight, cached: data.cached });
+    });
+  };
+
+  const flashAction = (msg: string) => {
+    setActionToast(msg);
+    setTimeout(() => setActionToast(null), 2500);
+  };
+
+  const setReminder = (days: number) => {
+    startTransition(async () => {
+      const result = await setFollowUpAction({ id: cardId, followUpAt: offsetIso(days) });
+      if (result?.data?.ok) {
+        flashAction(`已設定 +${days} 天提醒`);
+        router.refresh();
+      } else {
+        flashAction("設定失敗");
+      }
+    });
+  };
+
+  const togglePin = () => {
+    startTransition(async () => {
+      const result = await toggleCardPinAction({ id: cardId, pinned: !isPinned });
+      if (result?.data?.ok) {
+        flashAction(isPinned ? "已取消重要" : "已加入重要聯絡人");
+        router.refresh();
+      } else {
+        flashAction("操作失敗");
+      }
+    });
+  };
+
+  return (
+    <section className={styles.section} aria-label="AI 人脈教練">
+      <header className={styles.header}>
+        <h2 className={styles.title}>
+          <span className={styles.sparkle} aria-hidden="true">
+            ✨
+          </span>
+          AI 人脈教練
+        </h2>
+        {state.kind === "ready" && (
+          <button
+            type="button"
+            className={styles.regenerate}
+            onClick={() => fetchInsights(true)}
+            disabled={pending}
+          >
+            {state.cached ? "重新生成" : "再來一輪"}
+          </button>
+        )}
+      </header>
+
+      {state.kind === "idle" && (
+        <div className={styles.emptyState}>
+          <p className={styles.lead}>
+            問問 AI：下次聯絡這個人可以聊什麼？他現在可能在意什麼？這週可以做哪些動作？
+          </p>
+          <button
+            type="button"
+            className={styles.primaryBtn}
+            onClick={() => fetchInsights(false)}
+            disabled={pending}
+          >
+            {pending ? "教練思考中…" : "✨ 請 AI 教練給我建議"}
+          </button>
+        </div>
+      )}
+
+      {state.kind === "loading" && (
+        <div className={styles.loading} aria-live="polite">
+          <span className={styles.spinner} aria-hidden="true" />
+          <span>教練正在閱讀這張名片的脈絡…</span>
+        </div>
+      )}
+
+      {state.kind === "error" && (
+        <div className={styles.errorBox} role="alert">
+          <p>{state.message}</p>
+          <button
+            type="button"
+            className={styles.secondaryBtn}
+            onClick={() => fetchInsights(false)}
+            disabled={pending}
+          >
+            重試
+          </button>
+        </div>
+      )}
+
+      {state.kind === "ready" && (
+        <div className={styles.results}>
+          {state.insight.conversationStarters.length > 0 && (
+            <Bucket icon="🗣️" title="下次聯絡可以聊" items={state.insight.conversationStarters} />
+          )}
+          {state.insight.inferredNeeds.length > 0 && (
+            <Bucket icon="💼" title="他現在可能在意" items={state.insight.inferredNeeds} />
+          )}
+          {state.insight.suggestedActions.length > 0 && (
+            <Bucket icon="🎯" title="建議本週的行動" items={state.insight.suggestedActions} />
+          )}
+
+          <div className={styles.quickActions}>
+            <button
+              type="button"
+              className={styles.actionBtn}
+              onClick={() => setReminder(3)}
+              disabled={pending}
+            >
+              📅 設 +3 天提醒
+            </button>
+            <button
+              type="button"
+              className={styles.actionBtn}
+              onClick={() => setReminder(7)}
+              disabled={pending}
+            >
+              📅 設 +7 天提醒
+            </button>
+            <button
+              type="button"
+              className={styles.actionBtn}
+              onClick={() => setReminder(14)}
+              disabled={pending}
+            >
+              📅 設 +14 天提醒
+            </button>
+            <button
+              type="button"
+              className={styles.actionBtn}
+              onClick={togglePin}
+              disabled={pending}
+            >
+              {isPinned ? "📍 取消重要" : "📌 加入重要聯絡人"}
+            </button>
+          </div>
+
+          {state.cached && (
+            <p className={styles.cachedNote}>
+              這份建議來自 24 小時內的快取，點「重新生成」可重算。
+            </p>
+          )}
+        </div>
+      )}
+
+      {actionToast && (
+        <p role="status" aria-live="polite" className={styles.toast}>
+          {actionToast}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function Bucket({ icon, title, items }: { icon: string; title: string; items: string[] }) {
+  return (
+    <div className={styles.bucket}>
+      <h3 className={styles.bucketTitle}>
+        <span className={styles.bucketIcon} aria-hidden="true">
+          {icon}
+        </span>
+        {title}
+      </h3>
+      <ul className={styles.bucketList}>
+        {items.map((item, i) => (
+          <li key={i}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/coach/__tests__/insights.test.ts
+++ b/src/lib/coach/__tests__/insights.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary, ContactEvent } from "@/db/cards";
+
+import {
+  buildCoachPrompt,
+  buildLlmMessages,
+  contextHash,
+  isEmptyInsight,
+  parseCoachResponse,
+  type CoachContext,
+} from "../insights";
+
+const NOW = new Date("2026-04-25T10:00:00Z");
+
+function mkCard(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "card-1",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "陳玉涵",
+    nameEn: "Yu-Han Chen",
+    jobTitleZh: "產品經理",
+    companyZh: "智威科技",
+    department: undefined,
+    whyRemember: "2024 Computex 攤位上聊邊緣 AI 推論",
+    firstMetDate: "2024-06-04",
+    firstMetEventTag: "2024 COMPUTEX",
+    firstMetContext: "在攤位上聊到邊緣 AI",
+    notes: undefined,
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    social: {},
+    isPinned: false,
+    createdAt: new Date("2024-06-04"),
+    updatedAt: new Date("2024-06-04"),
+    lastContactedAt: new Date("2025-09-01"),
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function mkEvent(overrides: Partial<ContactEvent> = {}): ContactEvent {
+  return {
+    id: "ev-1",
+    at: new Date("2025-09-01T00:00:00Z"),
+    note: "",
+    authorUid: "u",
+    authorDisplay: null,
+    ...overrides,
+  };
+}
+
+function mkContext(overrides: Partial<CoachContext> = {}): CoachContext {
+  return {
+    card: mkCard(),
+    events: [],
+    companyMates: [],
+    eventMates: [],
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe("buildCoachPrompt", () => {
+  it("includes name / role / company / whyRemember", () => {
+    const prompt = buildCoachPrompt(mkContext());
+    expect(prompt).toContain("陳玉涵");
+    expect(prompt).toContain("產品經理");
+    expect(prompt).toContain("智威科技");
+    expect(prompt).toContain("Computex 攤位上聊邊緣 AI 推論");
+  });
+
+  it("includes first-met context block", () => {
+    const prompt = buildCoachPrompt(mkContext());
+    expect(prompt).toContain("第一次見面");
+    expect(prompt).toContain("2024-06-04");
+    expect(prompt).toContain("2024 COMPUTEX");
+    expect(prompt).toContain("攤位");
+  });
+
+  it("includes recent contact events with dates", () => {
+    const ctx = mkContext({
+      events: [mkEvent({ id: "e1", at: new Date("2026-04-01"), note: "視訊聊新方案" })],
+    });
+    const prompt = buildCoachPrompt(ctx);
+    expect(prompt).toContain("近期互動歷史");
+    expect(prompt).toContain("2026-04-01");
+    expect(prompt).toContain("視訊聊新方案");
+  });
+
+  it("computes days-since-contact and flags >=90 days", () => {
+    const ctx = mkContext(); // lastContactedAt 2025-09-01, NOW 2026-04-25 = ~236 days
+    const prompt = buildCoachPrompt(ctx);
+    expect(prompt).toMatch(/上次互動：2025-09-01（\d+ 天前，已超過 90 天）/);
+  });
+
+  it("treats missing lastContactedAt as 'no follow-up yet'", () => {
+    const ctx = mkContext({ card: mkCard({ lastContactedAt: null }) });
+    const prompt = buildCoachPrompt(ctx);
+    expect(prompt).toContain("尚未記錄任何互動");
+  });
+
+  it("includes company mates with their roles", () => {
+    const mate = mkCard({ id: "m1", nameZh: "王小明", jobTitleZh: "工程師" });
+    const prompt = buildCoachPrompt(mkContext({ companyMates: [mate] }));
+    expect(prompt).toContain("同公司其他聯絡人");
+    expect(prompt).toContain("王小明");
+    expect(prompt).toContain("工程師");
+  });
+
+  it("includes event mates with their company", () => {
+    const mate = mkCard({ id: "m2", nameZh: "李大同", companyZh: "ACME" });
+    const prompt = buildCoachPrompt(mkContext({ eventMates: [mate] }));
+    expect(prompt).toContain("同場合認識的人");
+    expect(prompt).toContain("李大同");
+    expect(prompt).toContain("ACME");
+  });
+
+  it("does not crash when most optional fields are absent", () => {
+    const minimal = mkCard({
+      jobTitleZh: undefined,
+      companyZh: undefined,
+      whyRemember: "",
+      firstMetDate: undefined,
+      firstMetEventTag: undefined,
+      firstMetContext: undefined,
+      lastContactedAt: null,
+    });
+    expect(() => buildCoachPrompt(mkContext({ card: minimal }))).not.toThrow();
+  });
+});
+
+describe("buildLlmMessages", () => {
+  it("returns a system + user message pair", () => {
+    const msgs = buildLlmMessages(mkContext());
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.role).toBe("system");
+    expect(msgs[1]!.role).toBe("user");
+  });
+
+  it("system message instructs JSON-only output with the right schema keys", () => {
+    const msgs = buildLlmMessages(mkContext());
+    expect(msgs[0]!.content).toContain("conversationStarters");
+    expect(msgs[0]!.content).toContain("inferredNeeds");
+    expect(msgs[0]!.content).toContain("suggestedActions");
+  });
+});
+
+describe("contextHash", () => {
+  it("is stable across calls with the same context", () => {
+    const ctx1 = mkContext();
+    const ctx2 = mkContext();
+    expect(contextHash(ctx1)).toBe(contextHash(ctx2));
+  });
+
+  it("changes when whyRemember changes", () => {
+    const a = mkContext();
+    const b = mkContext({ card: mkCard({ whyRemember: "different memory" }) });
+    expect(contextHash(a)).not.toBe(contextHash(b));
+  });
+
+  it("changes when a new contact event is added", () => {
+    const a = mkContext();
+    const b = mkContext({ events: [mkEvent({ id: "new", note: "called" })] });
+    expect(contextHash(a)).not.toBe(contextHash(b));
+  });
+
+  it("does NOT change on unrelated `now` clock drift (same data → same hash)", () => {
+    const a = mkContext();
+    const b = mkContext({ now: new Date("2026-04-26T10:00:00Z") });
+    // The hash includes daysSinceContact, which IS time-sensitive (1 day later
+    // = different bucket). So this is expected to differ. We test the
+    // converse: identical inputs → identical hash.
+    expect(contextHash(a)).toBe(contextHash(a));
+    expect(contextHash(b)).toBe(contextHash(b));
+  });
+});
+
+describe("parseCoachResponse", () => {
+  it("parses a clean JSON response", () => {
+    const raw = JSON.stringify({
+      conversationStarters: ["a", "b"],
+      inferredNeeds: ["x"],
+      suggestedActions: ["y", "z"],
+    });
+    const insight = parseCoachResponse(raw);
+    expect(insight.conversationStarters).toEqual(["a", "b"]);
+    expect(insight.inferredNeeds).toEqual(["x"]);
+    expect(insight.suggestedActions).toEqual(["y", "z"]);
+  });
+
+  it("strips a markdown json fence", () => {
+    const raw = "```json\n" + JSON.stringify({ conversationStarters: ["hi"] }) + "\n```";
+    const insight = parseCoachResponse(raw);
+    expect(insight.conversationStarters).toEqual(["hi"]);
+  });
+
+  it("returns empty arrays on malformed JSON", () => {
+    const insight = parseCoachResponse("not json at all");
+    expect(insight.conversationStarters).toEqual([]);
+    expect(insight.inferredNeeds).toEqual([]);
+    expect(insight.suggestedActions).toEqual([]);
+  });
+
+  it("returns empty on non-object root", () => {
+    const insight = parseCoachResponse("[1,2,3]");
+    expect(insight.conversationStarters).toEqual([]);
+  });
+
+  it("ignores non-string array items and trims whitespace", () => {
+    const raw = JSON.stringify({
+      conversationStarters: ["  hello  ", 42, null, "world"],
+    });
+    const insight = parseCoachResponse(raw);
+    expect(insight.conversationStarters).toEqual(["hello", "world"]);
+  });
+
+  it("caps each bucket at its limit", () => {
+    const raw = JSON.stringify({
+      conversationStarters: Array.from({ length: 20 }, (_, i) => `c${i}`),
+      inferredNeeds: Array.from({ length: 20 }, (_, i) => `n${i}`),
+      suggestedActions: Array.from({ length: 20 }, (_, i) => `a${i}`),
+    });
+    const insight = parseCoachResponse(raw);
+    expect(insight.conversationStarters.length).toBeLessThanOrEqual(5);
+    expect(insight.inferredNeeds.length).toBeLessThanOrEqual(4);
+    expect(insight.suggestedActions.length).toBeLessThanOrEqual(4);
+  });
+});
+
+describe("isEmptyInsight", () => {
+  it("true when all three buckets are empty", () => {
+    expect(
+      isEmptyInsight({ conversationStarters: [], inferredNeeds: [], suggestedActions: [] }),
+    ).toBe(true);
+  });
+
+  it("false when any bucket has content", () => {
+    expect(
+      isEmptyInsight({ conversationStarters: ["x"], inferredNeeds: [], suggestedActions: [] }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/coach/insights.ts
+++ b/src/lib/coach/insights.ts
@@ -1,0 +1,235 @@
+import { createHash } from "node:crypto";
+
+import type { CardSummary } from "@/db/cards";
+import type { ContactEvent } from "@/db/cards";
+
+export interface CoachContext {
+  card: CardSummary;
+  /** Up to 10 most-recent contact events for this card. */
+  events: ContactEvent[];
+  /** Other cards at the same company (excludes the focal card). */
+  companyMates: CardSummary[];
+  /** Other cards met at the same event (excludes the focal card). */
+  eventMates: CardSummary[];
+  /** Reference "now" so prompt is reproducible in tests. */
+  now: Date;
+}
+
+export interface CoachInsight {
+  /** 3-5 conversation starters for the next interaction. */
+  conversationStarters: string[];
+  /** What this person likely cares about right now (inferred). */
+  inferredNeeds: string[];
+  /** Concrete actions the user can take this week. */
+  suggestedActions: string[];
+}
+
+const MAX_CONVERSATION = 5;
+const MAX_NEEDS = 4;
+const MAX_ACTIONS = 4;
+const MAX_ITEM_LEN = 200;
+
+function pickName(c: CardSummary): string {
+  return c.nameZh || c.nameEn || "（未命名）";
+}
+
+function pickRole(c: CardSummary): string {
+  return c.jobTitleZh || c.jobTitleEn || "";
+}
+
+function pickCompany(c: CardSummary): string {
+  return c.companyZh || c.companyEn || "";
+}
+
+function daysSince(date: Date | null | undefined, now: Date): number | null {
+  if (!date) return null;
+  const ms = now.getTime() - date.getTime();
+  if (!Number.isFinite(ms)) return null;
+  return Math.floor(ms / (24 * 60 * 60 * 1000));
+}
+
+function formatYmd(date: Date | null | undefined): string {
+  return date ? date.toISOString().slice(0, 10) : "";
+}
+
+/**
+ * Stable, deterministic hash of the inputs that influence the LLM
+ * response. Used as the cache key so re-opening the same card with no
+ * data change reuses the cached insight (cheap LLM bill).
+ */
+export function contextHash(ctx: CoachContext): string {
+  const stable = {
+    cardId: ctx.card.id,
+    name: pickName(ctx.card),
+    role: pickRole(ctx.card),
+    company: pickCompany(ctx.card),
+    why: ctx.card.whyRemember ?? "",
+    firstMet: ctx.card.firstMetDate ?? "",
+    eventTag: ctx.card.firstMetEventTag ?? "",
+    notes: ctx.card.notes ?? "",
+    daysSinceContact: daysSince(ctx.card.lastContactedAt, ctx.now),
+    eventIds: ctx.events
+      .map((e) => `${e.id}:${e.note.slice(0, 80)}`)
+      .sort()
+      .join("|"),
+    companyMates: ctx.companyMates
+      .map((c) => `${pickName(c)}/${pickRole(c)}`)
+      .sort()
+      .join("|"),
+    eventMates: ctx.eventMates
+      .map((c) => `${pickName(c)}/${pickCompany(c)}`)
+      .sort()
+      .join("|"),
+  };
+  const json = JSON.stringify(stable);
+  return createHash("sha256").update(json).digest("hex").slice(0, 32);
+}
+
+/**
+ * Build the structured prompt sent to the LLM. Pure function — no
+ * fetch, no env, no I/O. Easy to snapshot-test.
+ */
+export function buildCoachPrompt(ctx: CoachContext): string {
+  const c = ctx.card;
+  const lines: string[] = [];
+  lines.push("=== 名片基本資料 ===");
+  lines.push(`姓名：${pickName(c)}`);
+  if (pickRole(c)) lines.push(`職稱：${pickRole(c)}`);
+  if (pickCompany(c)) lines.push(`公司：${pickCompany(c)}`);
+  if (c.department) lines.push(`部門：${c.department}`);
+
+  if (c.whyRemember) {
+    lines.push("");
+    lines.push("=== 為什麼記得這個人 ===");
+    lines.push(c.whyRemember);
+  }
+
+  if (c.firstMetDate || c.firstMetEventTag || c.firstMetContext) {
+    lines.push("");
+    lines.push("=== 第一次見面 ===");
+    if (c.firstMetDate) lines.push(`日期：${c.firstMetDate}`);
+    if (c.firstMetEventTag) lines.push(`場合：${c.firstMetEventTag}`);
+    if (c.firstMetContext) lines.push(`情境：${c.firstMetContext}`);
+  }
+
+  if (c.notes) {
+    lines.push("");
+    lines.push("=== 備註 ===");
+    lines.push(c.notes);
+  }
+
+  const days = daysSince(c.lastContactedAt, ctx.now);
+  if (days !== null) {
+    lines.push("");
+    lines.push(`=== 互動狀態 ===`);
+    lines.push(
+      `上次互動：${formatYmd(c.lastContactedAt)}（${days} 天前${days >= 90 ? "，已超過 90 天" : ""}）`,
+    );
+  } else if (c.firstMetDate) {
+    lines.push("");
+    lines.push("=== 互動狀態 ===");
+    lines.push("尚未記錄任何互動 — 自首次見面後沒有 follow-up 紀錄");
+  }
+
+  if (ctx.events.length > 0) {
+    lines.push("");
+    lines.push("=== 近期互動歷史（新→舊） ===");
+    for (const e of ctx.events.slice(0, 6)) {
+      const note = e.note?.trim() || "（無備註）";
+      lines.push(`- ${formatYmd(e.at)}：${note.slice(0, 200)}`);
+    }
+  }
+
+  if (ctx.companyMates.length > 0) {
+    lines.push("");
+    lines.push(`=== 同公司其他聯絡人（${ctx.companyMates.length} 位） ===`);
+    for (const m of ctx.companyMates.slice(0, 6)) {
+      const role = pickRole(m);
+      lines.push(`- ${pickName(m)}${role ? `（${role}）` : ""}`);
+    }
+  }
+
+  if (ctx.eventMates.length > 0) {
+    lines.push("");
+    lines.push(`=== 同場合認識的人（${ctx.eventMates.length} 位） ===`);
+    for (const m of ctx.eventMates.slice(0, 6)) {
+      const co = pickCompany(m);
+      lines.push(`- ${pickName(m)}${co ? `（${co}）` : ""}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+const SYSTEM_PROMPT =
+  "你是一位資深商務人脈教練，專長是幫助使用者經營一對一的商務關係。" +
+  "根據使用者提供的名片內容、互動歷史、公司同事、同場合認識的人，給出三段 actionable 建議。" +
+  "回答必須是合法的 JSON，符合下列 schema，不要任何其他文字、不要 markdown 圍欄：\n" +
+  '{"conversationStarters": string[], "inferredNeeds": string[], "suggestedActions": string[]}\n' +
+  "規則：\n" +
+  "- conversationStarters：3-5 個下次聯絡可以聊的具體話題。每點一句話內，要有具體 hook（提到 whyRemember 或互動歷史的關鍵字、或同公司同事/同場合認識的人）。\n" +
+  "- inferredNeeds：2-4 個推測這個人現在可能在意的事，根據職稱、公司、產業、互動歷史推理。\n" +
+  "- suggestedActions：2-4 個使用者本週可以做的具體動作。第一個應該是「現在就能寄／傳訊息／打電話」的小動作；其它可以是中期的（介紹某人、分享某文章、邀某活動）。\n" +
+  "- 用繁體中文回答（除非名字或專有名詞英文）。\n" +
+  "- 每點 200 字內。具體勝過抽象。\n" +
+  "- 沒有資料的領域不要強行編造（例：沒有互動歷史就別假裝有）。";
+
+export function buildLlmMessages(
+  ctx: CoachContext,
+): Array<{ role: "system" | "user"; content: string }> {
+  return [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: buildCoachPrompt(ctx) },
+  ];
+}
+
+function sanitizeStringArray(value: unknown, max: number): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const trimmed = item.trim();
+    if (!trimmed) continue;
+    out.push(trimmed.slice(0, MAX_ITEM_LEN));
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+/**
+ * Parse the LLM's JSON response into a structured CoachInsight. Defensive:
+ * any malformed input → empty arrays so the UI degrades cleanly.
+ */
+export function parseCoachResponse(raw: string): CoachInsight {
+  const empty: CoachInsight = {
+    conversationStarters: [],
+    inferredNeeds: [],
+    suggestedActions: [],
+  };
+  if (!raw) return empty;
+  const trimmed = raw.trim();
+  // Strip optional markdown fence the LLM may add despite instructions.
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const inner = fenced ? fenced[1]! : trimmed;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(inner);
+  } catch {
+    return empty;
+  }
+  if (!parsed || typeof parsed !== "object") return empty;
+  const obj = parsed as Record<string, unknown>;
+  return {
+    conversationStarters: sanitizeStringArray(obj.conversationStarters, MAX_CONVERSATION),
+    inferredNeeds: sanitizeStringArray(obj.inferredNeeds, MAX_NEEDS),
+    suggestedActions: sanitizeStringArray(obj.suggestedActions, MAX_ACTIONS),
+  };
+}
+
+export function isEmptyInsight(insight: CoachInsight): boolean {
+  return (
+    insight.conversationStarters.length === 0 &&
+    insight.inferredNeeds.length === 0 &&
+    insight.suggestedActions.length === 0
+  );
+}

--- a/src/lib/coach/llm.ts
+++ b/src/lib/coach/llm.ts
@@ -1,0 +1,77 @@
+import "server-only";
+
+import {
+  buildLlmMessages,
+  parseCoachResponse,
+  type CoachContext,
+  type CoachInsight,
+} from "./insights";
+
+const DEFAULT_BASE_URL = "https://api.minimax.chat/v1";
+const DEFAULT_MODEL = "MiniMax-M2.7";
+const DEFAULT_TIMEOUT_MS = 12_000;
+
+interface MiniMaxChatResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+export interface CoachLlmOptions {
+  /** Hard timeout in ms. Default 12000 (LLM is doing real reasoning). */
+  timeoutMs?: number;
+}
+
+/**
+ * Call MiniMax with a coach prompt. Returns null when:
+ *  - no API key configured (graceful no-op)
+ *  - network / HTTP error / timeout
+ *  - response cannot be parsed into a CoachInsight
+ *
+ * Caller is responsible for caching — this fn is the raw LLM hop.
+ */
+export async function callCoachLlm(
+  ctx: CoachContext,
+  options: CoachLlmOptions = {},
+): Promise<CoachInsight | null> {
+  const apiKey = process.env.MINIMAX_API_KEY ?? "";
+  if (!apiKey) return null;
+
+  const baseUrl = process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = process.env.MINIMAX_MODEL ?? DEFAULT_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const body = {
+    model,
+    temperature: 0.5,
+    max_tokens: 1200,
+    messages: buildLlmMessages(ctx),
+  };
+
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: abort.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as MiniMaxChatResponse;
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) return null;
+    return parseCoachResponse(raw);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Cheap probe so the UI can hide the section entirely when LLM unavailable. */
+export function isCoachConfigured(): boolean {
+  return Boolean(process.env.MINIMAX_API_KEY);
+}

--- a/src/lib/coach/store.ts
+++ b/src/lib/coach/store.ts
@@ -1,0 +1,61 @@
+import "server-only";
+
+import { Timestamp } from "firebase-admin/firestore";
+
+import { getAdminFirestore } from "@/lib/firebase/server";
+import { cardsPath, personalWorkspaceId } from "@/lib/firebase/shared";
+
+import type { CoachInsight } from "./insights";
+
+const COACH_SUBCOLLECTION = "coach";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+interface CachedCoachDoc {
+  hash: string;
+  insight: CoachInsight;
+  generatedAt: Timestamp;
+}
+
+/**
+ * Look up a previously-cached insight for the given card + context hash.
+ * Returns null on miss, on cache expiry, or when the stored hash differs
+ * (i.e. the user added a new event / updated the card so the prompt
+ * inputs no longer match).
+ */
+export async function readCoachCache(
+  uid: string,
+  cardId: string,
+  hash: string,
+): Promise<CoachInsight | null> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${cardsPath(wid)}/${cardId}/${COACH_SUBCOLLECTION}/latest`);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const data = snap.data() as CachedCoachDoc | undefined;
+  if (!data) return null;
+  if (data.hash !== hash) return null;
+  const ageMs = Date.now() - data.generatedAt.toMillis();
+  if (ageMs > CACHE_TTL_MS) return null;
+  return data.insight;
+}
+
+/**
+ * Persist the latest insight under cards/{id}/coach/latest. Single-doc
+ * (not append) — older insights aren't useful once the context shifts.
+ */
+export async function writeCoachCache(
+  uid: string,
+  cardId: string,
+  hash: string,
+  insight: CoachInsight,
+): Promise<void> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${cardsPath(wid)}/${cardId}/${COACH_SUBCOLLECTION}/latest`);
+  await ref.set({
+    hash,
+    insight,
+    generatedAt: Timestamp.now(),
+  });
+}


### PR DESCRIPTION
Closes #82

## Summary
商務人士打開卡片最想知道：「下次見到他該聊什麼？他現在可能在意什麼？」目前 system 把資料儲存得很好但**不主動洞察**。這刀讓 AI 把全部 context 餵給 MiniMax，產出三段 actionable 建議。

> 把 app 從 passive viewer → active relationship coach。

## Demo (when MINIMAX_API_KEY is set)

```
✨ AI 人脈教練

🗣️ 下次聯絡可以聊
- 邊緣 AI 推論的最新進展（你們在 2024 Computex 聊過）
- 智威科技近期新成立的 ML team — 他可能是窗口
- 互動記錄裡你欠他的 referral

💼 他現在可能在意
- ML infra 成本降低（公司近期方向）
- 跨部門對接（他剛升 PM）

🎯 建議本週的行動
- 寄一篇 NVIDIA 邊緣推論的文章 + 問近況
- 邀請他下個月的 AI Conf 一起聊

[📅 設 +3 天提醒] [📅 設 +7 天提醒] [📅 設 +14 天提醒] [📌 加入重要]
```

## Files
- `src/lib/coach/insights.ts` (+220) — pure prompt builder, JSON parser, sha256 contextHash
- `src/lib/coach/llm.ts` (+65) — MiniMax client, 12s timeout, env-key check, null on failure
- `src/lib/coach/store.ts` (+55) — Firestore `cards/{id}/coach/latest` 24h cache
- `src/lib/coach/__tests__/insights.test.ts` — 22 UT
- `src/app/(app)/cards/actions.ts` — `getCoachInsightsAction({ cardId, force })` (cache→LLM→cache)
- `src/components/cards/CoachInsightSection.tsx` (+220) + module.css — opt-in disclosure UI
- `src/app/(app)/cards/[id]/page.tsx` — render section conditionally on `isCoachConfigured()`

## Architecture decisions
- **Opt-in**: no LLM call until user clicks「✨ 請 AI 教練給我建議」. Page-load stays fast, tokens not burned on glances
- **24h cache** keyed by `(cardId, contextHash)` so revisits reuse the insight unless data shifted
- **Reuses existing entities**: contactEvents (互動歷史), companies (groupCardsByCompany finds mates), events (getCardsBySharedEvent finds same-event mates)
- **Inline action buttons** wire directly to existing `setFollowUpAction` + `toggleCardPinAction` — coach suggests, user one-clicks to execute
- **Graceful degradation chain**: no `MINIMAX_API_KEY` → section hidden; LLM fail → 「暫時無法回應」 + retry; malformed JSON → empty state; cache stale → silent regen

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 489 pass (+22 new)
- [x] `pnpm lint` — clean (4 unrelated pre-existing)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — green
- [ ] CI green → merge → mac mini deploy

## Out of scope
- Conversation transcription (audio infra)
- Cross-card batch insights ("這 5 位可以一起 ping")
- AI-drafted email body — coach 給 talking points，使用者寫信