### PR TITLE
feat(cards): 🎙️ Voice-to-card Phase 2 — Web Speech API live transcript

### DIFF
--- a/src/components/cards/VoiceCardCapture.module.css
+++ b/src/components/cards/VoiceCardCapture.module.css
@@ -40,6 +40,22 @@
   gap: var(--space-sm);
 }
 
+.interim {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  margin: 0;
+  padding: var(--space-xs) var(--space-sm);
+  border-left: 3px solid var(--color-accent-ink);
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 50%,
+    var(--color-paper)
+  );
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
 .primaryBtn {
   font-family: var(--font-sans);
   font-size: var(--text-body);

--- a/src/components/cards/VoiceCardCapture.tsx
+++ b/src/components/cards/VoiceCardCapture.tsx
@@ -7,6 +7,7 @@ import { extractCardFromTextAction } from "@/app/(app)/cards/actions";
 import type { ExtractedCard } from "@/lib/voice/extract";
 
 import styles from "./VoiceCardCapture.module.css";
+import { VoiceMicButton } from "./VoiceMicButton";
 
 const EXAMPLES = [
   "陳玉涵 PM 智威科技 在 2024 Computex 攤位上聊邊緣 AI 推論很投緣，提到他們公司在做 ML 加速器",
@@ -30,6 +31,7 @@ type Phase =
 export function VoiceCardCapture() {
   const router = useRouter();
   const [text, setText] = useState("");
+  const [interim, setInterim] = useState("");
   const [phase, setPhase] = useState<Phase>({ kind: "input" });
   const [pending, startTransition] = useTransition();
 
@@ -86,6 +88,15 @@ export function VoiceCardCapture() {
         placeholder="例如：陳玉涵 PM 智威科技 在 Computex 攤位聊邊緣 AI 推論..."
         rows={5}
         maxLength={2000}
+        disabled={pending && phase.kind === "loading"}
+      />
+      {interim && <p className={styles.interim}>聆聽中：「{interim}」</p>}
+      <VoiceMicButton
+        onFinalTranscript={(t) => {
+          setText((prev) => (prev ? `${prev} ${t}` : t));
+          setInterim("");
+        }}
+        onInterimTranscript={setInterim}
         disabled={pending && phase.kind === "loading"}
       />
       <div className={styles.actions}>

--- a/src/components/cards/VoiceMicButton.module.css
+++ b/src/components/cards/VoiceMicButton.module.css
@@ -1,0 +1,87 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  align-items: flex-start;
+}
+
+.btn,
+.btnActive {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-sm) var(--space-lg);
+  border-radius: 999px;
+  border: var(--border-hair) solid var(--color-accent-ink);
+  background: var(--color-paper);
+  color: var(--color-accent-ink);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard),
+    transform var(--duration-fast) var(--ease-standard);
+}
+
+.btn:hover:not(:disabled) {
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.btn:disabled,
+.btnActive:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.btnActive {
+  background: var(--color-accent-ink);
+  color: var(--color-paper);
+  border-color: var(--color-accent-ink);
+  animation: micGlow 1.5s ease-in-out infinite;
+}
+
+@keyframes micGlow {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in oklch, var(--color-accent-ink) 35%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 10px color-mix(in oklch, var(--color-accent-ink) 0%, transparent);
+  }
+}
+
+.pulse {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: currentColor;
+  animation: micPulse 1s ease-in-out infinite;
+}
+
+@keyframes micPulse {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: scale(0.85);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+}
+
+.hint,
+.fallback {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0;
+  font-style: italic;
+}
+
+.hint {
+  color: var(--color-error, #b00020);
+  font-style: normal;
+}

--- a/src/components/cards/VoiceMicButton.tsx
+++ b/src/components/cards/VoiceMicButton.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import styles from "./VoiceMicButton.module.css";
+
+interface VoiceMicButtonProps {
+  /**
+   * Called whenever the recognizer emits a *final* recognized utterance.
+   * Caller is responsible for appending to its own text state.
+   */
+  onFinalTranscript: (text: string) => void;
+  /**
+   * Called with the live (in-progress) interim transcript so the host
+   * UI can show a "聆聽中：「…」" preview. Optional.
+   */
+  onInterimTranscript?: (text: string) => void;
+  /** BCP-47 language tag. Defaults to zh-TW. */
+  lang?: string;
+  /** Disable the entire button (e.g. while parent is processing). */
+  disabled?: boolean;
+}
+
+type RecognitionState = "idle" | "listening" | "denied" | "unsupported";
+
+interface SpeechRecognitionEventLike {
+  results: ArrayLike<{
+    isFinal: boolean;
+    [index: number]: { transcript: string };
+    length: number;
+  }> & { length: number };
+  resultIndex: number;
+}
+
+interface SpeechRecognitionLike {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start(): void;
+  stop(): void;
+  abort(): void;
+  onresult: ((e: SpeechRecognitionEventLike) => void) | null;
+  onerror: ((e: { error?: string }) => void) | null;
+  onend: (() => void) | null;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionLike;
+}
+
+function getRecognitionCtor(): SpeechRecognitionConstructor | null {
+  if (typeof window === "undefined") return null;
+  const w = window as unknown as {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  };
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+}
+
+/**
+ * Mobile-friendly mic button that wraps the browser's Web Speech API.
+ * Press to toggle listening; live transcript bubbles up via the
+ * `onInterimTranscript` callback while final utterances fire
+ * `onFinalTranscript`. Free, no API key, no server hop — but only
+ * works in browsers that support Web Speech (Chrome, Edge, modern
+ * Safari). Unsupported browsers see a hidden button + a hint.
+ */
+export function VoiceMicButton({
+  onFinalTranscript,
+  onInterimTranscript,
+  lang = "zh-TW",
+  disabled = false,
+}: VoiceMicButtonProps) {
+  // Detect Web Speech support during initial state via lazy init —
+  // sidesteps the react-hooks/set-state-in-effect rule (no effect needed
+  // for a one-time DOM-API capability check).
+  const [state, setState] = useState<RecognitionState>(() => {
+    if (typeof window === "undefined") return "idle";
+    return getRecognitionCtor() ? "idle" : "unsupported";
+  });
+  const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  // The Web Speech engine sometimes ends a session after a short pause.
+  // We re-arm it ourselves until the user explicitly stops — read this
+  // ref inside `onend` (the state snapshot in a closure would be stale).
+  const wantListeningRef = useRef(false);
+
+  const start = () => {
+    if (disabled || state === "listening") return;
+    const ctor = getRecognitionCtor();
+    if (!ctor) {
+      setState("unsupported");
+      return;
+    }
+    const r = new ctor();
+    r.continuous = true;
+    r.interimResults = true;
+    r.lang = lang;
+    r.onresult = (e) => {
+      let interim = "";
+      let final = "";
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        const result = e.results[i]!;
+        const transcript = result[0]?.transcript ?? "";
+        if (result.isFinal) {
+          final += transcript;
+        } else {
+          interim += transcript;
+        }
+      }
+      if (final) onFinalTranscript(final.trim());
+      if (interim && onInterimTranscript) onInterimTranscript(interim.trim());
+    };
+    r.onerror = (e) => {
+      if (e.error === "not-allowed" || e.error === "service-not-allowed") {
+        setState("denied");
+      } else {
+        setState("idle");
+      }
+    };
+    r.onend = () => {
+      // Auto-restart while user *intends* to keep listening — Web
+      // Speech sometimes ends after a short pause. Read the intent ref
+      // (not React state) because the closure captured a stale value.
+      if (recognitionRef.current === r && wantListeningRef.current) {
+        try {
+          r.start();
+          return;
+        } catch {
+          // Already started or in transition — fall through.
+        }
+      }
+      setState((s) => (s === "listening" ? "idle" : s));
+    };
+    recognitionRef.current = r;
+    wantListeningRef.current = true;
+    try {
+      r.start();
+      setState("listening");
+    } catch {
+      wantListeningRef.current = false;
+      setState("idle");
+    }
+  };
+
+  const stop = () => {
+    wantListeningRef.current = false;
+    const r = recognitionRef.current;
+    if (!r) {
+      setState("idle");
+      return;
+    }
+    try {
+      r.stop();
+    } catch {
+      // already stopped
+    }
+    recognitionRef.current = null;
+    setState("idle");
+    if (onInterimTranscript) onInterimTranscript("");
+  };
+
+  // Cleanup on unmount.
+  useEffect(() => {
+    return () => {
+      const r = recognitionRef.current;
+      if (r) {
+        try {
+          r.abort();
+        } catch {
+          // noop
+        }
+        recognitionRef.current = null;
+      }
+    };
+  }, []);
+
+  if (state === "unsupported") {
+    return (
+      <p className={styles.fallback}>
+        🎙️ 你的瀏覽器不支援語音輸入（建議用 Chrome / Edge / 新版 Safari）。請打字輸入。
+      </p>
+    );
+  }
+
+  const listening = state === "listening";
+  return (
+    <div className={styles.wrapper}>
+      <button
+        type="button"
+        className={listening ? styles.btnActive : styles.btn}
+        onClick={listening ? stop : start}
+        disabled={disabled}
+        aria-pressed={listening}
+        aria-label={listening ? "停止語音輸入" : "開始語音輸入"}
+        title={listening ? "點擊停止" : "點擊開始說話"}
+      >
+        {listening ? (
+          <>
+            <span className={styles.pulse} aria-hidden="true" />
+            🎙️ 聆聽中…（再點一次停止）
+          </>
+        ) : (
+          "🎙️ 按住說話"
+        )}
+      </button>
+      {state === "denied" && (
+        <p className={styles.hint} role="status">
+          已拒絕麥克風權限。到瀏覽器設定允許後重試。
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/cards/__tests__/VoiceMicButton.test.tsx
+++ b/src/components/cards/__tests__/VoiceMicButton.test.tsx
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+import { VoiceMicButton } from "../VoiceMicButton";
+
+interface FakeRecognition {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onresult: ((e: { results: unknown; resultIndex: number }) => void) | null;
+  onerror: ((e: { error?: string }) => void) | null;
+  onend: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+  __started: boolean;
+  __stopped: boolean;
+}
+
+function makeFakeRecognition(): FakeRecognition {
+  const fake: FakeRecognition = {
+    continuous: false,
+    interimResults: false,
+    lang: "",
+    onresult: null,
+    onerror: null,
+    onend: null,
+    __started: false,
+    __stopped: false,
+    start: () => {
+      fake.__started = true;
+    },
+    stop: () => {
+      fake.__stopped = true;
+    },
+    abort: () => {
+      fake.__stopped = true;
+    },
+  };
+  return fake;
+}
+
+describe("VoiceMicButton", () => {
+  let originalSpeechRecognition: unknown;
+  let lastFake: FakeRecognition | null = null;
+
+  beforeEach(() => {
+    lastFake = null;
+    originalSpeechRecognition = (window as unknown as { webkitSpeechRecognition?: unknown })
+      .webkitSpeechRecognition;
+    (window as unknown as { webkitSpeechRecognition: () => unknown }).webkitSpeechRecognition =
+      function () {
+        const f = makeFakeRecognition();
+        lastFake = f;
+        return f;
+      } as unknown as () => unknown;
+  });
+
+  afterEach(() => {
+    (window as unknown as { webkitSpeechRecognition?: unknown }).webkitSpeechRecognition =
+      originalSpeechRecognition;
+  });
+
+  it("renders the start button when Web Speech is supported", () => {
+    render(<VoiceMicButton onFinalTranscript={() => {}} />);
+    expect(screen.getByRole("button", { name: /開始語音輸入/ })).toBeInTheDocument();
+  });
+
+  it("clicking start enters listening state and starts the recognizer", () => {
+    render(<VoiceMicButton onFinalTranscript={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /開始語音輸入/ }));
+    expect(screen.getByRole("button", { name: /停止語音輸入/ })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(lastFake?.__started).toBe(true);
+    expect(lastFake?.lang).toBe("zh-TW");
+  });
+
+  it("clicking stop exits listening and stops the recognizer", () => {
+    render(<VoiceMicButton onFinalTranscript={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /開始語音輸入/ }));
+    fireEvent.click(screen.getByRole("button", { name: /停止語音輸入/ }));
+    expect(screen.getByRole("button", { name: /開始語音輸入/ })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(lastFake?.__stopped).toBe(true);
+  });
+
+  it("emits final transcript via callback on result event", () => {
+    const onFinal = vi.fn();
+    render(<VoiceMicButton onFinalTranscript={onFinal} />);
+    fireEvent.click(screen.getByRole("button", { name: /開始語音輸入/ }));
+    lastFake?.onresult?.({
+      results: {
+        length: 1,
+        0: {
+          length: 1,
+          isFinal: true,
+          0: { transcript: "  陳玉涵 PM 智威  " },
+        },
+      } as unknown as { length: 1; [k: number]: { isFinal: boolean; length: number } },
+      resultIndex: 0,
+    });
+    expect(onFinal).toHaveBeenCalledWith("陳玉涵 PM 智威");
+  });
+
+  it("emits interim transcript when result is non-final", () => {
+    const onFinal = vi.fn();
+    const onInterim = vi.fn();
+    render(<VoiceMicButton onFinalTranscript={onFinal} onInterimTranscript={onInterim} />);
+    fireEvent.click(screen.getByRole("button", { name: /開始語音輸入/ }));
+    lastFake?.onresult?.({
+      results: {
+        length: 1,
+        0: { length: 1, isFinal: false, 0: { transcript: "陳玉" } },
+      } as unknown as { length: 1; [k: number]: { isFinal: boolean; length: number } },
+      resultIndex: 0,
+    });
+    expect(onInterim).toHaveBeenCalledWith("陳玉");
+    expect(onFinal).not.toHaveBeenCalled();
+  });
+
+  it("shows denied hint when permission error fires", () => {
+    render(<VoiceMicButton onFinalTranscript={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /開始語音輸入/ }));
+    act(() => {
+      lastFake?.onerror?.({ error: "not-allowed" });
+    });
+    expect(screen.getByText(/已拒絕麥克風權限/)).toBeInTheDocument();
+  });
+
+  it("disables button when disabled prop is true", () => {
+    render(<VoiceMicButton onFinalTranscript={() => {}} disabled />);
+    expect(screen.getByRole("button", { name: /開始語音輸入/ })).toBeDisabled();
+  });
+
+  it("renders fallback text when Web Speech is unsupported", () => {
+    (window as unknown as { webkitSpeechRecognition?: unknown }).webkitSpeechRecognition =
+      undefined;
+    (window as unknown as { SpeechRecognition?: unknown }).SpeechRecognition = undefined;
+    render(<VoiceMicButton onFinalTranscript={() => {}} />);
+    expect(screen.getByText(/不支援語音輸入/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /開始語音輸入/ })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #92

## Summary
Phase 1 (#90) 已能「文字 → AI 解析 → 預填表單」。但商務人士在 networking event 後手往往沒空打字。Phase 2 加 Web Speech API (browser native, free, no API key) — 按 mic → 講話 → live transcript → 鬆開 → 文字進 textarea → Phase 1 的 LLM 接著解析。

> 從見面到建卡：拿手機 → 點 mic → 講 30 秒 → 點解析 → 點建立。手沒離過一秒。

## Demo

```
🎙️ 語音建卡

[textarea]
聆聽中：「陳玉涵 PM 智威科技 在 Computex 攤位...」  ← italic, accent color

[🎙️ 聆聽中…（再點一次停止）]  ← pulsing red circle

⬇ stop ⬇

textarea: 陳玉涵 PM 智威科技 在 Computex 攤位上聊邊緣 AI 推論

[✨ 解析 + 預填表單]  ← Phase 1 接手
```

## Files
- `src/components/cards/VoiceMicButton.tsx` (+200) — Web Speech wrapper
- `src/components/cards/VoiceMicButton.module.css` — pulsing mic button + fallback hint
- `src/components/cards/VoiceCardCapture.tsx` — wires mic; append final, render interim italic preview
- `src/components/cards/VoiceCardCapture.module.css` — `.interim` style
- 8 UT (render gating, start/stop, final/interim transcript callback, mic-denied state, disabled, unsupported fallback)

## Architecture decisions
- **Lazy useState init** for capability detection — sidesteps `react-hooks/set-state-in-effect`. Same pattern as the prior `MobileNavWrapper` rule fix.
- **`wantListeningRef`** instead of state read in `onend`: Web Speech engine sometimes auto-ends a session after a pause; we re-arm based on user *intent* (latest ref value) not the stale state captured at closure creation.
- **Interim vs final separation**: live transcript previews in italic accent box, only final utterances get appended to the textarea. User sees what the engine *might* be hearing without polluting the actual input.
- **Graceful unsupported**: Firefox / iOS Safari old → no mic button rendered, fallback hint suggests Chrome / Edge / new Safari + falls back to typing.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 569 pass (+8 new)
- [x] `pnpm lint` — 0 errors (4 pre-existing warnings)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — green
- [ ] CI green → merge → mac mini deploy

## Out of scope (Phase 3)
- Server-side Whisper API fallback for browsers without Web Speech
- Multi-card extraction from one long voice memo
- Direct create (skip preview)