### PR TITLE
feat(followups): ✨ AI 重新聯絡訊息草稿 — 一鍵生成 3 種口氣訊息

### DIFF
--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -31,6 +31,9 @@ import {
 } from "@/lib/coach/insights";
 import { callCoachLlm, isCoachConfigured } from "@/lib/coach/llm";
 import { selectTodayPriorityCards, type PriorityCandidate } from "@/lib/coach/priority";
+import { reengageCacheKey, type ReengageContext, type ReengageDrafts } from "@/lib/coach/reengage";
+import { callReengageLlm } from "@/lib/coach/reengage-llm";
+import { readReengageCache, writeReengageCache } from "@/lib/coach/reengage-store";
 import { readCoachCache, writeCoachCache } from "@/lib/coach/store";
 import { pickCanonicalCompany } from "@/lib/companies/group";
 
@@ -350,6 +353,47 @@ export const getDailyBriefingAction = authedAction
         })
         .filter((x): x is { pick: BriefingPick; candidate: PriorityCandidate } => x !== null);
       return { ok: true, picks, cached: false };
+    },
+  );
+
+/**
+ * ✨ AI 重新聯絡訊息草稿 — for a single card, ask MiniMax to produce
+ * 3 ready-to-send drafts (LINE 短訊 / Email 正式 / 偶遇式 hook) given
+ * whyRemember + days-since-contact + recent events. Cached 12h per
+ * (cardId, contextHash with staleness bucket).
+ */
+export const getReengageDraftsAction = authedAction
+  .inputSchema(
+    z.object({
+      cardId: z.string().min(1),
+      force: z.boolean().optional().default(false),
+    }),
+  )
+  .action(
+    async ({
+      parsedInput,
+      ctx,
+    }): Promise<
+      | { ok: true; drafts: ReengageDrafts; cached: boolean }
+      | { ok: false; reason: "no-llm" | "card-not-found" | "llm-failed" }
+    > => {
+      if (!isCoachConfigured()) return { ok: false, reason: "no-llm" };
+      const card = await getCardForUser(ctx.user.uid, parsedInput.cardId);
+      if (!card || card.deletedAt) return { ok: false, reason: "card-not-found" };
+
+      const recentEvents = await listContactEventsForUser(card.id, ctx.user.uid, 5);
+      const reengageCtx: ReengageContext = { card, recentEvents, now: new Date() };
+      const hash = reengageCacheKey(reengageCtx);
+
+      if (!parsedInput.force) {
+        const cached = await readReengageCache(ctx.user.uid, card.id, hash);
+        if (cached) return { ok: true, drafts: cached, cached: true };
+      }
+
+      const drafts = await callReengageLlm(reengageCtx);
+      if (!drafts) return { ok: false, reason: "llm-failed" };
+      await writeReengageCache(ctx.user.uid, card.id, hash, drafts);
+      return { ok: true, drafts, cached: false };
     },
   );
 

--- a/src/app/(app)/followups/page.tsx
+++ b/src/app/(app)/followups/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { FollowupCardRow } from "@/components/followups/FollowupCardRow";
 import { listCardsForUser } from "@/db/cards";
+import { isCoachConfigured } from "@/lib/coach/llm";
 import { readSession } from "@/lib/firebase/session";
 import { bucketFollowups, totalFollowups, type FollowupBucket } from "@/lib/timeline/followups";
 
@@ -22,6 +23,7 @@ export default async function FollowupsPage() {
   });
   const groups = bucketFollowups(cards, new Date());
   const total = totalFollowups(groups);
+  const showAiDrafts = isCoachConfigured();
 
   const ordered: FollowupBucket[] = [
     groups.pinnedStale,
@@ -67,7 +69,12 @@ export default async function FollowupsPage() {
               </header>
               <ol className={styles.list}>
                 {bucket.cards.map(({ card, days }) => (
-                  <FollowupCardRow key={card.id} card={card} days={days} />
+                  <FollowupCardRow
+                    key={card.id}
+                    card={card}
+                    days={days}
+                    showAiDrafts={showAiDrafts}
+                  />
                 ))}
               </ol>
             </section>

--- a/src/components/coach/ReengageDraftsButton.module.css
+++ b/src/components/coach/ReengageDraftsButton.module.css
@@ -1,0 +1,199 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  position: relative;
+  width: 100%;
+}
+
+.trigger {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--color-paper);
+  color: var(--color-accent-ink);
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.trigger:hover:not(:disabled) {
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.trigger:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.panel {
+  margin-top: var(--space-xs);
+  padding: var(--space-md);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 35%, var(--color-paper)) 0%,
+    var(--color-paper) 100%
+  );
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.spinner {
+  width: 0.9em;
+  height: 0.9em;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent-ink);
+  border-radius: 50%;
+  animation: reengageSpin 0.7s linear infinite;
+}
+
+@keyframes reengageSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.errorBox {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-sm);
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 80%,
+    var(--color-paper)
+  );
+  border-radius: var(--radius-sm);
+  font-family: var(--font-sans);
+}
+
+.errorBox p {
+  margin: 0;
+  font-size: var(--text-caption);
+  color: var(--color-ink);
+}
+
+.drafts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.draftBlock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-sm);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.draftHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.draftTitle {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  font-weight: 600;
+  color: var(--color-ink);
+  letter-spacing: var(--tracking-wide);
+}
+
+.draftActions {
+  display: flex;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+}
+
+.draftBody {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-feature-settings: normal;
+}
+
+.smallBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  padding: 0.15em 0.6em;
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.smallBtn:hover:not(:disabled) {
+  border-color: var(--color-accent-ink);
+}
+
+.smallBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.smallLink {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  padding: 0.15em 0.6em;
+  color: var(--color-accent-ink);
+  text-decoration: none;
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-sm);
+}
+
+.smallLink:hover {
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding-top: var(--space-xs);
+  border-top: var(--border-hair) solid var(--color-border);
+}
+
+.cachedNote {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  color: var(--color-ink-muted);
+  font-style: italic;
+}
+
+.copyToast {
+  position: fixed;
+  bottom: var(--space-lg);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  z-index: 100;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 20%);
+}

--- a/src/components/coach/ReengageDraftsButton.tsx
+++ b/src/components/coach/ReengageDraftsButton.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { getReengageDraftsAction } from "@/app/(app)/cards/actions";
+import type { ReengageDrafts } from "@/lib/coach/reengage";
+
+import styles from "./ReengageDraftsButton.module.css";
+
+interface ReengageDraftsButtonProps {
+  cardId: string;
+  /** Optional contact channels — when present, the UI offers "open in app" alongside copy. */
+  primaryEmail?: string;
+  primaryPhone?: string;
+  lineId?: string;
+}
+
+type LoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; drafts: ReengageDrafts; cached: boolean }
+  | { kind: "error"; message: string };
+
+function lineUrl(lineId: string): string {
+  return `https://line.me/ti/p/${
+    lineId.startsWith("@") ? encodeURIComponent(lineId) : `~${encodeURIComponent(lineId)}`
+  }`;
+}
+
+/**
+ * Inline "✨ AI 草稿" disclosure on the followup row. Opt-in to avoid
+ * burning tokens until the user explicitly asks for help. Renders
+ * three styles (短訊 / Email / 偶遇) with copy buttons + native
+ * deep-link openers when contact channels are available.
+ */
+export function ReengageDraftsButton({
+  cardId,
+  primaryEmail,
+  primaryPhone,
+  lineId,
+}: ReengageDraftsButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [state, setState] = useState<LoadState>({ kind: "idle" });
+  const [pending, startTransition] = useTransition();
+  const [copyToast, setCopyToast] = useState<string | null>(null);
+
+  const fetchDrafts = (force: boolean) => {
+    setState({ kind: "loading" });
+    startTransition(async () => {
+      const result = await getReengageDraftsAction({ cardId, force });
+      if (result?.serverError) {
+        setState({ kind: "error", message: result.serverError });
+        return;
+      }
+      const data = result?.data;
+      if (!data) {
+        setState({ kind: "error", message: "草稿生成失敗，請重試" });
+        return;
+      }
+      if (!data.ok) {
+        const messages: Record<string, string> = {
+          "no-llm": "AI 未啟用",
+          "card-not-found": "找不到名片",
+          "llm-failed": "AI 暫時無法回應",
+        };
+        setState({ kind: "error", message: messages[data.reason] ?? "未知錯誤" });
+        return;
+      }
+      setState({ kind: "ready", drafts: data.drafts, cached: data.cached });
+    });
+  };
+
+  const copy = async (text: string, what: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyToast(`已複製${what}`);
+      setTimeout(() => setCopyToast(null), 1800);
+    } catch {
+      setCopyToast("複製失敗");
+      setTimeout(() => setCopyToast(null), 1800);
+    }
+  };
+
+  const toggle = () => {
+    setOpen((v) => {
+      const next = !v;
+      if (next && state.kind === "idle") fetchDrafts(false);
+      return next;
+    });
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <button
+        type="button"
+        className={styles.trigger}
+        onClick={toggle}
+        aria-expanded={open}
+        disabled={pending && state.kind === "loading"}
+      >
+        {open ? "✕ 收合" : "✨ AI 草稿"}
+      </button>
+      {open && (
+        <div className={styles.panel} aria-live="polite">
+          {state.kind === "loading" && (
+            <p className={styles.loading}>
+              <span className={styles.spinner} aria-hidden="true" />
+              AI 寫稿中…
+            </p>
+          )}
+
+          {state.kind === "error" && (
+            <div className={styles.errorBox} role="alert">
+              <p>{state.message}</p>
+              <button type="button" className={styles.smallBtn} onClick={() => fetchDrafts(false)}>
+                重試
+              </button>
+            </div>
+          )}
+
+          {state.kind === "ready" && (
+            <div className={styles.drafts}>
+              {state.drafts.shortMessage && (
+                <DraftBlock title="🎯 短訊版" text={state.drafts.shortMessage}>
+                  <button
+                    type="button"
+                    className={styles.smallBtn}
+                    onClick={() => copy(state.drafts.shortMessage, "短訊")}
+                  >
+                    複製
+                  </button>
+                  {lineId && (
+                    <a
+                      href={lineUrl(lineId)}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className={styles.smallLink}
+                      onClick={() => copy(state.drafts.shortMessage, "短訊")}
+                    >
+                      開 LINE →
+                    </a>
+                  )}
+                  {primaryPhone && (
+                    <a
+                      href={`sms:${primaryPhone}?body=${encodeURIComponent(state.drafts.shortMessage)}`}
+                      className={styles.smallLink}
+                    >
+                      開 SMS →
+                    </a>
+                  )}
+                </DraftBlock>
+              )}
+
+              {(state.drafts.email.subject || state.drafts.email.body) && (
+                <DraftBlock
+                  title="📧 Email 版"
+                  text={
+                    state.drafts.email.subject
+                      ? `Subject: ${state.drafts.email.subject}\n\n${state.drafts.email.body}`
+                      : state.drafts.email.body
+                  }
+                >
+                  <button
+                    type="button"
+                    className={styles.smallBtn}
+                    onClick={() =>
+                      copy(
+                        `Subject: ${state.drafts.email.subject}\n\n${state.drafts.email.body}`,
+                        "Email",
+                      )
+                    }
+                  >
+                    複製
+                  </button>
+                  {primaryEmail && (
+                    <a
+                      href={`mailto:${primaryEmail}?subject=${encodeURIComponent(state.drafts.email.subject)}&body=${encodeURIComponent(state.drafts.email.body)}`}
+                      className={styles.smallLink}
+                    >
+                      開信件 →
+                    </a>
+                  )}
+                </DraftBlock>
+              )}
+
+              {state.drafts.casualPing && (
+                <DraftBlock title="☕ 偶遇版" text={state.drafts.casualPing}>
+                  <button
+                    type="button"
+                    className={styles.smallBtn}
+                    onClick={() => copy(state.drafts.casualPing, "偶遇 hook")}
+                  >
+                    複製
+                  </button>
+                </DraftBlock>
+              )}
+
+              <div className={styles.footer}>
+                <button
+                  type="button"
+                  className={styles.smallBtn}
+                  onClick={() => fetchDrafts(true)}
+                  disabled={pending}
+                >
+                  🔄 重新生成
+                </button>
+                {state.cached && <span className={styles.cachedNote}>12 小時內快取</span>}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+      {copyToast && (
+        <p className={styles.copyToast} role="status" aria-live="polite">
+          {copyToast}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function DraftBlock({
+  title,
+  text,
+  children,
+}: {
+  title: string;
+  text: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={styles.draftBlock}>
+      <header className={styles.draftHeader}>
+        <span className={styles.draftTitle}>{title}</span>
+        <div className={styles.draftActions}>{children}</div>
+      </header>
+      <pre className={styles.draftBody}>{text}</pre>
+    </div>
+  );
+}

--- a/src/components/followups/FollowupCardRow.module.css
+++ b/src/components/followups/FollowupCardRow.module.css
@@ -1,10 +1,16 @@
 .row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-sm) 0;
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.headerRow {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: var(--space-md);
   align-items: center;
-  padding: var(--space-sm) 0;
-  border-bottom: var(--border-hair) solid var(--color-border);
 }
 
 .link {

--- a/src/components/followups/FollowupCardRow.tsx
+++ b/src/components/followups/FollowupCardRow.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
 import { logContactAction } from "@/app/(app)/cards/actions";
+import { ReengageDraftsButton } from "@/components/coach/ReengageDraftsButton";
 import type { CardSummary } from "@/db/cards";
 
 import styles from "./FollowupCardRow.module.css";
@@ -12,6 +13,8 @@ import styles from "./FollowupCardRow.module.css";
 interface FollowupCardRowProps {
   card: CardSummary;
   days: number;
+  /** When false, hides the ✨ AI 草稿 disclosure (e.g. server didn't config LLM). */
+  showAiDrafts?: boolean;
 }
 
 /**
@@ -20,7 +23,7 @@ interface FollowupCardRowProps {
  * purpose — triage flow should be fast; typing a note is an extra
  * click the user can do from the detail page when they want to.
  */
-export function FollowupCardRow({ card, days }: FollowupCardRowProps) {
+export function FollowupCardRow({ card, days, showAiDrafts = false }: FollowupCardRowProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [done, setDone] = useState(false);
@@ -29,6 +32,9 @@ export function FollowupCardRow({ card, days }: FollowupCardRowProps) {
   const secondary = [card.jobTitleZh || card.jobTitleEn, card.companyZh || card.companyEn]
     .filter(Boolean)
     .join(" · ");
+  const primaryEmail = card.emails?.find((e) => e.primary)?.value ?? card.emails?.[0]?.value;
+  const primaryPhone = card.phones?.find((p) => p.primary)?.value ?? card.phones?.[0]?.value;
+  const lineId = card.social?.lineId;
 
   function handleMark() {
     startTransition(async () => {
@@ -43,23 +49,33 @@ export function FollowupCardRow({ card, days }: FollowupCardRowProps) {
 
   return (
     <li className={styles.row}>
-      <Link href={`/cards/${card.id}`} className={styles.link}>
-        <div className={styles.primary}>
-          {card.isPinned && <span className={styles.pin}>📍</span>}
-          <span className={styles.name}>{primary}</span>
-          {secondary && <span className={styles.secondary}>{secondary}</span>}
-        </div>
-        <span className={styles.days}>{days} 天</span>
-      </Link>
-      <button
-        type="button"
-        className={styles.markBtn}
-        onClick={handleMark}
-        disabled={pending || done}
-        aria-label={`標記已聯絡 ${primary}`}
-      >
-        {done ? "✓ 完成" : pending ? "記錄中…" : "✅ 已聯絡"}
-      </button>
+      <div className={styles.headerRow}>
+        <Link href={`/cards/${card.id}`} className={styles.link}>
+          <div className={styles.primary}>
+            {card.isPinned && <span className={styles.pin}>📍</span>}
+            <span className={styles.name}>{primary}</span>
+            {secondary && <span className={styles.secondary}>{secondary}</span>}
+          </div>
+          <span className={styles.days}>{days} 天</span>
+        </Link>
+        <button
+          type="button"
+          className={styles.markBtn}
+          onClick={handleMark}
+          disabled={pending || done}
+          aria-label={`標記已聯絡 ${primary}`}
+        >
+          {done ? "✓ 完成" : pending ? "記錄中…" : "✅ 已聯絡"}
+        </button>
+      </div>
+      {showAiDrafts && (
+        <ReengageDraftsButton
+          cardId={card.id}
+          primaryEmail={primaryEmail}
+          primaryPhone={primaryPhone}
+          lineId={lineId}
+        />
+      )}
     </li>
   );
 }

--- a/src/lib/coach/__tests__/reengage.test.ts
+++ b/src/lib/coach/__tests__/reengage.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary, ContactEvent } from "@/db/cards";
+
+import {
+  buildReengageMessages,
+  buildReengagePrompt,
+  isEmptyReengage,
+  parseReengageResponse,
+  reengageCacheKey,
+  type ReengageContext,
+} from "../reengage";
+
+const NOW = new Date("2026-04-25T10:00:00Z");
+
+function mkCard(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "card-1",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "陳玉涵",
+    nameEn: "Yu-Han",
+    jobTitleZh: "PM",
+    companyZh: "智威",
+    whyRemember: "Computex 邊緣 AI",
+    firstMetEventTag: "2024 COMPUTEX",
+    firstMetDate: "2024-06-04",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    social: {},
+    isPinned: false,
+    createdAt: new Date("2024-06-04"),
+    updatedAt: null,
+    lastContactedAt: new Date("2025-09-01"),
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function mkEvent(overrides: Partial<ContactEvent> = {}): ContactEvent {
+  return {
+    id: "ev-1",
+    at: new Date("2025-09-01"),
+    note: "",
+    authorUid: "u",
+    authorDisplay: null,
+    ...overrides,
+  };
+}
+
+function mkCtx(overrides: Partial<ReengageContext> = {}): ReengageContext {
+  return {
+    card: mkCard(),
+    recentEvents: [],
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe("buildReengagePrompt", () => {
+  it("includes name + role + company + whyRemember", () => {
+    const prompt = buildReengagePrompt(mkCtx());
+    expect(prompt).toContain("陳玉涵");
+    expect(prompt).toContain("PM");
+    expect(prompt).toContain("智威");
+    expect(prompt).toContain("Computex 邊緣 AI");
+  });
+
+  it("computes days-since-contact", () => {
+    const prompt = buildReengagePrompt(mkCtx());
+    // 2026-04-25 - 2025-09-01 ≈ 236 days
+    expect(prompt).toMatch(/距上次互動：\d+ 天/);
+  });
+
+  it("flags 'no contact yet' when lastContactedAt is null", () => {
+    const prompt = buildReengagePrompt(mkCtx({ card: mkCard({ lastContactedAt: null }) }));
+    expect(prompt).toContain("尚未有任何互動紀錄");
+  });
+
+  it("includes recent contact event notes", () => {
+    const ctx = mkCtx({
+      recentEvents: [mkEvent({ note: "視訊聊新方案", at: new Date("2026-04-01") })],
+    });
+    const prompt = buildReengagePrompt(ctx);
+    expect(prompt).toContain("近期互動歷史");
+    expect(prompt).toContain("2026-04-01");
+    expect(prompt).toContain("視訊聊新方案");
+  });
+});
+
+describe("buildReengageMessages", () => {
+  it("returns system + user, system specifies 3-bucket schema", () => {
+    const msgs = buildReengageMessages(mkCtx());
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.content).toContain("shortMessage");
+    expect(msgs[0]!.content).toContain("email");
+    expect(msgs[0]!.content).toContain("casualPing");
+  });
+});
+
+describe("parseReengageResponse", () => {
+  it("parses a clean JSON response", () => {
+    const raw = JSON.stringify({
+      shortMessage: "Hi 陳玉涵！最近怎樣？",
+      email: { subject: "問候 + 一個想法", body: "親愛的玉涵...\n\n保持聯絡 :)" },
+      casualPing: "剛剛看到 NVIDIA 新晶片，想到你。",
+    });
+    const result = parseReengageResponse(raw);
+    expect(result).not.toBeNull();
+    expect(result!.shortMessage).toBe("Hi 陳玉涵！最近怎樣？");
+    expect(result!.email.subject).toBe("問候 + 一個想法");
+    expect(result!.casualPing).toContain("NVIDIA");
+  });
+
+  it("strips markdown json fence", () => {
+    const raw =
+      "```json\n" +
+      JSON.stringify({
+        shortMessage: "hi",
+        email: { subject: "x", body: "y" },
+        casualPing: "z",
+      }) +
+      "\n```";
+    const result = parseReengageResponse(raw);
+    expect(result).not.toBeNull();
+    expect(result!.shortMessage).toBe("hi");
+  });
+
+  it("returns null on malformed JSON", () => {
+    expect(parseReengageResponse("not json")).toBeNull();
+  });
+
+  it("returns null on non-object root", () => {
+    expect(parseReengageResponse("[1,2]")).toBeNull();
+  });
+
+  it("returns null when all fields are empty / missing", () => {
+    expect(parseReengageResponse(JSON.stringify({}))).toBeNull();
+  });
+
+  it("survives partial response (just shortMessage)", () => {
+    const result = parseReengageResponse(JSON.stringify({ shortMessage: "hi" }));
+    expect(result).not.toBeNull();
+    expect(result!.shortMessage).toBe("hi");
+    expect(result!.email.subject).toBe("");
+    expect(result!.casualPing).toBe("");
+  });
+
+  it("trims whitespace and respects max lengths", () => {
+    const longText = "x".repeat(2000);
+    const result = parseReengageResponse(
+      JSON.stringify({
+        shortMessage: `  ${longText}  `,
+        email: { subject: longText, body: longText },
+        casualPing: "valid",
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.shortMessage.length).toBeLessThanOrEqual(280);
+    expect(result!.email.subject.length).toBeLessThanOrEqual(120);
+    expect(result!.email.body.length).toBeLessThanOrEqual(1200);
+  });
+});
+
+describe("isEmptyReengage", () => {
+  it("true for null", () => {
+    expect(isEmptyReengage(null)).toBe(true);
+  });
+
+  it("true when all fields are empty", () => {
+    expect(
+      isEmptyReengage({
+        shortMessage: "",
+        email: { subject: "", body: "" },
+        casualPing: "",
+      }),
+    ).toBe(true);
+  });
+
+  it("false when any field has content", () => {
+    expect(
+      isEmptyReengage({
+        shortMessage: "x",
+        email: { subject: "", body: "" },
+        casualPing: "",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("reengageCacheKey", () => {
+  it("is stable for identical context", () => {
+    expect(reengageCacheKey(mkCtx())).toBe(reengageCacheKey(mkCtx()));
+  });
+
+  it("changes when whyRemember changes", () => {
+    const a = reengageCacheKey(mkCtx());
+    const b = reengageCacheKey(mkCtx({ card: mkCard({ whyRemember: "different" }) }));
+    expect(a).not.toBe(b);
+  });
+
+  it("stays in the same bucket within a 14-day window", () => {
+    // both within "0-14d" bucket
+    const a = reengageCacheKey(
+      mkCtx({
+        card: mkCard({ lastContactedAt: new Date("2026-04-25T00:00:00Z") }),
+      }),
+    );
+    const b = reengageCacheKey(
+      mkCtx({
+        card: mkCard({ lastContactedAt: new Date("2026-04-12T00:00:00Z") }),
+      }),
+    );
+    expect(a).toBe(b);
+  });
+
+  it("changes when crossing a bucket boundary", () => {
+    // 5 days vs 60 days = different buckets
+    const a = reengageCacheKey(
+      mkCtx({ card: mkCard({ lastContactedAt: new Date("2026-04-20") }) }),
+    );
+    const b = reengageCacheKey(
+      mkCtx({ card: mkCard({ lastContactedAt: new Date("2026-02-25") }) }),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("changes when a new contact event note appears", () => {
+    const a = reengageCacheKey(mkCtx());
+    const b = reengageCacheKey(mkCtx({ recentEvents: [mkEvent({ note: "fresh meeting" })] }));
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/lib/coach/reengage-llm.ts
+++ b/src/lib/coach/reengage-llm.ts
@@ -1,0 +1,58 @@
+import "server-only";
+
+import {
+  buildReengageMessages,
+  parseReengageResponse,
+  type ReengageContext,
+  type ReengageDrafts,
+} from "./reengage";
+
+const DEFAULT_BASE_URL = "https://api.minimax.chat/v1";
+const DEFAULT_MODEL = "MiniMax-M2.7";
+const DEFAULT_TIMEOUT_MS = 12_000;
+
+interface MiniMaxChatResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+export async function callReengageLlm(
+  ctx: ReengageContext,
+  options: { timeoutMs?: number } = {},
+): Promise<ReengageDrafts | null> {
+  const apiKey = process.env.MINIMAX_API_KEY ?? "";
+  if (!apiKey) return null;
+
+  const baseUrl = process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = process.env.MINIMAX_MODEL ?? DEFAULT_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const body = {
+    model,
+    temperature: 0.7,
+    max_tokens: 1500,
+    messages: buildReengageMessages(ctx),
+  };
+
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: abort.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as MiniMaxChatResponse;
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) return null;
+    return parseReengageResponse(raw);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/coach/reengage-store.ts
+++ b/src/lib/coach/reengage-store.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+import { Timestamp } from "firebase-admin/firestore";
+
+import { getAdminFirestore } from "@/lib/firebase/server";
+import { cardsPath, personalWorkspaceId } from "@/lib/firebase/shared";
+
+import type { ReengageDrafts } from "./reengage";
+
+const REENGAGE_SUBCOLLECTION = "reengage";
+const CACHE_TTL_MS = 12 * 60 * 60 * 1000; // 12h
+
+interface CachedReengageDoc {
+  hash: string;
+  drafts: ReengageDrafts;
+  generatedAt: Timestamp;
+}
+
+export async function readReengageCache(
+  uid: string,
+  cardId: string,
+  hash: string,
+): Promise<ReengageDrafts | null> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${cardsPath(wid)}/${cardId}/${REENGAGE_SUBCOLLECTION}/latest`);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const data = snap.data() as CachedReengageDoc | undefined;
+  if (!data) return null;
+  if (data.hash !== hash) return null;
+  if (Date.now() - data.generatedAt.toMillis() > CACHE_TTL_MS) return null;
+  return data.drafts;
+}
+
+export async function writeReengageCache(
+  uid: string,
+  cardId: string,
+  hash: string,
+  drafts: ReengageDrafts,
+): Promise<void> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${cardsPath(wid)}/${cardId}/${REENGAGE_SUBCOLLECTION}/latest`);
+  await ref.set({
+    hash,
+    drafts,
+    generatedAt: Timestamp.now(),
+  });
+}

--- a/src/lib/coach/reengage.ts
+++ b/src/lib/coach/reengage.ts
@@ -1,0 +1,173 @@
+import { createHash } from "node:crypto";
+
+import type { CardSummary } from "@/db/cards";
+import type { ContactEvent } from "@/db/cards";
+
+export interface ReengageDrafts {
+  /** LINE / WhatsApp 風格短訊。輕快，2-3 句。 */
+  shortMessage: string;
+  /** Email 版本，含 subject + body，正式 4-6 句。 */
+  email: { subject: string; body: string };
+  /** 「剛好想到你」自然偶遇式 hook，2-3 句。 */
+  casualPing: string;
+}
+
+export interface ReengageContext {
+  card: CardSummary;
+  /** Up to 5 most-recent contact events (used for "你欠我什麼" hooks). */
+  recentEvents: ContactEvent[];
+  now: Date;
+}
+
+const MAX_SHORT_LEN = 280;
+const MAX_EMAIL_SUBJECT_LEN = 120;
+const MAX_EMAIL_BODY_LEN = 1200;
+const MAX_CASUAL_LEN = 280;
+
+function pickName(card: CardSummary): string {
+  return card.nameZh || card.nameEn || "（未命名）";
+}
+
+function pickRole(card: CardSummary): string {
+  return card.jobTitleZh || card.jobTitleEn || "";
+}
+
+function pickCompany(card: CardSummary): string {
+  return card.companyZh || card.companyEn || "";
+}
+
+function daysSince(date: Date | null | undefined, now: Date): number | null {
+  if (!date) return null;
+  const ms = now.getTime() - date.getTime();
+  if (!Number.isFinite(ms)) return null;
+  return Math.floor(ms / (24 * 60 * 60 * 1000));
+}
+
+function bucketDays(days: number | null): string {
+  if (days === null) return "never";
+  if (days <= 14) return "0-14d";
+  if (days <= 30) return "15-30d";
+  if (days <= 90) return "31-90d";
+  if (days <= 180) return "91-180d";
+  if (days <= 365) return "181-365d";
+  return "365d+";
+}
+
+/**
+ * Cache key — same card with similar staleness bucket → same drafts.
+ * Day-precise hashing would burn LLM tokens for trivial 1-day shifts;
+ * bucketing keeps drafts stable across a typical "I'll deal with this
+ * tomorrow" window without going stale across months.
+ */
+export function reengageCacheKey(ctx: ReengageContext): string {
+  const days = daysSince(ctx.card.lastContactedAt, ctx.now);
+  const stable = {
+    cardId: ctx.card.id,
+    name: pickName(ctx.card),
+    role: pickRole(ctx.card),
+    company: pickCompany(ctx.card),
+    why: ctx.card.whyRemember ?? "",
+    eventTag: ctx.card.firstMetEventTag ?? "",
+    bucket: bucketDays(days),
+    eventNotes: ctx.recentEvents
+      .map((e) => (e.note ?? "").slice(0, 80))
+      .filter(Boolean)
+      .sort()
+      .join("|"),
+  };
+  return createHash("sha256").update(JSON.stringify(stable)).digest("hex").slice(0, 32);
+}
+
+export function buildReengagePrompt(ctx: ReengageContext): string {
+  const card = ctx.card;
+  const days = daysSince(card.lastContactedAt, ctx.now);
+  const lines: string[] = [];
+  lines.push(`對方：${pickName(card)}`);
+  if (pickRole(card)) lines.push(`職稱：${pickRole(card)}`);
+  if (pickCompany(card)) lines.push(`公司：${pickCompany(card)}`);
+  if (card.whyRemember) lines.push(`為什麼記得：${card.whyRemember}`);
+  if (card.firstMetEventTag) lines.push(`首次見面場合：${card.firstMetEventTag}`);
+  if (card.firstMetDate) lines.push(`首次見面日期：${card.firstMetDate}`);
+  if (days !== null) {
+    lines.push(`距上次互動：${days} 天`);
+  } else {
+    lines.push("距上次互動：尚未有任何互動紀錄");
+  }
+  if (ctx.recentEvents.length > 0) {
+    lines.push("");
+    lines.push("近期互動歷史（新→舊）：");
+    for (const e of ctx.recentEvents.slice(0, 5)) {
+      const note = e.note?.trim() || "（無備註）";
+      lines.push(`- ${e.at.toISOString().slice(0, 10)}：${note.slice(0, 200)}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+const SYSTEM_PROMPT =
+  "你是商務人脈訊息草稿助手，幫使用者重新聯絡許久未見的人。" +
+  "根據對方的背景與互動歷史，產出 3 種風格的訊息草稿，讓使用者複製貼上即可發送。\n" +
+  "回答必須是合法 JSON，符合 schema：\n" +
+  '{"shortMessage": string, "email": {"subject": string, "body": string}, "casualPing": string}\n' +
+  "規則：\n" +
+  "- shortMessage：LINE / WhatsApp 風格，2-3 句，輕快，可帶 emoji。280 字內。直接稱呼名字開頭。\n" +
+  "- email.subject：120 字內，要具體（避免「你好」這種空泛 subject）。\n" +
+  "- email.body：4-6 句，正式但不冗長，1200 字內。包含 hook + 為什麼今天聯絡 + 開放性結尾。\n" +
+  "- casualPing：「剛好想到你」自然偶遇 hook，2-3 句，280 字內。引用一個具體記憶 hook（whyRemember 或互動歷史）。\n" +
+  "- 用繁體中文寫，但專有名詞保留原文。\n" +
+  "- 不要捏造對方的近況或事件 — 只根據提供的資料推理。\n" +
+  "- 不要任何 markdown 圍欄，只回傳 JSON。";
+
+export function buildReengageMessages(
+  ctx: ReengageContext,
+): Array<{ role: "system" | "user"; content: string }> {
+  return [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: buildReengagePrompt(ctx) },
+  ];
+}
+
+function sanitizeStr(value: unknown, max: number): string {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, max);
+}
+
+export function parseReengageResponse(raw: string): ReengageDrafts | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const inner = fenced ? fenced[1]! : trimmed;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(inner);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const obj = parsed as Record<string, unknown>;
+
+  const shortMessage = sanitizeStr(obj.shortMessage, MAX_SHORT_LEN);
+  const casualPing = sanitizeStr(obj.casualPing, MAX_CASUAL_LEN);
+  const emailObj = obj.email;
+  const subject =
+    emailObj && typeof emailObj === "object"
+      ? sanitizeStr((emailObj as { subject?: unknown }).subject, MAX_EMAIL_SUBJECT_LEN)
+      : "";
+  const body =
+    emailObj && typeof emailObj === "object"
+      ? sanitizeStr((emailObj as { body?: unknown }).body, MAX_EMAIL_BODY_LEN)
+      : "";
+
+  if (!shortMessage && !casualPing && !subject && !body) return null;
+
+  return {
+    shortMessage,
+    email: { subject, body },
+    casualPing,
+  };
+}
+
+export function isEmptyReengage(d: ReengageDrafts | null): boolean {
+  if (!d) return true;
+  return !d.shortMessage && !d.casualPing && !d.email.subject && !d.email.body;
+}


### PR DESCRIPTION
Closes #86

## Summary
商務人士看到 followup 名單常卡在「該怎麼開頭？」AI Coach (#83) 給的是 talking points (聊什麼)，這刀更進一步：直接給可複製貼上的訊息草稿。

> 把 /followups 從「list of names to chase」→「list of one-click drafts」。

## Demo

```
李大同 · 業務 / 沛理       已 56 天        [✅ 已聯絡]
[✨ AI 草稿]

  🎯 短訊版                                [複製] [開 LINE →]
  > 大同！最近忙嗎？想到我們在 Web Summit 聊的 AMM 合作，最近的進展也想跟你分享 ☕

  📧 Email 版                              [複製] [開信件 →]
  > Subject: 再續 Web Summit Lisbon 的對話
  >
  > Hi 大同，
  > 一年前我們在 Lisbon 認識...

  ☕ 偶遇版                                [複製]
  > 剛剛看到 NVIDIA 新晶片發表，想到你們之前在沛理的方向。最近還順嗎？
```

## Files
- `src/lib/coach/reengage.ts` (+150) — pure prompt + 3-bucket parser + bucketed cache key
- `src/lib/coach/reengage-llm.ts` (+55) — MiniMax client (mirrors briefing-llm.ts)
- `src/lib/coach/reengage-store.ts` (+50) — Firestore 12h cache
- Server Action `getReengageDraftsAction({ cardId, force })` in `src/app/(app)/cards/actions.ts`
- `<ReengageDraftsButton>` (+250) — disclosure + 3 styles + copy + deep links
- `FollowupCardRow` 加 `showAiDrafts` prop，條件渲染
- `/followups` page gated by `isCoachConfigured()`
- 20 UT for prompt builder + 3-bucket parser + bucketed cache key

## Architecture decisions
- **Bucketed cache key**: same staleness band (e.g. 0-14d, 15-30d) → same cache hit. Avoids invalidating drafts on trivial 1-day shifts. Cross-band → fresh draft.
- **Deep links** when channels exist: SMS / mailto / LINE prefilled with the AI text — user goes from "I should ping" to "ping sent" in one click.
- **Opt-in**: doesn't fetch until user clicks 「✨ AI 草稿」 disclosure. No tokens burned for cards user just glances at.
- **Conditional render**: `isCoachConfigured()` server-side check hides the button entirely when no LLM configured.
- **Mirror existing patterns**: prompt+llm+store layering matches briefing/coach modules; same degrade-silently chain.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 537 pass (+20 new)
- [x] `pnpm lint` — clean (4 unrelated pre-existing)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — green
- [ ] CI green → merge → mac mini deploy

## Out of scope
- 自動寄信（需 email infra + auth scope）
- LINE Messaging API push
- 多語言切換 — 先繁中