### PR TITLE
feat(cards): 🎙️ Voice-to-card — 自然語言敘述自動解析建檔 (Phase 1)

### DIFF
--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -37,6 +37,8 @@ import { callReengageLlm } from "@/lib/coach/reengage-llm";
 import { readReengageCache, writeReengageCache } from "@/lib/coach/reengage-store";
 import { readCoachCache, writeCoachCache } from "@/lib/coach/store";
 import { pickCanonicalCompany } from "@/lib/companies/group";
+import { encodePrefill, type ExtractedCard } from "@/lib/voice/extract";
+import { callExtractLlm } from "@/lib/voice/extract-llm";
 
 export const createCardAction = authedAction
   .inputSchema(cardCreateSchema)
@@ -428,6 +430,29 @@ export const setPublicSlugAction = authedAction
       revalidatePath(`/cards/${parsedInput.cardId}`);
       if (desired) revalidatePath(`/u/${desired}`);
       return { ok: true, slug: desired };
+    },
+  );
+
+/**
+ * 🎙️ Voice-to-card extract — take a free-form text describing the
+ * person the user just met (typed or transcribed from voice) and
+ * return a Partial<CardCreateInput> via MiniMax. The /cards/voice
+ * page calls this, then redirects to /cards/new?prefill=... so the
+ * user reviews + commits via the normal create flow.
+ */
+export const extractCardFromTextAction = authedAction
+  .inputSchema(z.object({ text: z.string().min(3).max(2000) }))
+  .action(
+    async ({
+      parsedInput,
+    }): Promise<
+      | { ok: true; extracted: ExtractedCard; prefillToken: string }
+      | { ok: false; reason: "no-llm" | "llm-failed" }
+    > => {
+      if (!isCoachConfigured()) return { ok: false, reason: "no-llm" };
+      const extracted = await callExtractLlm(parsedInput.text);
+      if (!extracted) return { ok: false, reason: "llm-failed" };
+      return { ok: true, extracted, prefillToken: encodePrefill(extracted) };
     },
   );
 

--- a/src/app/(app)/cards/new/page.tsx
+++ b/src/app/(app)/cards/new/page.tsx
@@ -1,11 +1,23 @@
 import { CardForm } from "@/components/cards/CardForm";
+import type { CardCreateInput } from "@/db/schema";
+import { decodePrefill } from "@/lib/voice/extract";
+
 import styles from "./new.module.css";
 
 export const metadata = {
   title: "新增名片",
 };
 
-export default function NewCardPage() {
+interface NewCardPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function NewCardPage({ searchParams }: NewCardPageProps) {
+  const sp = await searchParams;
+  const prefillRaw = typeof sp.prefill === "string" ? sp.prefill : null;
+  const prefill = prefillRaw ? decodePrefill(prefillRaw) : null;
+  const defaults: Partial<CardCreateInput> | undefined = prefill ?? undefined;
+
   return (
     <article className={styles.article}>
       <header className={styles.header}>
@@ -14,10 +26,14 @@ export default function NewCardPage() {
           為一位<em>值得記得</em>的人建檔
         </h1>
         <p className={styles.lead}>
-          「為什麼記得這個人」是必填欄位—— 寫下當下的情境與判斷，未來的你會感謝現在的你。
+          {prefill ? (
+            <>已用 AI 解析預填欄位，請檢查 / 補充後送出。</>
+          ) : (
+            <>「為什麼記得這個人」是必填欄位—— 寫下當下的情境與判斷，未來的你會感謝現在的你。</>
+          )}
         </p>
       </header>
-      <CardForm mode="create" />
+      <CardForm mode="create" defaults={defaults} />
     </article>
   );
 }

--- a/src/app/(app)/cards/voice/page.tsx
+++ b/src/app/(app)/cards/voice/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+import { VoiceCardCapture } from "@/components/cards/VoiceCardCapture";
+import { isCoachConfigured } from "@/lib/coach/llm";
+
+import styles from "./voice.module.css";
+
+export const metadata = {
+  title: "語音建卡",
+};
+
+export default function VoiceCardPage() {
+  const llmReady = isCoachConfigured();
+  return (
+    <article className={styles.article}>
+      <header className={styles.header}>
+        <p className={styles.kicker}>🎙️ 語音建卡</p>
+        <h1 className={styles.title}>
+          剛 networking 結束？<em>講 30 秒</em>讓 AI 幫你建檔
+        </h1>
+        <p className={styles.lead}>
+          不用手動填欄位 — 把剛剛遇到的人講出來：「陳玉涵 PM 智威科技 在 2024 Computex 攤位上聊邊緣
+          AI 推論很投緣」。AI 會解析出姓名、職稱、公司、認識場合、為什麼記得，預填到建立表單，你檢查
+          後一鍵送出。
+        </p>
+      </header>
+
+      {!llmReady ? (
+        <section className={styles.notReady}>
+          <p>
+            AI 目前未啟用 — 管理員尚未設定 LLM 金鑰。請改用 <Link href="/cards/new">手動建立</Link>
+            。
+          </p>
+        </section>
+      ) : (
+        <VoiceCardCapture />
+      )}
+    </article>
+  );
+}

--- a/src/app/(app)/cards/voice/voice.module.css
+++ b/src/app/(app)/cards/voice/voice.module.css
@@ -1,0 +1,62 @@
+.article {
+  max-width: var(--content-max);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding-bottom: var(--space-md);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h2);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+}
+
+.title em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-accent);
+}
+
+.lead {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  line-height: var(--leading-relaxed);
+  margin: var(--space-xs) 0 0;
+  max-width: 60ch;
+}
+
+.notReady {
+  padding: var(--space-2xl) var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  color: var(--color-ink-muted);
+  text-align: center;
+}
+
+.notReady a {
+  color: var(--color-accent-ink);
+}

--- a/src/components/cards/VoiceCardCapture.module.css
+++ b/src/components/cards/VoiceCardCapture.module.css
@@ -1,0 +1,207 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-lg);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-paper);
+}
+
+.label {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-ink);
+}
+
+.textarea {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  padding: var(--space-md);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  resize: vertical;
+  min-height: 7rem;
+  outline: none;
+  line-height: var(--leading-relaxed);
+}
+
+.textarea:focus {
+  border-color: var(--color-accent-ink);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--color-accent-ink) 25%, transparent);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.primaryBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.primaryBtn:hover:not(:disabled) {
+  background: var(--color-accent-ink);
+}
+
+.primaryBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.smallBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.smallBtn:hover {
+  border-color: var(--color-accent-ink);
+}
+
+.examples {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+}
+
+.examples summary {
+  cursor: pointer;
+  color: var(--color-accent-ink);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) 0;
+}
+
+.exampleList {
+  list-style: none;
+  margin: var(--space-xs) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.exampleBtn {
+  display: block;
+  width: 100%;
+  text-align: left;
+  font-family: var(--font-serif);
+  font-size: var(--text-caption);
+  font-style: italic;
+  padding: var(--space-sm);
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 40%,
+    var(--color-paper)
+  );
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-ink);
+  cursor: pointer;
+  line-height: var(--leading-relaxed);
+}
+
+.exampleBtn:hover {
+  border-color: var(--color-accent-ink);
+}
+
+.error {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-error, #b00020);
+  margin: 0;
+}
+
+.preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 30%, var(--color-paper)) 0%,
+    var(--color-paper) 100%
+  );
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-md);
+}
+
+.previewTitle {
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  font-weight: 500;
+  margin: 0;
+  color: var(--color-ink);
+}
+
+.fieldGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--space-sm);
+  margin: 0;
+}
+
+.field,
+.fieldHighlight {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15em;
+  padding: var(--space-sm);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.fieldHighlight {
+  border-color: var(--color-accent-ink);
+  grid-column: 1 / -1;
+}
+
+.fieldLabel {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.fieldValue {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  margin: 0;
+  line-height: var(--leading-relaxed);
+}
+
+.fieldEmpty {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  font-style: italic;
+  margin: 0;
+}
+
+.previewActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}

--- a/src/components/cards/VoiceCardCapture.tsx
+++ b/src/components/cards/VoiceCardCapture.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { extractCardFromTextAction } from "@/app/(app)/cards/actions";
+import type { ExtractedCard } from "@/lib/voice/extract";
+
+import styles from "./VoiceCardCapture.module.css";
+
+const EXAMPLES = [
+  "陳玉涵 PM 智威科技 在 2024 Computex 攤位上聊邊緣 AI 推論很投緣，提到他們公司在做 ML 加速器",
+  "李大同 沛理科技業務 BD 上週 Web Summit Lisbon 認識，欠他一個 referral 給 NVIDIA 的 contact",
+  "王秘書長 國發會 在 AI 高峰會上聊 sovereign AI 政策，他想知道民間如何配合",
+];
+
+type Phase =
+  | { kind: "input" }
+  | { kind: "loading" }
+  | { kind: "ready"; extracted: ExtractedCard; prefillToken: string }
+  | { kind: "error"; message: string };
+
+/**
+ * 「🎙️ 語音建卡」 capture form. Phase 1: typed text. Future Phase 2:
+ * Web Speech API live transcript. Submits the text to MiniMax for
+ * structured extraction, shows a preview grid, then redirects to
+ * /cards/new?prefill=... so the user reviews + commits via the
+ * standard create flow (re-uses all existing validation + UI).
+ */
+export function VoiceCardCapture() {
+  const router = useRouter();
+  const [text, setText] = useState("");
+  const [phase, setPhase] = useState<Phase>({ kind: "input" });
+  const [pending, startTransition] = useTransition();
+
+  const submit = () => {
+    const trimmed = text.trim();
+    if (trimmed.length < 3) {
+      setPhase({ kind: "error", message: "至少描述 3 個字" });
+      return;
+    }
+    setPhase({ kind: "loading" });
+    startTransition(async () => {
+      const result = await extractCardFromTextAction({ text: trimmed });
+      const data = result?.data;
+      if (result?.serverError) {
+        setPhase({ kind: "error", message: result.serverError });
+        return;
+      }
+      if (!data || !data.ok) {
+        const messages: Record<string, string> = {
+          "no-llm": "AI 未啟用",
+          "llm-failed": "AI 解析失敗，請重試或改用手動建立",
+        };
+        const reason = data && !data.ok ? data.reason : null;
+        setPhase({
+          kind: "error",
+          message: reason ? (messages[reason] ?? "未知錯誤") : "解析失敗",
+        });
+        return;
+      }
+      setPhase({ kind: "ready", extracted: data.extracted, prefillToken: data.prefillToken });
+    });
+  };
+
+  const applyExample = (s: string) => {
+    setText(s);
+    setPhase({ kind: "input" });
+  };
+
+  const goCreate = () => {
+    if (phase.kind !== "ready") return;
+    router.push(`/cards/new?prefill=${encodeURIComponent(phase.prefillToken)}`);
+  };
+
+  return (
+    <section className={styles.section}>
+      <label htmlFor="voice-text" className={styles.label}>
+        把剛剛遇到的人講出來（暫時用打字，未來會接語音）
+      </label>
+      <textarea
+        id="voice-text"
+        className={styles.textarea}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="例如：陳玉涵 PM 智威科技 在 Computex 攤位聊邊緣 AI 推論..."
+        rows={5}
+        maxLength={2000}
+        disabled={pending && phase.kind === "loading"}
+      />
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={styles.primaryBtn}
+          onClick={submit}
+          disabled={pending || text.trim().length < 3}
+        >
+          {pending && phase.kind === "loading" ? "✨ AI 解析中…" : "✨ 解析 + 預填表單"}
+        </button>
+        {text && (
+          <button type="button" className={styles.smallBtn} onClick={() => setText("")}>
+            清空
+          </button>
+        )}
+      </div>
+
+      <details className={styles.examples}>
+        <summary>看範例 →</summary>
+        <ul className={styles.exampleList}>
+          {EXAMPLES.map((ex, i) => (
+            <li key={i}>
+              <button type="button" className={styles.exampleBtn} onClick={() => applyExample(ex)}>
+                {ex}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </details>
+
+      {phase.kind === "error" && (
+        <p role="alert" className={styles.error}>
+          {phase.message}
+        </p>
+      )}
+
+      {phase.kind === "ready" && (
+        <div className={styles.preview} aria-live="polite">
+          <h2 className={styles.previewTitle}>✨ AI 解析結果</h2>
+          <dl className={styles.fieldGrid}>
+            <PreviewField label="姓名（中）" value={phase.extracted.nameZh} />
+            <PreviewField label="姓名（英）" value={phase.extracted.nameEn} />
+            <PreviewField label="職稱（中）" value={phase.extracted.jobTitleZh} />
+            <PreviewField label="職稱（英）" value={phase.extracted.jobTitleEn} />
+            <PreviewField label="公司（中）" value={phase.extracted.companyZh} />
+            <PreviewField label="公司（英）" value={phase.extracted.companyEn} />
+            <PreviewField label="部門" value={phase.extracted.department} />
+            <PreviewField label="認識場合" value={phase.extracted.firstMetEventTag} />
+            <PreviewField label="情境" value={phase.extracted.firstMetContext} />
+            <PreviewField
+              label="為什麼記得（必填）"
+              value={phase.extracted.whyRemember}
+              highlight
+            />
+            <PreviewField label="備註" value={phase.extracted.notes} />
+          </dl>
+          <div className={styles.previewActions}>
+            <button type="button" className={styles.primaryBtn} onClick={goCreate}>
+              使用此解析建立 →
+            </button>
+            <button
+              type="button"
+              className={styles.smallBtn}
+              onClick={() => setPhase({ kind: "input" })}
+            >
+              重新編輯文字
+            </button>
+            <button
+              type="button"
+              className={styles.smallBtn}
+              onClick={() => {
+                setPhase({ kind: "input" });
+                submit();
+              }}
+            >
+              🔄 重新解析
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PreviewField({
+  label,
+  value,
+  highlight = false,
+}: {
+  label: string;
+  value: string | undefined;
+  highlight?: boolean;
+}) {
+  return (
+    <div className={highlight ? styles.fieldHighlight : styles.field}>
+      <dt className={styles.fieldLabel}>{label}</dt>
+      <dd className={value ? styles.fieldValue : styles.fieldEmpty}>{value || "—"}</dd>
+    </div>
+  );
+}

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -19,6 +19,7 @@ const PRIMARY: NavItem[] = [
   { href: "/followups", label: "追蹤", description: "誰該 ping 了" },
   { href: "/cards", label: "名片冊", description: "畫廊 · 清單" },
   { href: "/cards/new", label: "新增", description: "手動建立一張" },
+  { href: "/cards/voice", label: "🎙️ 語音建卡", description: "講 30 秒讓 AI 解析" },
   { href: "/companies", label: "公司", description: "同公司聯絡人聚合" },
   { href: "/events", label: "場合", description: "同場合認識的人" },
   { href: "/tags", label: "標籤", description: "分類 · 重新命名" },

--- a/src/lib/voice/__tests__/extract.test.ts
+++ b/src/lib/voice/__tests__/extract.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildExtractMessages,
+  decodePrefill,
+  encodePrefill,
+  parseExtractedCard,
+  type ExtractedCard,
+} from "../extract";
+
+describe("buildExtractMessages", () => {
+  it("returns system + user messages with the user's text in user content", () => {
+    const msgs = buildExtractMessages("陳玉涵 PM 智威");
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.role).toBe("system");
+    expect(msgs[1]!.role).toBe("user");
+    expect(msgs[1]!.content).toContain("陳玉涵");
+  });
+
+  it("system prompt includes JSON schema hints", () => {
+    const msgs = buildExtractMessages("test");
+    expect(msgs[0]!.content).toContain("nameZh");
+    expect(msgs[0]!.content).toContain("companyZh");
+    expect(msgs[0]!.content).toContain("whyRemember");
+  });
+});
+
+describe("parseExtractedCard", () => {
+  it("parses a clean response into ExtractedCard", () => {
+    const raw = JSON.stringify({
+      nameZh: "陳玉涵",
+      jobTitleZh: "PM",
+      companyZh: "智威科技",
+      firstMetEventTag: "2024 COMPUTEX",
+      whyRemember: "Computex 攤位聊邊緣 AI",
+    });
+    const result = parseExtractedCard(raw, "fallback");
+    expect(result?.nameZh).toBe("陳玉涵");
+    expect(result?.jobTitleZh).toBe("PM");
+    expect(result?.companyZh).toBe("智威科技");
+    expect(result?.firstMetEventTag).toBe("2024 COMPUTEX");
+    expect(result?.whyRemember).toBe("Computex 攤位聊邊緣 AI");
+  });
+
+  it("strips markdown json fence", () => {
+    const raw = "```json\n" + JSON.stringify({ whyRemember: "x" }) + "\n```";
+    expect(parseExtractedCard(raw, "f")?.whyRemember).toBe("x");
+  });
+
+  it("returns null on malformed JSON", () => {
+    expect(parseExtractedCard("not json", "f")).toBeNull();
+  });
+
+  it("returns null on array root", () => {
+    expect(parseExtractedCard("[1,2]", "f")).toBeNull();
+  });
+
+  it("falls back to truncated input when LLM omits whyRemember", () => {
+    const raw = JSON.stringify({ nameZh: "陳玉涵" });
+    const result = parseExtractedCard(raw, "原始輸入");
+    expect(result?.whyRemember).toBe("原始輸入");
+    expect(result?.nameZh).toBe("陳玉涵");
+  });
+
+  it("uses placeholder when both LLM and fallback are empty", () => {
+    expect(parseExtractedCard(JSON.stringify({ nameZh: "x" }), "")?.whyRemember).toBe("（剛認識）");
+  });
+
+  it("trims and clamps long fields", () => {
+    const longText = "x".repeat(2000);
+    const raw = JSON.stringify({
+      nameZh: `  ${longText}  `,
+      whyRemember: longText,
+      notes: longText,
+    });
+    const result = parseExtractedCard(raw, "f")!;
+    expect(result.nameZh!.length).toBeLessThanOrEqual(200);
+    expect(result.whyRemember!.length).toBeLessThanOrEqual(500);
+    expect(result.notes!.length).toBeLessThanOrEqual(1000);
+  });
+
+  it("drops non-string fields", () => {
+    const raw = JSON.stringify({ nameZh: 42, whyRemember: "valid" });
+    const result = parseExtractedCard(raw, "f");
+    expect(result?.nameZh).toBeUndefined();
+    expect(result?.whyRemember).toBe("valid");
+  });
+
+  it("drops empty string fields (not just trims to empty)", () => {
+    const raw = JSON.stringify({ nameZh: "  ", whyRemember: "x" });
+    const result = parseExtractedCard(raw, "f");
+    expect(result?.nameZh).toBeUndefined();
+  });
+});
+
+describe("encodePrefill / decodePrefill round-trip", () => {
+  it("decodes what was encoded", () => {
+    const original: ExtractedCard = {
+      nameZh: "陳玉涵",
+      companyZh: "智威",
+      whyRemember: "Computex 邊緣 AI",
+    };
+    const encoded = encodePrefill(original);
+    const decoded = decodePrefill(encoded);
+    expect(decoded?.nameZh).toBe("陳玉涵");
+    expect(decoded?.companyZh).toBe("智威");
+    expect(decoded?.whyRemember).toBe("Computex 邊緣 AI");
+  });
+
+  it("returns null for empty / invalid encoded strings", () => {
+    expect(decodePrefill("")).toBeNull();
+    expect(decodePrefill(null)).toBeNull();
+    expect(decodePrefill(undefined)).toBeNull();
+    expect(decodePrefill("not-base64")).toBeNull();
+  });
+
+  it("returns null when payload decodes to non-object", () => {
+    const encoded = Buffer.from(JSON.stringify(["array"]), "utf8").toString("base64url");
+    expect(decodePrefill(encoded)).toBeNull();
+  });
+
+  it("re-sanitizes hostile decoded payloads (caps lengths, drops non-strings)", () => {
+    const longText = "x".repeat(5000);
+    const hostile = {
+      nameZh: longText,
+      jobTitleZh: 42,
+      whyRemember: "valid",
+    };
+    const encoded = Buffer.from(JSON.stringify(hostile), "utf8").toString("base64url");
+    const decoded = decodePrefill(encoded);
+    expect(decoded?.nameZh!.length).toBeLessThanOrEqual(200);
+    expect(decoded?.jobTitleZh).toBeUndefined();
+    expect(decoded?.whyRemember).toBe("valid");
+  });
+});

--- a/src/lib/voice/extract-llm.ts
+++ b/src/lib/voice/extract-llm.ts
@@ -1,0 +1,55 @@
+import "server-only";
+
+import { buildExtractMessages, parseExtractedCard, type ExtractedCard } from "./extract";
+
+const DEFAULT_BASE_URL = "https://api.minimax.chat/v1";
+const DEFAULT_MODEL = "MiniMax-M2.7";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+interface MiniMaxChatResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+export async function callExtractLlm(
+  text: string,
+  options: { timeoutMs?: number } = {},
+): Promise<ExtractedCard | null> {
+  const apiKey = process.env.MINIMAX_API_KEY ?? "";
+  if (!apiKey) return null;
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  const baseUrl = process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = process.env.MINIMAX_MODEL ?? DEFAULT_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const body = {
+    model,
+    temperature: 0.2,
+    max_tokens: 800,
+    messages: buildExtractMessages(trimmed),
+  };
+
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: abort.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as MiniMaxChatResponse;
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) return null;
+    return parseExtractedCard(raw, trimmed);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/voice/extract.ts
+++ b/src/lib/voice/extract.ts
@@ -1,0 +1,129 @@
+import type { CardCreateInput } from "@/db/schema";
+
+export type ExtractedCard = Partial<CardCreateInput>;
+
+const SYSTEM_PROMPT =
+  "你是名片資訊抽取器。" +
+  "使用者剛 networking event 結束，用自然語言描述他剛遇到的人。" +
+  "把以下這段話抽出結構化欄位，用 JSON 回答：\n" +
+  "{\n" +
+  '  "nameZh"?: string,        // 中文姓名\n' +
+  '  "nameEn"?: string,        // 英文姓名\n' +
+  '  "jobTitleZh"?: string,    // 中文職稱\n' +
+  '  "jobTitleEn"?: string,    // 英文職稱\n' +
+  '  "companyZh"?: string,     // 中文公司\n' +
+  '  "companyEn"?: string,     // 英文公司\n' +
+  '  "department"?: string,    // 部門\n' +
+  '  "firstMetEventTag"?: string,   // 認識場合，例如 2024 COMPUTEX\n' +
+  '  "firstMetContext"?: string,    // 認識的情境細節\n' +
+  '  "whyRemember": string,    // 「為什麼記得這個人」(必填，沒有就用整段話的精華)\n' +
+  '  "notes"?: string\n' +
+  "}\n" +
+  "規則：\n" +
+  "- 只回傳 JSON，不要任何說明文字、不要 markdown 圍欄。\n" +
+  "- 沒提到的欄位就 omit，不要填空字串。\n" +
+  "- whyRemember 是 *必填*。沒有明確線索時，把整段話最有 hook 的一句當作 whyRemember。\n" +
+  "- 中英文混雜的內容：name、jobTitle、company 各填到對應的中/英欄位。\n" +
+  "- whyRemember 一定用繁體中文。\n" +
+  "- 不要編造對方說過的具體事；只根據輸入推理。";
+
+export function buildExtractMessages(
+  text: string,
+): Array<{ role: "system" | "user"; content: string }> {
+  return [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: text },
+  ];
+}
+
+const MAX_FIELD_LEN = 200;
+const MAX_NOTES_LEN = 1000;
+const MAX_WHY_LEN = 500;
+
+function sanitizeStr(value: unknown, max: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, max);
+}
+
+/**
+ * Parse the LLM's JSON into a Partial<CardCreateInput>. Defensive:
+ *   - strips markdown fences
+ *   - drops non-string fields
+ *   - clamps lengths
+ *   - guarantees `whyRemember` is at least the truncated input if the
+ *     LLM didn't pick one (the schema requires it; UI can edit before save)
+ */
+export function parseExtractedCard(raw: string, fallbackText: string): ExtractedCard | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const inner = fenced ? fenced[1]! : trimmed;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(inner);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const obj = parsed as Record<string, unknown>;
+
+  const out: ExtractedCard = {};
+  const nameZh = sanitizeStr(obj.nameZh, MAX_FIELD_LEN);
+  if (nameZh) out.nameZh = nameZh;
+  const nameEn = sanitizeStr(obj.nameEn, MAX_FIELD_LEN);
+  if (nameEn) out.nameEn = nameEn;
+  const jobTitleZh = sanitizeStr(obj.jobTitleZh, MAX_FIELD_LEN);
+  if (jobTitleZh) out.jobTitleZh = jobTitleZh;
+  const jobTitleEn = sanitizeStr(obj.jobTitleEn, MAX_FIELD_LEN);
+  if (jobTitleEn) out.jobTitleEn = jobTitleEn;
+  const companyZh = sanitizeStr(obj.companyZh, MAX_FIELD_LEN);
+  if (companyZh) out.companyZh = companyZh;
+  const companyEn = sanitizeStr(obj.companyEn, MAX_FIELD_LEN);
+  if (companyEn) out.companyEn = companyEn;
+  const department = sanitizeStr(obj.department, MAX_FIELD_LEN);
+  if (department) out.department = department;
+  const firstMetEventTag = sanitizeStr(obj.firstMetEventTag, MAX_FIELD_LEN);
+  if (firstMetEventTag) out.firstMetEventTag = firstMetEventTag;
+  const firstMetContext = sanitizeStr(obj.firstMetContext, MAX_FIELD_LEN);
+  if (firstMetContext) out.firstMetContext = firstMetContext;
+  const notes = sanitizeStr(obj.notes, MAX_NOTES_LEN);
+  if (notes) out.notes = notes;
+  const why = sanitizeStr(obj.whyRemember, MAX_WHY_LEN);
+  if (why) {
+    out.whyRemember = why;
+  } else {
+    // Schema requires whyRemember — fall back to truncated input so the
+    // form has *something* the user can refine.
+    const fallback = fallbackText.trim().slice(0, MAX_WHY_LEN);
+    out.whyRemember = fallback || "（剛認識）";
+  }
+  return out;
+}
+
+/**
+ * Encoder/decoder for passing the parsed card through a URL query
+ * param. Base64-encoded JSON keeps the URL clean and survives a
+ * full-page navigation to /cards/new.
+ */
+export function encodePrefill(card: ExtractedCard): string {
+  const json = JSON.stringify(card);
+  // Use base64url to be URL-safe without manual encoding.
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+export function decodePrefill(encoded: string | undefined | null): ExtractedCard | null {
+  if (!encoded || typeof encoded !== "string") return null;
+  try {
+    const json = Buffer.from(encoded, "base64url").toString("utf8");
+    const parsed = JSON.parse(json);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    // Rerun the same sanitizer over the decoded payload so a
+    // hand-crafted URL can't smuggle huge / non-string values.
+    const re = parseExtractedCard(JSON.stringify(parsed), "");
+    return re && Object.keys(re).length > 0 ? re : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #90

## Summary
Networking event 結束後最快的建卡方式：「拿出手機，講 30 秒剛遇到誰、什麼公司、為什麼想記住」。AI 解析成結構化欄位、預填到建立表單，你檢查後一鍵送出。從見面到建卡 < 60 秒。

Phase 1：跳過音訊轉錄這層，user 直接 type 自然語言。Phase 2 再接 Web Speech API 做 live transcript，給沒 Web Speech 的瀏覽器用 Whisper。

## Demo

```
🎙️ 語音建卡

文字框: 「陳玉涵 PM 智威科技 在 2024 Computex 攤位上聊邊緣 AI 推論」

[✨ 解析 + 預填表單]

✨ AI 解析結果
姓名（中）：陳玉涵
職稱（中）：PM
公司（中）：智威科技
認識場合：2024 COMPUTEX
情境：攤位上聊邊緣 AI 推論
為什麼記得：在 Computex 攤位聊到邊緣 AI 推論，很有共鳴

[使用此解析建立 →]   ← 跳到 /cards/new?prefill=...
```

## Files
- `src/lib/voice/extract.ts` (+150) — pure prompt builder + JSON parser; encodePrefill/decodePrefill (base64url)
- `src/lib/voice/extract-llm.ts` (+55) — MiniMax client (mirror coach-llm pattern)
- Server Action `extractCardFromTextAction({ text })` in `cards/actions.ts`
- `src/app/(app)/cards/voice/{page,voice.module}.tsx/css` — 新路由
- `src/components/cards/VoiceCardCapture.tsx` (+200) + module.css — input → preview → jump
- `src/app/(app)/cards/new/page.tsx` — accept `?prefill=base64url` → decode → CardForm defaults
- `AppShell.tsx` — 「🎙️ 語音建卡」 nav entry
- 15 UT (prompt builder, parser robustness, encode/decode round-trip, hostile-payload re-sanitize)

## Architecture decisions
- **Two-step flow** (parse → review → create) instead of one-shot create: gives user agency to fix LLM mistakes before commit, reuses all existing CardForm validation
- **base64url prefill token** through query param: works across server hops (page navigation), no need for sessionStorage / Firestore round-trip
- **Defensive re-sanitize on decode**: even if URL is hand-crafted with hostile payload, fields are clamped + non-strings dropped (no XSS, no DoS)
- **whyRemember fallback to truncated input**: schema requires it; LLM may forget; UI doesn't break with form validation error before user sees the preview
- **Conditional render**: `/cards/voice` shows fallback message when `MINIMAX_API_KEY` missing

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 561 pass (+15 new)
- [x] `pnpm lint` — clean (4 unrelated pre-existing)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — `/cards/voice` registered
- [ ] CI green → merge → mac mini deploy

## Out of scope (Phase 2)
- Web Speech API live transcript on the textarea
- Whisper server-side transcription for browsers without Web Speech
- Multi-card extraction (e.g., one paragraph mentioning 3 people)