### PR TITLE
feat: 🪪 數位名片 — /u/{slug} public profile (Phase 1)

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -5,6 +5,7 @@ import { CardActions } from "@/components/cards/CardActions";
 import { CardInlineEdit } from "@/components/cards/CardInlineEdit";
 import { CoachInsightSection } from "@/components/cards/CoachInsightSection";
 import { ContactEventList } from "@/components/cards/ContactEventList";
+import { PublicProfileToggle } from "@/components/cards/PublicProfileToggle";
 import { RelatedByEvent } from "@/components/cards/RelatedByEvent";
 import { TagSuggestionsBanner } from "@/components/tags/TagSuggestionsBanner";
 import {
@@ -298,6 +299,16 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
             linkedinUrl={card.social?.linkedinUrl}
             isPinned={card.isPinned}
             followUpAt={card.followUpAt ? card.followUpAt.toISOString().slice(0, 10) : null}
+          />
+
+          <PublicProfileToggle
+            cardId={card.id}
+            currentSlug={card.publicSlug ?? null}
+            defaultSlugSuggestion={(card.nameEn || card.nameZh || "")
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, "-")
+              .replace(/^-|-$/g, "")
+              .slice(0, 30)}
           />
 
           {card.firstMetEventTag && sharedEventCards.length > 0 && (

--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -16,10 +16,11 @@ import {
   mergeCardsForUser,
   setCardPinned,
   setFollowUpForUser,
+  setPublicSlugForUser,
   softDeleteCardForUser,
   updateCardForUser,
 } from "@/db/cards";
-import { cardCreateSchema, cardUpdateSchema } from "@/db/schema";
+import { cardCreateSchema, cardUpdateSchema, publicSlugSchema } from "@/db/schema";
 import { briefingCacheKey, type BriefingPick } from "@/lib/coach/briefing";
 import { callBriefingLlm } from "@/lib/coach/briefing-llm";
 import { readBriefingCache, writeBriefingCache } from "@/lib/coach/briefing-store";
@@ -394,6 +395,39 @@ export const getReengageDraftsAction = authedAction
       if (!drafts) return { ok: false, reason: "llm-failed" };
       await writeReengageCache(ctx.user.uid, card.id, hash, drafts);
       return { ok: true, drafts, cached: false };
+    },
+  );
+
+/**
+ * Set or clear the card's public profile slug. When set, the card is
+ * reachable at /u/{slug} (no auth needed). Server-side validates slug
+ * format + reserved words + uniqueness across all workspaces. Returns
+ * the resolved slug on success or a friendly error message on conflict.
+ */
+export const setPublicSlugAction = authedAction
+  .inputSchema(
+    z.object({
+      cardId: z.string().min(1),
+      slug: z.union([publicSlugSchema, z.literal("")]).nullable(),
+    }),
+  )
+  .action(
+    async ({
+      parsedInput,
+      ctx,
+    }): Promise<{ ok: true; slug: string | null } | { ok: false; reason: string }> => {
+      const desired =
+        parsedInput.slug && parsedInput.slug !== "" ? parsedInput.slug.toLowerCase() : null;
+      try {
+        await setPublicSlugForUser(parsedInput.cardId, ctx.user.uid, desired);
+      } catch (err) {
+        return { ok: false, reason: err instanceof Error ? err.message : "操作失敗" };
+      }
+      revalidatePath("/");
+      revalidatePath("/cards");
+      revalidatePath(`/cards/${parsedInput.cardId}`);
+      if (desired) revalidatePath(`/u/${desired}`);
+      return { ok: true, slug: desired };
     },
   );
 

--- a/src/app/u/[slug]/page.tsx
+++ b/src/app/u/[slug]/page.tsx
@@ -1,0 +1,157 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { getCardByPublicSlug } from "@/db/cards";
+
+import styles from "./profile.module.css";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({ params }: PageProps) {
+  const { slug } = await params;
+  const card = await getCardByPublicSlug(decodeURIComponent(slug));
+  if (!card) return { title: "找不到名片" };
+  const name = card.nameZh || card.nameEn || "名片";
+  return { title: `${name} · 數位名片` };
+}
+
+function lineUrl(lineId: string): string {
+  return `https://line.me/ti/p/${
+    lineId.startsWith("@") ? encodeURIComponent(lineId) : `~${encodeURIComponent(lineId)}`
+  }`;
+}
+
+/**
+ * Public profile route — renders a single user's chosen card without
+ * any auth gate. Reached at /u/{slug}, the slug is a unique handle the
+ * user picked in their card detail page. No login link, no app chrome
+ * — this should look like a standalone digital business card.
+ */
+export default async function PublicProfilePage({ params }: PageProps) {
+  const { slug: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug);
+  const card = await getCardByPublicSlug(slug);
+  if (!card) notFound();
+
+  const nameZh = card.nameZh ?? "";
+  const nameEn = card.nameEn ?? "";
+  const role = card.jobTitleZh || card.jobTitleEn;
+  const company = card.companyZh || card.companyEn;
+  const department = card.department;
+  const phones = card.phones ?? [];
+  const emails = card.emails ?? [];
+  const lineId = card.social?.lineId;
+  const linkedinUrl = card.social?.linkedinUrl;
+  const wechatId = card.social?.wechatId;
+  const websiteUrl = card.social?.websiteUrl;
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.card}>
+        <header className={styles.header}>
+          <p className={styles.kicker}>數位名片</p>
+          {nameZh && <h1 className={styles.name}>{nameZh}</h1>}
+          {nameEn && <p className={styles.nameEn}>{nameEn}</p>}
+          {(role || company) && (
+            <p className={styles.subtitle}>
+              {role && <span>{role}</span>}
+              {role && (department || company) && <em className={styles.sep}>於</em>}
+              {department && <span>{department}</span>}
+              {department && company && <em className={styles.sep}>·</em>}
+              {company && <strong>{company}</strong>}
+            </p>
+          )}
+        </header>
+
+        {card.whyRemember && (
+          <section className={styles.about}>
+            <p className={styles.aboutLabel}>關於我</p>
+            <blockquote className={styles.aboutBody}>{card.whyRemember}</blockquote>
+          </section>
+        )}
+
+        <section className={styles.contactBlock}>
+          <h2 className={styles.sectionTitle}>聯絡方式</h2>
+          <ul className={styles.contactList}>
+            {phones.map((phone, i) => (
+              <li key={`phone-${i}`}>
+                <span className={styles.contactLabel}>📞 {phone.label}</span>
+                <a href={`tel:${phone.value}`} className={styles.contactValue}>
+                  {phone.value}
+                </a>
+              </li>
+            ))}
+            {emails.map((email, i) => (
+              <li key={`email-${i}`}>
+                <span className={styles.contactLabel}>📧 {email.label}</span>
+                <a href={`mailto:${email.value}`} className={styles.contactValue}>
+                  {email.value}
+                </a>
+              </li>
+            ))}
+            {lineId && (
+              <li>
+                <span className={styles.contactLabel}>💬 LINE</span>
+                <a
+                  href={lineUrl(lineId)}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className={styles.contactValue}
+                >
+                  {lineId}
+                </a>
+              </li>
+            )}
+            {linkedinUrl && (
+              <li>
+                <span className={styles.contactLabel}>🔗 LinkedIn</span>
+                <a
+                  href={linkedinUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className={styles.contactValue}
+                >
+                  打開連結
+                </a>
+              </li>
+            )}
+            {wechatId && (
+              <li>
+                <span className={styles.contactLabel}>💚 WeChat</span>
+                <span className={styles.contactValue}>{wechatId}</span>
+              </li>
+            )}
+            {websiteUrl && (
+              <li>
+                <span className={styles.contactLabel}>🌐 網站</span>
+                <a
+                  href={websiteUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className={styles.contactValue}
+                >
+                  打開連結
+                </a>
+              </li>
+            )}
+          </ul>
+        </section>
+
+        <a href={`/api/cards/${card.id}/vcard`} className={styles.downloadBtn} download>
+          ↓ 下載 vCard 加入通訊錄
+        </a>
+
+        <footer className={styles.footer}>
+          <Link href="/" className={styles.brandLink}>
+            namecard
+          </Link>
+          <span className={styles.handle}>/u/{slug}</span>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/app/u/[slug]/profile.module.css
+++ b/src/app/u/[slug]/profile.module.css
@@ -1,0 +1,218 @@
+.page {
+  min-height: 100dvh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: clamp(var(--space-md), 4vw, var(--space-2xl));
+  background: linear-gradient(
+    140deg,
+    var(--color-ink) 0%,
+    color-mix(in oklch, var(--color-ink) 85%, var(--color-accent-ink) 15%) 100%
+  );
+  background-attachment: fixed;
+}
+
+.card {
+  width: 100%;
+  max-width: 540px;
+  padding: clamp(var(--space-lg), 5vw, var(--space-2xl));
+  background: var(--color-paper);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 1px 3px rgb(0 0 0 / 12%),
+    0 24px 48px rgb(0 0 0 / 30%);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.name {
+  font-family: var(--font-display);
+  font-size: var(--text-h1);
+  font-weight: 500;
+  line-height: var(--leading-tight);
+  color: var(--color-ink);
+  margin: 0;
+  letter-spacing: var(--tracking-tight);
+}
+
+.nameEn {
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  font-weight: 400;
+  color: var(--color-ink-muted);
+  margin: 0;
+  font-style: italic;
+}
+
+.subtitle {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  margin: var(--space-xs) 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4em;
+}
+
+.sep {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-ink-muted);
+}
+
+.subtitle strong {
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.about {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-md);
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 60%,
+    var(--color-paper)
+  );
+  border-radius: var(--radius-md);
+}
+
+.aboutLabel {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.aboutBody {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+.contactBlock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.sectionTitle {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.contactList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.contactList li {
+  display: grid;
+  grid-template-columns: 7rem 1fr;
+  gap: var(--space-sm);
+  align-items: baseline;
+  padding-bottom: var(--space-sm);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.contactList li:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.contactLabel {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+}
+
+.contactValue {
+  font-family: var(--font-mono, var(--font-sans));
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  text-decoration: none;
+  word-break: break-word;
+}
+
+.contactValue:hover {
+  color: var(--color-accent-ink);
+  text-decoration: underline;
+}
+
+.downloadBtn {
+  display: inline-block;
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  letter-spacing: var(--tracking-wide);
+  text-decoration: none;
+  text-align: center;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.downloadBtn:hover {
+  background: var(--color-accent-ink);
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: var(--space-md);
+  border-top: var(--border-hair) solid var(--color-border);
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  color: var(--color-ink-muted);
+}
+
+.brandLink {
+  color: var(--color-ink-muted);
+  text-decoration: none;
+  letter-spacing: var(--tracking-wide);
+}
+
+.brandLink:hover {
+  color: var(--color-ink);
+}
+
+.handle {
+  font-family: var(--font-mono, var(--font-sans));
+  letter-spacing: var(--tracking-wide);
+}

--- a/src/components/cards/PublicProfileToggle.module.css
+++ b/src/components/cards/PublicProfileToggle.module.css
@@ -1,0 +1,187 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-ink);
+}
+
+.toggleBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-sm);
+  background: transparent;
+  color: var(--color-accent-ink);
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.toggleBtn:hover {
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.activeSummary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.activeLink {
+  font-family: var(--font-mono, var(--font-sans));
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.activeLink:hover {
+  text-decoration: underline;
+}
+
+.hint {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0;
+  line-height: var(--leading-relaxed);
+}
+
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.label {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink);
+  letter-spacing: var(--tracking-wide);
+}
+
+.input {
+  font-family: var(--font-mono, var(--font-sans));
+  font-size: var(--text-body);
+  padding: var(--space-xs) var(--space-sm);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--color-accent-ink);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--color-accent-ink) 25%, transparent);
+}
+
+.helper {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.error {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-error, #b00020);
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-top: var(--space-xs);
+}
+
+.primaryBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.primaryBtn:hover:not(:disabled) {
+  background: var(--color-accent-ink);
+}
+
+.primaryBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.dangerBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-sm);
+  background: transparent;
+  color: var(--color-error, #b00020);
+  border: var(--border-hair) solid var(--color-error, #b00020);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.dangerBtn:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--color-error, #b00020) 10%, transparent);
+}
+
+.dangerBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.smallBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.smallBtn:hover {
+  border-color: var(--color-accent-ink);
+}
+
+.toast {
+  position: fixed;
+  bottom: var(--space-lg);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  z-index: 100;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 20%);
+}

--- a/src/components/cards/PublicProfileToggle.tsx
+++ b/src/components/cards/PublicProfileToggle.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { setPublicSlugAction } from "@/app/(app)/cards/actions";
+
+import styles from "./PublicProfileToggle.module.css";
+
+interface PublicProfileToggleProps {
+  cardId: string;
+  /** Current slug if the card is already public; null/undefined when not. */
+  currentSlug?: string | null;
+  /** Suggested default slug derived from name (lowercased, normalized). */
+  defaultSlugSuggestion?: string;
+}
+
+function publicUrlFor(slug: string): string {
+  if (typeof window === "undefined") return `/u/${slug}`;
+  return `${window.location.origin}/u/${slug}`;
+}
+
+/**
+ * "🪪 數位名片" disclosure on /cards/[id] sidebar. User picks a slug,
+ * we POST → setPublicSlugAction; on success the card is reachable at
+ * `/u/{slug}` (no auth needed). Provides copy-URL + open-in-new-tab
+ * + clear toggle. Errors (clash, reserved word, format) surface inline.
+ */
+export function PublicProfileToggle({
+  cardId,
+  currentSlug = null,
+  defaultSlugSuggestion = "",
+}: PublicProfileToggleProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(currentSlug ?? defaultSlugSuggestion);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const flash = (msg: string) => {
+    setToast(msg);
+    setTimeout(() => setToast(null), 2400);
+  };
+
+  const submit = (slug: string | null) => {
+    setError(null);
+    startTransition(async () => {
+      const result = await setPublicSlugAction({ cardId, slug: slug ?? "" });
+      const data = result?.data;
+      if (result?.serverError) {
+        setError(result.serverError);
+        return;
+      }
+      if (!data) {
+        setError("操作失敗，請重試");
+        return;
+      }
+      if (!data.ok) {
+        setError(data.reason);
+        return;
+      }
+      flash(slug ? `已設為公開於 /u/${data.slug ?? slug}` : "已停用公開頁");
+      router.refresh();
+    });
+  };
+
+  const copyUrl = async () => {
+    if (!currentSlug) return;
+    const url = publicUrlFor(currentSlug);
+    try {
+      await navigator.clipboard.writeText(url);
+      flash("已複製公開網址");
+    } catch {
+      flash("複製失敗");
+    }
+  };
+
+  return (
+    <section className={styles.section} aria-label="公開數位名片">
+      <header className={styles.header}>
+        <h3 className={styles.title}>🪪 數位名片</h3>
+        <button
+          type="button"
+          className={styles.toggleBtn}
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+        >
+          {open ? "收起" : currentSlug ? "管理" : "設定"}
+        </button>
+      </header>
+
+      {currentSlug && !open && (
+        <div className={styles.activeSummary}>
+          <a
+            href={publicUrlFor(currentSlug)}
+            target="_blank"
+            rel="noreferrer noopener"
+            className={styles.activeLink}
+          >
+            /u/{currentSlug} ↗
+          </a>
+          <button type="button" onClick={copyUrl} className={styles.smallBtn}>
+            複製網址
+          </button>
+        </div>
+      )}
+
+      {!currentSlug && !open && (
+        <p className={styles.hint}>
+          把這張卡變可分享的數位名片 — 對方掃 QR / 點連結即看，不需要帳號。
+        </p>
+      )}
+
+      {open && (
+        <div className={styles.editor}>
+          <label htmlFor={`slug-${cardId}`} className={styles.label}>
+            自訂網址 ({typeof window !== "undefined" ? `${window.location.origin}/u/` : "/u/"}…)
+          </label>
+          <input
+            id={`slug-${cardId}`}
+            className={styles.input}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, ""))}
+            maxLength={30}
+            placeholder="例如 yu-han 或 chen-yh"
+            aria-describedby={error ? `slug-err-${cardId}` : undefined}
+          />
+          <p className={styles.helper}>3-30 字，小寫英數、底線、減號；不得以符號開頭/結尾。</p>
+          {error && (
+            <p id={`slug-err-${cardId}`} role="alert" className={styles.error}>
+              {error}
+            </p>
+          )}
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={styles.primaryBtn}
+              onClick={() => submit(draft.trim() || null)}
+              disabled={pending}
+            >
+              {pending ? "套用中…" : currentSlug === draft.trim() ? "未變更" : "套用"}
+            </button>
+            {currentSlug && (
+              <button
+                type="button"
+                className={styles.dangerBtn}
+                onClick={() => submit(null)}
+                disabled={pending}
+              >
+                停用公開頁
+              </button>
+            )}
+            <button type="button" className={styles.smallBtn} onClick={() => setOpen(false)}>
+              關閉
+            </button>
+          </div>
+        </div>
+      )}
+
+      {toast && (
+        <p role="status" aria-live="polite" className={styles.toast}>
+          {toast}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/db/__tests__/public-slug.test.ts
+++ b/src/db/__tests__/public-slug.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { publicSlugSchema } from "../schema";
+
+describe("publicSlugSchema", () => {
+  it("accepts a typical lowercase slug", () => {
+    const result = publicSlugSchema.safeParse("yu-han");
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts numbers and underscores", () => {
+    expect(publicSlugSchema.safeParse("user_123").success).toBe(true);
+    expect(publicSlugSchema.safeParse("a1b2c3").success).toBe(true);
+  });
+
+  it("accepts CJK-free slugs (intentional — slugs are URL identifiers)", () => {
+    // CJK is rejected because URLs should be readable + shareable in plain ASCII
+    expect(publicSlugSchema.safeParse("陳玉涵").success).toBe(false);
+  });
+
+  it("rejects slugs shorter than 3 chars", () => {
+    expect(publicSlugSchema.safeParse("ab").success).toBe(false);
+    expect(publicSlugSchema.safeParse("a").success).toBe(false);
+  });
+
+  it("rejects slugs longer than 30 chars", () => {
+    expect(publicSlugSchema.safeParse("a".repeat(31)).success).toBe(false);
+  });
+
+  it("rejects slugs with spaces or invalid chars", () => {
+    expect(publicSlugSchema.safeParse("yu han").success).toBe(false);
+    expect(publicSlugSchema.safeParse("yu.han").success).toBe(false);
+    expect(publicSlugSchema.safeParse("yu/han").success).toBe(false);
+    expect(publicSlugSchema.safeParse("YU-HAN").success).toBe(false); // uppercase
+  });
+
+  it("rejects slugs starting or ending with dash/underscore", () => {
+    expect(publicSlugSchema.safeParse("-yu-han").success).toBe(false);
+    expect(publicSlugSchema.safeParse("yu-han-").success).toBe(false);
+    expect(publicSlugSchema.safeParse("_yuhan").success).toBe(false);
+    expect(publicSlugSchema.safeParse("yuhan_").success).toBe(false);
+  });
+
+  it("accepts slug with internal dashes and underscores", () => {
+    expect(publicSlugSchema.safeParse("yu-han_chen").success).toBe(true);
+  });
+
+  it("accepts at exactly the boundary lengths", () => {
+    expect(publicSlugSchema.safeParse("abc").success).toBe(true); // exactly 3
+    expect(publicSlugSchema.safeParse("a".repeat(30)).success).toBe(true); // exactly 30
+  });
+});

--- a/src/db/cards-data.ts
+++ b/src/db/cards-data.ts
@@ -45,6 +45,7 @@ export function toSummaryFromData(id: string, data: FirebaseFirestore.DocumentDa
     backImagePath: data.backImagePath,
     isPinned: data.isPinned === true,
     followUpAt: tsToDate(data.followUpAt),
+    publicSlug: typeof data.publicSlug === "string" ? data.publicSlug : undefined,
     createdAt: tsToDate(data.createdAt),
     updatedAt: tsToDate(data.updatedAt),
     lastContactedAt: tsToDate(data.lastContactedAt),

--- a/src/db/cards.ts
+++ b/src/db/cards.ts
@@ -5,9 +5,10 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getAdminFirestore } from "@/lib/firebase/server";
 import {
   cardsPath,
+  COLLECTION_PUBLIC_SLUGS,
+  COLLECTION_WORKSPACES,
   personalWorkspaceId,
   SUB_COLLECTION_CARDS,
-  COLLECTION_WORKSPACES,
 } from "@/lib/firebase/shared";
 import { syncWithFallback } from "@/lib/search/reconcile";
 
@@ -61,6 +62,11 @@ export interface CardSummary {
    * valid (mirrors the isPinned backwards-compat pattern).
    */
   followUpAt?: Date | null;
+  /**
+   * If set, this card is exposed as a public profile at /u/{publicSlug}.
+   * Slug uniqueness is owned by `publicSlugs/{slug}` top-level docs.
+   */
+  publicSlug?: string;
   createdAt: Date | null;
   updatedAt: Date | null;
   lastContactedAt: Date | null;
@@ -510,6 +516,132 @@ export async function setCardPinned(cardId: string, uid: string, pinned: boolean
     isPinned: pinned,
     updatedAt: FieldValue.serverTimestamp(),
   });
+}
+
+const SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$/;
+const RESERVED_SLUGS = new Set([
+  "_next",
+  "api",
+  "app",
+  "admin",
+  "assets",
+  "cards",
+  "companies",
+  "events",
+  "favicon",
+  "followups",
+  "icon",
+  "import",
+  "login",
+  "logout",
+  "manifest",
+  "static",
+  "tags",
+  "u",
+  "unauthorized",
+  "workspace",
+]);
+
+/**
+ * Set or clear the public profile slug for a card. When set, the card
+ * becomes publicly reachable at /u/{slug} (no auth needed). Uniqueness
+ * is enforced by a top-level publicSlugs/{slug} index doc that points
+ * back at the card — write happens in a single transaction so two
+ * users can't grab the same slug simultaneously.
+ *
+ * Pass `slug: null` to take the card off the public hub (clears both
+ * card.publicSlug and the publicSlugs index doc).
+ */
+export async function setPublicSlugForUser(
+  cardId: string,
+  uid: string,
+  slug: string | null,
+): Promise<void> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const cardRef = db.doc(`${cardsPath(wid)}/${cardId}`);
+
+  if (slug !== null) {
+    const lower = slug.toLowerCase();
+    if (!SLUG_PATTERN.test(lower)) {
+      throw new Error("slug 格式不合：只允許小寫英數、底線、減號，3-30 字");
+    }
+    if (lower.length < 3 || lower.length > 30) {
+      throw new Error("slug 長度需 3-30 字");
+    }
+    if (RESERVED_SLUGS.has(lower)) {
+      throw new Error(`slug "${lower}" 是系統保留字，請換一個`);
+    }
+  }
+
+  await db.runTransaction(async (txn) => {
+    const cardSnap = await txn.get(cardRef);
+    if (!cardSnap.exists) throw new Error("card not found");
+    const cardData = cardSnap.data()!;
+    if (!cardData.memberUids?.includes(uid)) throw new Error("無權限修改此名片");
+    const previousSlug = typeof cardData.publicSlug === "string" ? cardData.publicSlug : null;
+
+    if (slug === null) {
+      if (previousSlug) {
+        txn.delete(db.doc(`${COLLECTION_PUBLIC_SLUGS}/${previousSlug}`));
+      }
+      txn.update(cardRef, {
+        publicSlug: FieldValue.delete(),
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      return;
+    }
+
+    const lower = slug.toLowerCase();
+    if (previousSlug === lower) return; // no-op
+
+    const slugRef = db.doc(`${COLLECTION_PUBLIC_SLUGS}/${lower}`);
+    const slugSnap = await txn.get(slugRef);
+    if (slugSnap.exists) {
+      const owner = slugSnap.data();
+      if (owner?.cardId !== cardId || owner?.workspaceId !== wid) {
+        throw new Error(`slug "${lower}" 已被別人使用，請換一個`);
+      }
+    }
+
+    if (previousSlug) {
+      txn.delete(db.doc(`${COLLECTION_PUBLIC_SLUGS}/${previousSlug}`));
+    }
+    txn.set(slugRef, {
+      workspaceId: wid,
+      cardId,
+      ownerUid: uid,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+    txn.update(cardRef, {
+      publicSlug: lower,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  });
+}
+
+/**
+ * Public reverse lookup: slug → card. No auth check (public route).
+ * Returns null when the slug doesn't resolve, the index doc is stale,
+ * or the underlying card has been soft-deleted (we don't want a
+ * dangling public URL pointing at a card the user removed).
+ */
+export async function getCardByPublicSlug(slug: string): Promise<CardSummary | null> {
+  const lower = slug.toLowerCase();
+  if (!SLUG_PATTERN.test(lower)) return null;
+  const db = getAdminFirestore();
+  const indexSnap = await db.doc(`${COLLECTION_PUBLIC_SLUGS}/${lower}`).get();
+  if (!indexSnap.exists) return null;
+  const idx = indexSnap.data();
+  const wid = typeof idx?.workspaceId === "string" ? idx.workspaceId : null;
+  const cardId = typeof idx?.cardId === "string" ? idx.cardId : null;
+  if (!wid || !cardId) return null;
+  const cardSnap = await db.doc(`${cardsPath(wid)}/${cardId}`).get();
+  if (!cardSnap.exists) return null;
+  const data = cardSnap.data()!;
+  if (data.deletedAt) return null;
+  if (data.publicSlug !== lower) return null; // index drift safety
+  return toSummary(cardId, data);
 }
 
 /**

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -121,7 +121,34 @@ const cardBaseShape = {
       message: "Invalid date (YYYY-MM-DD)",
     })
     .optional(),
+
+  // Public profile slug — when set, this card is reachable as a public
+  // page at /u/{publicSlug} without auth. User picks ONE of their cards
+  // (typically their own) to expose. Slug uniqueness enforced by a
+  // top-level publicSlugs/{slug} doc; see setPublicSlugForUser.
+  publicSlug: z
+    .string()
+    .min(3)
+    .max(30)
+    .regex(/^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$/)
+    .optional(),
 };
+
+/**
+ * Public profile slug rule:
+ * - lowercase a-z, 0-9, dash, underscore
+ * - 3-30 chars
+ * - cannot start/end with dash or underscore
+ *
+ * Reserved against scoping clashes (e.g. "_next") via runtime check
+ * in setPublicSlugForUser.
+ */
+export const publicSlugSchema = z
+  .string()
+  .min(3, "slug 至少 3 字")
+  .max(30, "slug 最多 30 字")
+  .regex(/^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$/, "只允許小寫英數、底線、減號；不得以符號開頭/結尾");
+export type PublicSlug = z.infer<typeof publicSlugSchema>;
 
 /** Payload shape when creating a card (client → server). */
 export const cardCreateSchema = z

--- a/src/lib/firebase/shared.ts
+++ b/src/lib/firebase/shared.ts
@@ -11,6 +11,12 @@ export const SESSION_COOKIE_MAX_AGE_MS = 5 * 24 * 60 * 60 * 1000; // 5 days
 export const COLLECTION_WORKSPACES = "workspaces";
 export const SUB_COLLECTION_CARDS = "cards";
 export const SUB_COLLECTION_TAGS = "tags";
+/**
+ * Top-level reverse-lookup index for public profile slugs. Each doc id
+ * is the slug; doc body points back to {workspaceId, cardId} so the
+ * public page can resolve a slug → card without scanning all workspaces.
+ */
+export const COLLECTION_PUBLIC_SLUGS = "publicSlugs";
 
 /** Personal workspace id is exactly the user uid — see AGENTS.md invariant #1. */
 export function personalWorkspaceId(uid: string): string {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,6 +17,9 @@ function isPublic(pathname: string): boolean {
   if (PUBLIC_PATHS.has(pathname)) return true;
   if (pathname.startsWith("/_next/")) return true;
   if (pathname.startsWith("/favicon")) return true;
+  // Public profile pages: /u/{slug} renders a single user's card without
+  // auth so it can be shared like a digital business card.
+  if (pathname.startsWith("/u/")) return true;
   // Test-only bypass route — route handler itself returns 404 in production
   // (gated by E2E_TEST_MODE). Exposing it here just keeps it reachable for
   // Playwright under CI to mint sessions.


### PR DESCRIPTION
Closes #88

## Summary
商務人士天天遇到「給我你的聯絡方式」— 目前只能複製貼上 / 寄 vCard / 念給對方記。LinkedIn URL 是部分解，但對方不一定有帳號、沒「為什麼記得我」、沒 public-friendly profile UX。

Phase 1：每個 user 可以把自己 *任一張名片* 設為「我的數位名片」，產出 public URL `/u/{slug}` (無需登入即可訪問)。

## Files
- `src/db/schema.ts` — `publicSlugSchema` + `cardBaseShape.publicSlug`
- `src/db/cards.ts` — `setPublicSlugForUser` (transactional), `getCardByPublicSlug` (public)
- `src/lib/firebase/shared.ts` — `COLLECTION_PUBLIC_SLUGS`
- `src/middleware.ts` — `/u/*` whitelist (no session needed)
- `src/app/u/[slug]/page.tsx` + `profile.module.css` — public profile route
- `src/app/(app)/cards/actions.ts` — `setPublicSlugAction`
- `src/components/cards/PublicProfileToggle.tsx` + `.module.css` — disclosure on detail sidebar
- `src/db/__tests__/public-slug.test.ts` — 9 UT for schema validation

## Demo
- User goes to /cards/[id] → 「🪪 數位名片」 disclosure → enter slug → save
- URL becomes `https://namecard.openclaw/namecard-web/u/yu-han` (no auth)
- Renders polished standalone card: name / role / company / 「關於我」 / contact channels with deep links + 「下載 vCard」 button
- Slug uniqueness: write transaction prevents two users grabbing the same slug
- Reserved words list (api / cards / login / etc.) blocks scope clashes
- `setPublicSlugForUser(cardId, uid, null)` clears the public exposure

## Architecture
- **Top-level reverse-lookup index**: `publicSlugs/{slug}` doc points at `{workspaceId, cardId, ownerUid}`. Public route reads index → resolves card. No collection-group scan.
- **Index drift safety**: `getCardByPublicSlug` cross-checks that the resolved card's own `publicSlug` field still matches — protects against orphaned index docs.
- **Soft-delete safety**: deleted cards return null even if index entry survived.
- **Slug input UX**: client-side input filter strips invalid chars while typing; server-side validates with friendly error messages on clash / reserved / format.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 546 pass (+9 new)
- [x] `pnpm lint` — 0 errors (4 pre-existing warnings)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — `/u/[slug]` registered
- [ ] CI green → merge → mac mini deploy

## Out of scope (Phase 2)
- QR code generation
- Two-way scan exchange (一方掃對方 QR → 雙方都加進名片冊)
- Avatar upload for public profile
- Public profile editor (separate UI to customize what shows)