### PR TITLE
feat(home): 📰 今日人脈簡報 — AI 每天挑 3 位最該聯絡的人 + 為什麼

### DIFF
--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -20,6 +20,9 @@ import {
   updateCardForUser,
 } from "@/db/cards";
 import { cardCreateSchema, cardUpdateSchema } from "@/db/schema";
+import { briefingCacheKey, type BriefingPick } from "@/lib/coach/briefing";
+import { callBriefingLlm } from "@/lib/coach/briefing-llm";
+import { readBriefingCache, writeBriefingCache } from "@/lib/coach/briefing-store";
 import {
   contextHash,
   isEmptyInsight,
@@ -27,6 +30,7 @@ import {
   type CoachInsight,
 } from "@/lib/coach/insights";
 import { callCoachLlm, isCoachConfigured } from "@/lib/coach/llm";
+import { selectTodayPriorityCards, type PriorityCandidate } from "@/lib/coach/priority";
 import { readCoachCache, writeCoachCache } from "@/lib/coach/store";
 import { pickCanonicalCompany } from "@/lib/companies/group";
 
@@ -282,6 +286,70 @@ export const getCoachInsightsAction = authedAction
       }
       await writeCoachCache(ctx.user.uid, card.id, hash, insight);
       return { ok: true, insight, cached: false };
+    },
+  );
+
+/**
+ * 📰 今日人脈簡報 — pure-fn priority scorer narrows top 5 candidates,
+ * LLM picks 3 with human-voice reasons. Daily-cache keyed by
+ * (date, sorted candidate ids) so opening the app multiple times
+ * today returns the same picks (no ad-hoc regeneration).
+ *
+ * Returns picks paired with the original CardSummary so the UI can
+ * render mini-cards without a second fetch.
+ */
+export const getDailyBriefingAction = authedAction
+  .inputSchema(z.object({ force: z.boolean().optional().default(false) }))
+  .action(
+    async ({
+      parsedInput,
+      ctx,
+    }): Promise<
+      | {
+          ok: true;
+          picks: Array<{ pick: BriefingPick; candidate: PriorityCandidate }>;
+          cached: boolean;
+        }
+      | { ok: false; reason: "no-llm" | "no-candidates" | "llm-failed" }
+    > => {
+      if (!isCoachConfigured()) return { ok: false, reason: "no-llm" };
+      const allCards = await listCardsForUser(ctx.user.uid, { limit: 500 });
+      const now = new Date();
+      const candidates = selectTodayPriorityCards(allCards, { now });
+      if (candidates.length === 0) return { ok: false, reason: "no-candidates" };
+
+      const cacheKey = briefingCacheKey(
+        now,
+        candidates.map((c) => c.card.id),
+      );
+      const candidateById = new Map(candidates.map((c) => [c.card.id, c]));
+
+      if (!parsedInput.force) {
+        const cached = await readBriefingCache(ctx.user.uid, cacheKey);
+        if (cached && cached.length > 0) {
+          const picks = cached
+            .map((pick) => {
+              const candidate = candidateById.get(pick.cardId);
+              return candidate ? { pick, candidate } : null;
+            })
+            .filter((x): x is { pick: BriefingPick; candidate: PriorityCandidate } => x !== null);
+          if (picks.length > 0) return { ok: true, picks, cached: true };
+        }
+      }
+
+      const llmPicks = await callBriefingLlm(candidates, now);
+      if (!llmPicks || llmPicks.length === 0) {
+        return { ok: false, reason: "llm-failed" };
+      }
+      await writeBriefingCache(ctx.user.uid, cacheKey, llmPicks);
+
+      const picks = llmPicks
+        .map((pick) => {
+          const candidate = candidateById.get(pick.cardId);
+          return candidate ? { pick, candidate } : null;
+        })
+        .filter((x): x is { pick: BriefingPick; candidate: PriorityCandidate } => x !== null);
+      return { ok: true, picks, cached: false };
     },
   );
 

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 
+import { DailyBriefingSection } from "@/components/coach/DailyBriefingSection";
 import { TimelineSection } from "@/components/timeline/TimelineSection";
 import { listCardsForUser } from "@/db/cards";
+import { isCoachConfigured } from "@/lib/coach/llm";
 import { readSession } from "@/lib/firebase/session";
 import { categorizeTimeline } from "@/lib/timeline/categorize";
 
@@ -54,11 +56,14 @@ export default async function HomePage() {
           </p>
         </div>
       ) : (
-        <div className={styles.sections}>
-          {sections.map((section) => (
-            <TimelineSection key={section.id} section={section} />
-          ))}
-        </div>
+        <>
+          {isCoachConfigured() && cards.length >= 3 && <DailyBriefingSection />}
+          <div className={styles.sections}>
+            {sections.map((section) => (
+              <TimelineSection key={section.id} section={section} />
+            ))}
+          </div>
+        </>
       )}
     </article>
   );

--- a/src/components/coach/DailyBriefingSection.module.css
+++ b/src/components/coach/DailyBriefingSection.module.css
@@ -1,0 +1,338 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-lg);
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(
+    135deg,
+    color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 60%, var(--color-paper)) 0%,
+    var(--color-paper) 80%
+  );
+  position: relative;
+  overflow: hidden;
+}
+
+.section::before {
+  content: "";
+  position: absolute;
+  top: -40%;
+  right: -20%;
+  width: 60%;
+  height: 140%;
+  background: radial-gradient(
+    circle,
+    color-mix(in oklch, var(--color-accent) 14%, transparent),
+    transparent 65%
+  );
+  pointer-events: none;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  position: relative;
+  z-index: 1;
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-family: var(--font-display);
+  font-size: var(--text-h2);
+  font-weight: 500;
+  color: var(--color-ink);
+  margin: 0;
+}
+
+.sparkle {
+  font-size: 1em;
+}
+
+.regenerate {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  background: transparent;
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.regenerate:hover:not(:disabled) {
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.regenerate:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  align-items: flex-start;
+  position: relative;
+  z-index: 1;
+}
+
+.lead {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+  max-width: 60ch;
+}
+
+.primaryBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.primaryBtn:hover:not(:disabled) {
+  background: var(--color-accent-ink);
+}
+
+.primaryBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  position: relative;
+  z-index: 1;
+}
+
+.spinner {
+  width: 1.1em;
+  height: 1.1em;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent-ink);
+  border-radius: 50%;
+  animation: briefingSpin 0.7s linear infinite;
+}
+
+@keyframes briefingSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.errorBox {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 70%,
+    var(--color-paper)
+  );
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  position: relative;
+  z-index: 1;
+}
+
+.errorBox p {
+  margin: 0;
+  color: var(--color-ink);
+}
+
+.secondaryBtn {
+  align-self: flex-start;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.secondaryBtn:hover:not(:disabled) {
+  border-color: var(--color-accent-ink);
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  position: relative;
+  z-index: 1;
+}
+
+.pickList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.pickItem {
+  display: flex;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.pickRank {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 50%;
+  background: var(--color-ink);
+  color: var(--color-paper);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.pickBody {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.pickHeader {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.pickName {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-ink);
+  text-decoration: none;
+}
+
+.pickName:hover {
+  text-decoration: underline;
+  text-decoration-color: var(--color-accent-ink);
+}
+
+.pickSub {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+}
+
+.pickReason {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+}
+
+.pickAction {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  margin: 0;
+  font-weight: 500;
+}
+
+.pickButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-top: var(--space-xs);
+}
+
+.pickBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.pickBtn:hover:not(:disabled) {
+  border-color: var(--color-accent-ink);
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.pickBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pickLink {
+  align-self: center;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  text-decoration: none;
+}
+
+.pickLink:hover {
+  text-decoration: underline;
+}
+
+.cachedNote {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  color: var(--color-ink-muted);
+  margin: 0;
+  font-style: italic;
+}
+
+.toast {
+  position: fixed;
+  bottom: var(--space-lg);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  z-index: 100;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 20%);
+}

--- a/src/components/coach/DailyBriefingSection.tsx
+++ b/src/components/coach/DailyBriefingSection.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import {
+  getDailyBriefingAction,
+  logContactAction,
+  setFollowUpAction,
+} from "@/app/(app)/cards/actions";
+import type { BriefingPick } from "@/lib/coach/briefing";
+import type { PriorityCandidate } from "@/lib/coach/priority";
+
+import styles from "./DailyBriefingSection.module.css";
+
+type LoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | {
+      kind: "ready";
+      picks: Array<{ pick: BriefingPick; candidate: PriorityCandidate }>;
+      cached: boolean;
+    }
+  | { kind: "error"; message: string };
+
+function offsetIso(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function pickName(c: PriorityCandidate["card"]): string {
+  return c.nameZh || c.nameEn || "（未命名）";
+}
+
+function pickSubtitle(c: PriorityCandidate["card"]): string {
+  const role = c.jobTitleZh || c.jobTitleEn;
+  const company = c.companyZh || c.companyEn;
+  return [role, company].filter(Boolean).join(" · ");
+}
+
+/**
+ * 「📰 今日人脈簡報」on the timeline home. Pure-fn priority scorer
+ * narrows N cards → top 5; LLM picks 3 with human-voice reasons.
+ * Daily-cached so opening the app multiple times today returns the
+ * same picks (predictable + zero token churn).
+ *
+ * Opt-in: doesn't fetch until user clicks the button. Keeps page-load
+ * fast and avoids tokens on cards the user is just glancing at.
+ */
+export function DailyBriefingSection() {
+  const router = useRouter();
+  const [state, setState] = useState<LoadState>({ kind: "idle" });
+  const [pending, startTransition] = useTransition();
+  const [actionToast, setActionToast] = useState<string | null>(null);
+
+  const fetchBriefing = (force: boolean) => {
+    setState({ kind: "loading" });
+    startTransition(async () => {
+      const result = await getDailyBriefingAction({ force });
+      if (result?.serverError) {
+        setState({ kind: "error", message: result.serverError });
+        return;
+      }
+      const data = result?.data;
+      if (!data) {
+        setState({ kind: "error", message: "簡報官沒回應，請稍後再試" });
+        return;
+      }
+      if (!data.ok) {
+        const messages: Record<string, string> = {
+          "no-llm": "AI 簡報未啟用（管理員未設定 LLM 金鑰）",
+          "no-candidates":
+            "今天沒有需要優先聯絡的人 — 所有 followUp 都是未來日、沒有週年、Pinned 都最近聯絡過 ✨",
+          "llm-failed": "簡報官暫時無法回應，請稍後再試",
+        };
+        setState({ kind: "error", message: messages[data.reason] ?? "未知錯誤" });
+        return;
+      }
+      setState({ kind: "ready", picks: data.picks, cached: data.cached });
+    });
+  };
+
+  const flashAction = (msg: string) => {
+    setActionToast(msg);
+    setTimeout(() => setActionToast(null), 2400);
+  };
+
+  const logContact = (cardId: string) => {
+    startTransition(async () => {
+      const result = await logContactAction({ id: cardId, note: "" });
+      if (result?.data?.ok) {
+        flashAction("已標記聯絡");
+        router.refresh();
+      } else {
+        flashAction("標記失敗");
+      }
+    });
+  };
+
+  const setReminder = (cardId: string, days: number) => {
+    startTransition(async () => {
+      const result = await setFollowUpAction({ id: cardId, followUpAt: offsetIso(days) });
+      if (result?.data?.ok) {
+        flashAction(`已設定 +${days} 天提醒`);
+        router.refresh();
+      } else {
+        flashAction("設定失敗");
+      }
+    });
+  };
+
+  return (
+    <section className={styles.section} aria-label="今日人脈簡報">
+      <header className={styles.header}>
+        <h2 className={styles.title}>
+          <span className={styles.sparkle} aria-hidden="true">
+            📰
+          </span>
+          今日人脈簡報
+        </h2>
+        {state.kind === "ready" && (
+          <button
+            type="button"
+            className={styles.regenerate}
+            onClick={() => fetchBriefing(true)}
+            disabled={pending}
+          >
+            重新生成
+          </button>
+        )}
+      </header>
+
+      {state.kind === "idle" && (
+        <div className={styles.emptyState}>
+          <p className={styles.lead}>
+            問問 AI：今天最該聯絡的 3 位是誰？AI
+            會看完所有提醒、週年、Pinned、久未聯絡的人，挑出最重要的 3 位 + 為什麼。
+          </p>
+          <button
+            type="button"
+            className={styles.primaryBtn}
+            onClick={() => fetchBriefing(false)}
+            disabled={pending}
+          >
+            {pending ? "簡報官閱讀中…" : "📰 看今天的人脈簡報"}
+          </button>
+        </div>
+      )}
+
+      {state.kind === "loading" && (
+        <div className={styles.loading} aria-live="polite">
+          <span className={styles.spinner} aria-hidden="true" />
+          <span>簡報官正在挑出今天最重要的 3 位…</span>
+        </div>
+      )}
+
+      {state.kind === "error" && (
+        <div className={styles.errorBox} role="alert">
+          <p>{state.message}</p>
+          <button
+            type="button"
+            className={styles.secondaryBtn}
+            onClick={() => fetchBriefing(false)}
+            disabled={pending}
+          >
+            重試
+          </button>
+        </div>
+      )}
+
+      {state.kind === "ready" && (
+        <div className={styles.results}>
+          <ol className={styles.pickList}>
+            {state.picks.map((entry, i) => {
+              const card = entry.candidate.card;
+              const subtitle = pickSubtitle(card);
+              return (
+                <li key={card.id} className={styles.pickItem}>
+                  <div className={styles.pickRank} aria-hidden="true">
+                    {i + 1}
+                  </div>
+                  <div className={styles.pickBody}>
+                    <div className={styles.pickHeader}>
+                      <Link href={`/cards/${card.id}`} className={styles.pickName}>
+                        {pickName(card)}
+                      </Link>
+                      {subtitle && <span className={styles.pickSub}>{subtitle}</span>}
+                    </div>
+                    <p className={styles.pickReason}>{entry.pick.reason}</p>
+                    <p className={styles.pickAction}>👉 {entry.pick.suggestedAction}</p>
+                    <div className={styles.pickButtons}>
+                      <button
+                        type="button"
+                        className={styles.pickBtn}
+                        onClick={() => logContact(card.id)}
+                        disabled={pending}
+                      >
+                        ✅ 今天已聯絡
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.pickBtn}
+                        onClick={() => setReminder(card.id, 7)}
+                        disabled={pending}
+                      >
+                        📅 +7 天再提醒
+                      </button>
+                      <Link href={`/cards/${card.id}`} className={styles.pickLink}>
+                        看完整名片 →
+                      </Link>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+          {state.cached && (
+            <p className={styles.cachedNote}>
+              這份簡報是今天上午產生的快取。明天會自動重算；想立刻換組可點「重新生成」。
+            </p>
+          )}
+        </div>
+      )}
+
+      {actionToast && (
+        <p role="status" aria-live="polite" className={styles.toast}>
+          {actionToast}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/lib/coach/__tests__/briefing.test.ts
+++ b/src/lib/coach/__tests__/briefing.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import {
+  briefingCacheKey,
+  buildBriefingMessages,
+  buildBriefingPrompt,
+  parseBriefingResponse,
+} from "../briefing";
+import type { PriorityCandidate } from "../priority";
+
+const NOW = new Date("2026-04-25T10:00:00Z");
+
+function mkCandidate(overrides: Partial<CardSummary & PriorityCandidate> = {}): PriorityCandidate {
+  const card: CardSummary = {
+    id: "card-1",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "陳玉涵",
+    jobTitleZh: "PM",
+    companyZh: "智威",
+    whyRemember: "Computex 攤位聊邊緣 AI",
+    firstMetDate: "2024-06-04",
+    firstMetEventTag: "2024 COMPUTEX",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    social: {},
+    isPinned: false,
+    createdAt: new Date("2024-06-04"),
+    updatedAt: null,
+    lastContactedAt: new Date("2025-09-01"),
+    deletedAt: null,
+    ...(overrides as Partial<CardSummary>),
+  };
+  return {
+    card,
+    score: overrides.score ?? 100,
+    reason: overrides.reason ?? "followup-overdue",
+    daysOffset: overrides.daysOffset ?? 5,
+  };
+}
+
+describe("buildBriefingPrompt", () => {
+  it("includes today's date", () => {
+    const prompt = buildBriefingPrompt([mkCandidate()], NOW);
+    expect(prompt).toContain("2026-04-25");
+  });
+
+  it("includes each candidate's name, role, company", () => {
+    const c1 = mkCandidate({ id: "c1", nameZh: "Alice" });
+    const c2 = mkCandidate({ id: "c2", nameZh: "Bob", companyZh: "ACME" });
+    const prompt = buildBriefingPrompt([c1, c2], NOW);
+    expect(prompt).toContain("Alice");
+    expect(prompt).toContain("Bob");
+    expect(prompt).toContain("ACME");
+    expect(prompt).toContain("c1");
+    expect(prompt).toContain("c2");
+  });
+
+  it("surfaces the system score and reason kind", () => {
+    const c = mkCandidate({ score: 142, reason: "followup-overdue", daysOffset: 7 });
+    const prompt = buildBriefingPrompt([c], NOW);
+    expect(prompt).toContain("評分=142");
+    expect(prompt).toContain("提醒已過期 7 天");
+  });
+
+  it("anniversary daysOffset reads as 'N 年前的今天認識'", () => {
+    const c = mkCandidate({ reason: "anniversary", daysOffset: 5, score: 100 });
+    const prompt = buildBriefingPrompt([c], NOW);
+    expect(prompt).toContain("5 年前的今天認識");
+  });
+
+  it("pinned-stale shows days-since-contact", () => {
+    const c = mkCandidate({
+      reason: "pinned-stale",
+      daysOffset: 30,
+      isPinned: true,
+    } as Partial<CardSummary & PriorityCandidate>);
+    const prompt = buildBriefingPrompt([c], NOW);
+    expect(prompt).toContain("已 30 天沒互動");
+    expect(prompt).toContain("重要聯絡人");
+  });
+});
+
+describe("buildBriefingMessages", () => {
+  it("returns system + user messages with the right schema hints", () => {
+    const msgs = buildBriefingMessages([mkCandidate()], NOW);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.role).toBe("system");
+    expect(msgs[0]!.content).toContain("picks");
+    expect(msgs[0]!.content).toContain("cardId");
+    expect(msgs[0]!.content).toContain("reason");
+    expect(msgs[0]!.content).toContain("suggestedAction");
+  });
+});
+
+describe("parseBriefingResponse", () => {
+  const validIds = new Set(["a", "b", "c"]);
+
+  it("parses a clean JSON response", () => {
+    const raw = JSON.stringify({
+      picks: [
+        { cardId: "a", reason: "因為 X", suggestedAction: "寄個訊息" },
+        { cardId: "b", reason: "因為 Y", suggestedAction: "打通電話" },
+      ],
+    });
+    const result = parseBriefingResponse(raw, validIds);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.cardId).toBe("a");
+    expect(result[0]!.suggestedAction).toBe("寄個訊息");
+  });
+
+  it("strips markdown json fence", () => {
+    const raw =
+      "```json\n" +
+      JSON.stringify({ picks: [{ cardId: "a", reason: "x", suggestedAction: "y" }] }) +
+      "\n```";
+    const result = parseBriefingResponse(raw, validIds);
+    expect(result).toHaveLength(1);
+  });
+
+  it("drops picks whose cardId is not in the candidate set (anti-hallucination)", () => {
+    const raw = JSON.stringify({
+      picks: [
+        { cardId: "a", reason: "x", suggestedAction: "y" },
+        { cardId: "MADE-UP-ID", reason: "x", suggestedAction: "y" },
+      ],
+    });
+    const result = parseBriefingResponse(raw, validIds);
+    expect(result.map((p) => p.cardId)).toEqual(["a"]);
+  });
+
+  it("drops picks missing reason or suggestedAction", () => {
+    const raw = JSON.stringify({
+      picks: [
+        { cardId: "a" },
+        { cardId: "b", reason: "x" },
+        { cardId: "c", reason: "x", suggestedAction: "y" },
+      ],
+    });
+    const result = parseBriefingResponse(raw, validIds);
+    expect(result.map((p) => p.cardId)).toEqual(["c"]);
+  });
+
+  it("caps at 3 picks even if LLM returns more", () => {
+    const raw = JSON.stringify({
+      picks: Array.from({ length: 8 }, (_, i) => ({
+        cardId: i % 3 === 0 ? "a" : i % 3 === 1 ? "b" : "c",
+        reason: `r${i}`,
+        suggestedAction: `a${i}`,
+      })),
+    });
+    const result = parseBriefingResponse(raw, validIds);
+    expect(result.length).toBeLessThanOrEqual(3);
+  });
+
+  it("returns empty on malformed JSON", () => {
+    expect(parseBriefingResponse("not json", validIds)).toEqual([]);
+  });
+
+  it("returns empty when picks is missing", () => {
+    expect(parseBriefingResponse(JSON.stringify({ other: 1 }), validIds)).toEqual([]);
+  });
+});
+
+describe("briefingCacheKey", () => {
+  it("is stable for same date + candidate set", () => {
+    const a = briefingCacheKey(NOW, ["c1", "c2", "c3"]);
+    const b = briefingCacheKey(NOW, ["c1", "c2", "c3"]);
+    expect(a).toBe(b);
+  });
+
+  it("is order-independent on candidate ids", () => {
+    const a = briefingCacheKey(NOW, ["c1", "c2", "c3"]);
+    const b = briefingCacheKey(NOW, ["c3", "c1", "c2"]);
+    expect(a).toBe(b);
+  });
+
+  it("changes when the date changes", () => {
+    const today = briefingCacheKey(NOW, ["a"]);
+    const tomorrow = briefingCacheKey(new Date("2026-04-26T10:00:00Z"), ["a"]);
+    expect(today).not.toBe(tomorrow);
+  });
+
+  it("changes when the candidate set changes", () => {
+    const a = briefingCacheKey(NOW, ["c1", "c2"]);
+    const b = briefingCacheKey(NOW, ["c1", "c2", "c3"]);
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/lib/coach/__tests__/priority.test.ts
+++ b/src/lib/coach/__tests__/priority.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import { selectTodayPriorityCards } from "../priority";
+
+const NOW = new Date("2026-04-25T10:00:00Z");
+
+function mk(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    social: {},
+    createdAt: new Date("2025-01-01"),
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe("selectTodayPriorityCards", () => {
+  it("returns empty when no cards meet any priority threshold", () => {
+    const fresh = mk({
+      id: "fresh",
+      lastContactedAt: new Date("2026-04-20"),
+    });
+    expect(selectTodayPriorityCards([fresh], { now: NOW })).toEqual([]);
+  });
+
+  it("flags overdue followUp with the highest score", () => {
+    const overdue = mk({
+      id: "overdue",
+      followUpAt: new Date("2026-04-10"), // 15 days overdue
+    });
+    const dueToday = mk({
+      id: "today",
+      followUpAt: new Date("2026-04-25"),
+    });
+    const result = selectTodayPriorityCards([dueToday, overdue], { now: NOW });
+    expect(result.map((r) => r.card.id)).toEqual(["overdue", "today"]);
+    expect(result[0]!.reason).toBe("followup-overdue");
+    expect(result[1]!.reason).toBe("followup-due-today");
+  });
+
+  it("scores anniversary lower than followUp but higher than uncontacted", () => {
+    const followUp = mk({
+      id: "fu",
+      followUpAt: new Date("2026-04-25"),
+    });
+    const anniv = mk({
+      id: "anniv",
+      firstMetDate: "2025-04-25",
+    });
+    const stale = mk({
+      id: "stale",
+      lastContactedAt: new Date("2025-12-01"),
+    });
+    const result = selectTodayPriorityCards([anniv, followUp, stale], { now: NOW });
+    expect(result.map((r) => r.card.id)).toEqual(["fu", "anniv", "stale"]);
+    expect(result[1]!.reason).toBe("anniversary");
+    expect(result[2]!.reason).toBe("uncontacted-long");
+  });
+
+  it("flags pinned-stale (>=21 days uncontacted) for pinned cards", () => {
+    const pinnedStale = mk({
+      id: "pinned",
+      isPinned: true,
+      lastContactedAt: new Date("2026-04-01"), // 24 days
+    });
+    const result = selectTodayPriorityCards([pinnedStale], { now: NOW });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.reason).toBe("pinned-stale");
+  });
+
+  it("does not include pinned cards contacted recently", () => {
+    const pinnedFresh = mk({
+      id: "pinFresh",
+      isPinned: true,
+      lastContactedAt: new Date("2026-04-20"), // 5 days
+    });
+    expect(selectTodayPriorityCards([pinnedFresh], { now: NOW })).toEqual([]);
+  });
+
+  it("excludes soft-deleted cards", () => {
+    const deleted = mk({
+      id: "del",
+      followUpAt: new Date("2026-04-10"),
+      deletedAt: new Date("2026-04-20"),
+    });
+    expect(selectTodayPriorityCards([deleted], { now: NOW })).toEqual([]);
+  });
+
+  it("caps results at max (default 5)", () => {
+    const cards = Array.from({ length: 12 }, (_, i) =>
+      mk({
+        id: `c${i}`,
+        followUpAt: new Date("2026-04-20"),
+      }),
+    );
+    const result = selectTodayPriorityCards(cards, { now: NOW });
+    expect(result).toHaveLength(5);
+  });
+
+  it("respects custom max", () => {
+    const cards = Array.from({ length: 8 }, (_, i) =>
+      mk({
+        id: `c${i}`,
+        followUpAt: new Date("2026-04-20"),
+      }),
+    );
+    expect(selectTodayPriorityCards(cards, { now: NOW, max: 3 })).toHaveLength(3);
+  });
+
+  it("anniversary years scale the score (5y > 1y)", () => {
+    const oneYear = mk({ id: "1y", firstMetDate: "2025-04-25" });
+    const fiveYear = mk({ id: "5y", firstMetDate: "2021-04-25" });
+    const result = selectTodayPriorityCards([oneYear, fiveYear], { now: NOW });
+    expect(result.map((r) => r.card.id)).toEqual(["5y", "1y"]);
+  });
+
+  it("a card hitting multiple categories keeps its highest reason only", () => {
+    const both = mk({
+      id: "both",
+      followUpAt: new Date("2026-04-10"), // overdue
+      firstMetDate: "2025-04-25", // anniversary today too
+    });
+    const result = selectTodayPriorityCards([both], { now: NOW });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.reason).toBe("followup-overdue");
+  });
+
+  it("daysOffset is meaningful per reason kind", () => {
+    const overdue = mk({ id: "o", followUpAt: new Date("2026-04-10") });
+    const dueToday = mk({ id: "d", followUpAt: new Date("2026-04-25") });
+    const stale = mk({ id: "s", lastContactedAt: new Date("2025-10-01") });
+    const result = selectTodayPriorityCards([overdue, dueToday, stale], { now: NOW });
+    expect(result.find((r) => r.card.id === "o")!.daysOffset).toBeGreaterThan(0);
+    expect(result.find((r) => r.card.id === "d")!.daysOffset).toBe(0);
+    expect(result.find((r) => r.card.id === "s")!.daysOffset).toBeGreaterThan(60);
+  });
+});

--- a/src/lib/coach/briefing-llm.ts
+++ b/src/lib/coach/briefing-llm.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+import { buildBriefingMessages, parseBriefingResponse, type BriefingPick } from "./briefing";
+import type { PriorityCandidate } from "./priority";
+
+const DEFAULT_BASE_URL = "https://api.minimax.chat/v1";
+const DEFAULT_MODEL = "MiniMax-M2.7";
+const DEFAULT_TIMEOUT_MS = 12_000;
+
+interface MiniMaxChatResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+/**
+ * Call MiniMax to narrow N pre-scored candidates to the top 3 with
+ * human-voice reasons. Returns null on any failure (matches the rest
+ * of the coach module's degrade-silently pattern).
+ */
+export async function callBriefingLlm(
+  candidates: readonly PriorityCandidate[],
+  today: Date,
+  options: { timeoutMs?: number } = {},
+): Promise<BriefingPick[] | null> {
+  const apiKey = process.env.MINIMAX_API_KEY ?? "";
+  if (!apiKey) return null;
+  if (candidates.length === 0) return [];
+
+  const baseUrl = process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = process.env.MINIMAX_MODEL ?? DEFAULT_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const body = {
+    model,
+    temperature: 0.4,
+    max_tokens: 800,
+    messages: buildBriefingMessages(candidates, today),
+  };
+
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: abort.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as MiniMaxChatResponse;
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) return null;
+    const validIds = new Set(candidates.map((c) => c.card.id));
+    return parseBriefingResponse(raw, validIds);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/coach/briefing-store.ts
+++ b/src/lib/coach/briefing-store.ts
@@ -1,0 +1,54 @@
+import "server-only";
+
+import { Timestamp } from "firebase-admin/firestore";
+
+import { getAdminFirestore } from "@/lib/firebase/server";
+import { COLLECTION_WORKSPACES, personalWorkspaceId } from "@/lib/firebase/shared";
+
+import type { BriefingPick } from "./briefing";
+
+const BRIEFING_SUBCOLLECTION = "briefing";
+
+interface CachedBriefingDoc {
+  cacheKey: string;
+  picks: BriefingPick[];
+  generatedAt: Timestamp;
+}
+
+/**
+ * Look up the user's daily briefing for a given cache key. Returns null
+ * on miss or when the stored cache key differs (e.g. candidate set
+ * changed since this morning so the cached picks are stale).
+ *
+ * Stored at workspaces/{wid}/briefing/today (single doc — older
+ * briefings aren't useful, fresh picks every day).
+ */
+export async function readBriefingCache(
+  uid: string,
+  cacheKey: string,
+): Promise<BriefingPick[] | null> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${COLLECTION_WORKSPACES}/${wid}/${BRIEFING_SUBCOLLECTION}/today`);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const data = snap.data() as CachedBriefingDoc | undefined;
+  if (!data) return null;
+  if (data.cacheKey !== cacheKey) return null;
+  return data.picks;
+}
+
+export async function writeBriefingCache(
+  uid: string,
+  cacheKey: string,
+  picks: BriefingPick[],
+): Promise<void> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${COLLECTION_WORKSPACES}/${wid}/${BRIEFING_SUBCOLLECTION}/today`);
+  await ref.set({
+    cacheKey,
+    picks,
+    generatedAt: Timestamp.now(),
+  });
+}

--- a/src/lib/coach/briefing.ts
+++ b/src/lib/coach/briefing.ts
@@ -1,0 +1,147 @@
+import type { PriorityCandidate, PriorityReason } from "./priority";
+
+export interface BriefingPick {
+  cardId: string;
+  /** 1-2 sentence reason in zh-Hant explaining why today is the right day. */
+  reason: string;
+  /** A single concrete suggested action ("寄一封 follow-up email", "打電話約下週咖啡"). */
+  suggestedAction: string;
+}
+
+export interface DailyBriefing {
+  /** ISO date the briefing was generated for (YYYY-MM-DD). */
+  date: string;
+  /** AI-curated top 3 picks (or fewer if fewer candidates). */
+  picks: BriefingPick[];
+}
+
+const MAX_PICKS = 3;
+const MAX_REASON_LEN = 220;
+const MAX_ACTION_LEN = 120;
+
+function reasonLabel(reason: PriorityReason, days: number | null): string {
+  switch (reason) {
+    case "followup-overdue":
+      return `提醒已過期 ${days ?? "?"} 天`;
+    case "followup-due-today":
+      return "提醒到期今天";
+    case "anniversary":
+      return `${days ?? "?"} 年前的今天認識`;
+    case "pinned-stale":
+      return `重要聯絡人，已 ${days ?? "?"} 天沒互動`;
+    case "uncontacted-long":
+      return `已 ${days ?? "?"} 天沒互動`;
+  }
+}
+
+function pickName(card: PriorityCandidate["card"]): string {
+  return card.nameZh || card.nameEn || "（未命名）";
+}
+
+/**
+ * Build the prompt sent to the LLM. The candidates are pre-scored — the
+ * LLM's job is to *narrow to 3* and *write the reason in human voice*,
+ * not to do the prioritization math itself.
+ */
+export function buildBriefingPrompt(candidates: readonly PriorityCandidate[], today: Date): string {
+  const dateStr = today.toISOString().slice(0, 10);
+  const lines: string[] = [];
+  lines.push(`今天是 ${dateStr}。`);
+  lines.push(`從以下 ${candidates.length} 位候選聯絡人中，挑 ${MAX_PICKS} 位最該今天聯絡的人。`);
+  lines.push("");
+  lines.push("=== 候選人（按系統評分排序，分數越高越急） ===");
+  for (const c of candidates) {
+    const card = c.card;
+    const tags: string[] = [];
+    tags.push(`評分=${c.score}`);
+    tags.push(reasonLabel(c.reason, c.daysOffset));
+    if (card.isPinned) tags.push("重要聯絡人");
+    if (card.firstMetEventTag) tags.push(`場合=${card.firstMetEventTag}`);
+    const company = card.companyZh || card.companyEn;
+    const role = card.jobTitleZh || card.jobTitleEn;
+    const header = `# ${pickName(card)}（${[role, company].filter(Boolean).join(" / ") || "—"}）`;
+    lines.push("");
+    lines.push(header);
+    lines.push(`卡片 ID: ${card.id}`);
+    lines.push(`狀態: ${tags.join(" · ")}`);
+    if (card.whyRemember) lines.push(`為什麼記得: ${card.whyRemember}`);
+    if (card.firstMetDate) lines.push(`首次見面: ${card.firstMetDate}`);
+    if (card.lastContactedAt) {
+      lines.push(`上次互動: ${card.lastContactedAt.toISOString().slice(0, 10)}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+const SYSTEM_PROMPT =
+  "你是商務人脈每日簡報官，幫使用者每天挑出最該聯絡的 3 位人。" +
+  "從使用者提供的候選人中挑 3 位，根據他們的系統評分、為什麼記得、首次見面背景，" +
+  "用一段 1-2 句的繁體中文 reason 解釋「今天為什麼該找他」，要具體、有 hook。" +
+  "再給一個 suggestedAction（一個動詞開頭的具體動作，例如「寄一封 hello email + 問近況」）。\n" +
+  "回答必須是合法 JSON，符合 schema：\n" +
+  '{"picks": [{"cardId": string, "reason": string, "suggestedAction": string}]}\n' +
+  "規則：\n" +
+  "- 最多 3 位；如果候選人少於 3 位，就回傳全部。\n" +
+  "- cardId 必須完全對應候選人的卡片 ID。\n" +
+  "- reason 220 字內、suggestedAction 120 字內。\n" +
+  "- 不要任何其他文字、不要 markdown 圍欄。";
+
+export function buildBriefingMessages(
+  candidates: readonly PriorityCandidate[],
+  today: Date,
+): Array<{ role: "system" | "user"; content: string }> {
+  return [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: buildBriefingPrompt(candidates, today) },
+  ];
+}
+
+function sanitizeStr(value: unknown, max: number): string {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, max);
+}
+
+/**
+ * Parse the LLM JSON. Defensive: drops malformed picks, trims long
+ * fields, caps at MAX_PICKS, validates cardId belongs to the
+ * candidate set so the LLM can't fabricate IDs.
+ */
+export function parseBriefingResponse(
+  raw: string,
+  validCardIds: ReadonlySet<string>,
+): BriefingPick[] {
+  if (!raw) return [];
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const inner = fenced ? fenced[1]! : trimmed;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(inner);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object") return [];
+  const picks = (parsed as { picks?: unknown }).picks;
+  if (!Array.isArray(picks)) return [];
+
+  const out: BriefingPick[] = [];
+  for (const item of picks) {
+    if (!item || typeof item !== "object") continue;
+    const obj = item as Record<string, unknown>;
+    const cardId = sanitizeStr(obj.cardId, 200);
+    if (!cardId || !validCardIds.has(cardId)) continue;
+    const reason = sanitizeStr(obj.reason, MAX_REASON_LEN);
+    const suggestedAction = sanitizeStr(obj.suggestedAction, MAX_ACTION_LEN);
+    if (!reason || !suggestedAction) continue;
+    out.push({ cardId, reason, suggestedAction });
+    if (out.length >= MAX_PICKS) break;
+  }
+  return out;
+}
+
+/** Cache key for the daily briefing — stable for same date + candidate set. */
+export function briefingCacheKey(date: Date, candidateIds: readonly string[]): string {
+  const dateStr = date.toISOString().slice(0, 10);
+  const sortedIds = [...candidateIds].sort().join(",");
+  return `${dateStr}::${sortedIds}`;
+}

--- a/src/lib/coach/priority.ts
+++ b/src/lib/coach/priority.ts
@@ -1,0 +1,149 @@
+import type { CardSummary } from "@/db/cards";
+
+import { findAnniversariesToday } from "@/lib/timeline/anniversaries";
+
+export interface PriorityCandidate {
+  card: CardSummary;
+  /** Composite score, higher = more urgent. */
+  score: number;
+  /** Human-readable reason cluster ("followUp due", "anniversary", "stale-pinned", "uncontacted-30+"). */
+  reason: PriorityReason;
+  /** Days until / since the trigger, used by LLM to phrase the reason naturally. */
+  daysOffset: number | null;
+}
+
+export type PriorityReason =
+  | "followup-overdue"
+  | "followup-due-today"
+  | "anniversary"
+  | "pinned-stale"
+  | "uncontacted-long";
+
+interface PriorityOptions {
+  now: Date;
+  /** Maximum candidates to return for the LLM picker. Default 5. */
+  max?: number;
+  /** Pinned cards re-engage threshold (days). Default 21. */
+  pinnedStaleDays?: number;
+  /** Generic uncontacted threshold (days). Default 30. */
+  uncontactedDays?: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.floor((a.getTime() - b.getTime()) / MS_PER_DAY);
+}
+
+function endOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(23, 59, 59, 999);
+  return x;
+}
+
+/**
+ * Score-based ranker that picks today's highest-priority cards. Used by
+ * the daily briefing as the initial candidate filter — the LLM then
+ * narrows further (it can read the *content* of whyRemember / events,
+ * which a pure scorer cannot).
+ *
+ * Score weights:
+ *   followup-overdue:       100 + days-overdue * 2  (overdue followUp ages, never decays)
+ *   followup-due-today:     90  (committed action today)
+ *   anniversary:            80  + 5 * years (5 年週年比 1 年高)
+ *   pinned-stale (≥ 21d):   60  + days-since-contact / 7
+ *   uncontacted (≥ 30d):    40  + days-since-contact / 30 (capped at +20)
+ *
+ * A card can hit multiple categories — we keep its highest-scoring
+ * reason so the LLM gets unambiguous context.
+ */
+export function selectTodayPriorityCards(
+  cards: readonly CardSummary[],
+  options: PriorityOptions,
+): PriorityCandidate[] {
+  const { now, max = 5, pinnedStaleDays = 21, uncontactedDays = 30 } = options;
+  const live = cards.filter((c) => !c.deletedAt);
+  const todayEnd = endOfDay(now);
+  const anniversaryMap = new Map(
+    findAnniversariesToday(live, now).map((e) => [e.card.id, e.years]),
+  );
+
+  const candidates: PriorityCandidate[] = [];
+
+  for (const card of live) {
+    const reasons: PriorityCandidate[] = [];
+
+    if (card.followUpAt) {
+      const days = daysBetween(todayEnd, card.followUpAt);
+      if (days > 0) {
+        reasons.push({
+          card,
+          score: 100 + Math.min(days * 2, 60),
+          reason: "followup-overdue",
+          daysOffset: days,
+        });
+      } else if (days === 0 || days === -0) {
+        reasons.push({ card, score: 90, reason: "followup-due-today", daysOffset: 0 });
+      }
+    }
+
+    const annivYears = anniversaryMap.get(card.id);
+    if (annivYears !== undefined) {
+      reasons.push({
+        card,
+        score: 80 + Math.min(annivYears * 5, 25),
+        reason: "anniversary",
+        daysOffset: annivYears,
+      });
+    }
+
+    if (card.isPinned && card.lastContactedAt) {
+      const days = daysBetween(now, card.lastContactedAt);
+      if (days >= pinnedStaleDays) {
+        reasons.push({
+          card,
+          score: 60 + Math.floor(days / 7),
+          reason: "pinned-stale",
+          daysOffset: days,
+        });
+      }
+    } else if (card.isPinned && !card.lastContactedAt && card.createdAt) {
+      const days = daysBetween(now, card.createdAt);
+      if (days >= pinnedStaleDays) {
+        reasons.push({
+          card,
+          score: 60 + Math.floor(days / 7),
+          reason: "pinned-stale",
+          daysOffset: days,
+        });
+      }
+    }
+
+    // Generic stale-uncontacted only for non-pinned cards (pinned already covered above).
+    if (!card.isPinned) {
+      const baseDate = card.lastContactedAt ?? card.createdAt;
+      if (baseDate) {
+        const days = daysBetween(now, baseDate);
+        if (days >= uncontactedDays) {
+          reasons.push({
+            card,
+            score: 40 + Math.min(Math.floor(days / 30), 20),
+            reason: "uncontacted-long",
+            daysOffset: days,
+          });
+        }
+      }
+    }
+
+    if (reasons.length === 0) continue;
+    // Keep the highest-scoring reason for this card.
+    reasons.sort((a, b) => b.score - a.score);
+    candidates.push(reasons[0]!);
+  }
+
+  candidates.sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score;
+    return a.card.id.localeCompare(b.card.id);
+  });
+  return candidates.slice(0, max);
+}


### PR DESCRIPTION
Closes #84

## Summary
商務人士每天打開 app 第一個動作應該是「今天該找誰？」AI Coach (#82) 已能對單卡產出洞察。這刀把同樣能力升級成 1:N — 每天 AI 從所有 cards 挑 3 位最該 ping 的人，給每位一段「為什麼今天該找他」+ 一鍵動作。

> 把 app 從 daily glance → daily personalized standup。

## Demo (when MINIMAX_API_KEY is set)

```
📰 今日人脈簡報

[1] 王 PM（產品 / 智威科技）
    你們 3 個月前在 Computex 攤位聊邊緣 AI。距上次互動 32 天，他剛升 PM
    可能在重整資源 — 這是個自然的「最近怎樣」破冰機會。
    👉 寄一封短 email 問「智威 ML team 最近在忙什麼？」+ 分享一篇邊緣推論文章

[2] 陳 CEO（執行長 / FastTrack）
    重要聯絡人，已 24 天沒互動。距你們上次合作提案剛好滿一個月，
    可以接續上次討論的下一步。
    👉 LINE 一句「上次討論的合作下一步要怎麼走？」

[3] 李 BD（業務開發 / 沛理）
    一年前的今天認識（Web Summit Lisbon 2025）。週年是商務人脈最自然的
    re-engage 觸發點。
    👉 寫個訊息「一年前我們在 Lisbon 認識，現在還在沛理嗎？」

[✅ 今天已聯絡] [📅 +7 天再提醒] [看完整名片 →]
```

## Files
- `src/lib/coach/priority.ts` (+135) — pure-fn scorer combining 4 signals
- `src/lib/coach/briefing.ts` (+150) — prompt builder + JSON parser + cache key
- `src/lib/coach/briefing-llm.ts` (+60) — MiniMax client (12s timeout, null on fail)
- `src/lib/coach/briefing-store.ts` (+55) — Firestore daily cache
- Server Action `getDailyBriefingAction({ force })` in `src/app/(app)/cards/actions.ts`
- `<DailyBriefingSection>` (+220) on home — 3 numbered picks with inline actions
- 25 UT total (11 priority + 14 briefing)

## Architecture
- **Pure-fn scorer first**: priority.ts narrows N cards → top 5 deterministically. Cheap. LLM only sees 5.
- **LLM does narrowing + voicing**: from 5, picks 3 + writes human-voice reason. The hard part.
- **Daily cache**: workspaces/{wid}/briefing/today, key = (date + sorted candidate ids). Same day re-opens = same picks. Tomorrow = auto-recompute.
- **Anti-hallucination**: parser drops any cardId not in the original candidate set. LLM can't fabricate IDs.
- **Inline actions** wire to existing `logContactAction` + `setFollowUpAction`. Coach suggests, user one-clicks to execute, then router.refresh() re-runs the candidate scoring (cleared from list since lastContactedAt updated).
- **Conditional render**: only when `isCoachConfigured()` AND ≥3 cards exist (no point briefing 1 card).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 517 pass (+25 new)
- [x] `pnpm lint` — clean (4 unrelated pre-existing)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — green
- [ ] CI green → merge → mac mini deploy

## Out of scope
- Push notification / email digest (要 cron infra)
- Cross-day history「過去 7 天我 ping 過誰」
- Briefing customization (e.g.「只挑 pinned」)