### PR TITLE
feat(intros): 🤝 AI 介紹建議 — 「你認識的 X 跟 Y 應該介紹」+ 一鍵 intro email

### DIFF
--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -30,6 +30,14 @@ import {
   type CoachContext,
   type CoachInsight,
 } from "@/lib/coach/insights";
+import {
+  introsCacheKey,
+  parseIntrosResponse,
+  selectIntroCandidates,
+  type IntroSuggestion,
+} from "@/lib/coach/intros";
+import { callIntrosLlm } from "@/lib/coach/intros-llm";
+import { readIntrosCache, writeIntrosCache } from "@/lib/coach/intros-store";
 import { callCoachLlm, isCoachConfigured } from "@/lib/coach/llm";
 import { selectTodayPriorityCards, type PriorityCandidate } from "@/lib/coach/priority";
 import { reengageCacheKey, type ReengageContext, type ReengageDrafts } from "@/lib/coach/reengage";
@@ -430,6 +438,74 @@ export const setPublicSlugAction = authedAction
       revalidatePath(`/cards/${parsedInput.cardId}`);
       if (desired) revalidatePath(`/u/${desired}`);
       return { ok: true, slug: desired };
+    },
+  );
+
+/**
+ * 🤝 AI 介紹建議 — assemble candidates → LLM picks 3-5 (cardA, cardB)
+ * pairs with reason + ready-to-send intro email. Cached weekly so
+ * suggestions feel like a "weekly digest" not a daily churn.
+ */
+export const getIntroSuggestionsAction = authedAction
+  .inputSchema(z.object({ force: z.boolean().optional().default(false) }))
+  .action(
+    async ({
+      parsedInput,
+      ctx,
+    }): Promise<
+      | {
+          ok: true;
+          intros: Array<{
+            intro: IntroSuggestion;
+            cardA: PriorityCandidate["card"];
+            cardB: PriorityCandidate["card"];
+          }>;
+          cached: boolean;
+        }
+      | { ok: false; reason: "no-llm" | "too-few-cards" | "llm-failed" }
+    > => {
+      if (!isCoachConfigured()) return { ok: false, reason: "no-llm" };
+      const allCards = await listCardsForUser(ctx.user.uid, { limit: 500 });
+      const candidates = selectIntroCandidates(allCards);
+      if (candidates.length < 4) return { ok: false, reason: "too-few-cards" };
+
+      const cacheKey = introsCacheKey(
+        new Date(),
+        candidates.map((c) => c.id),
+      );
+      const candidateById = new Map(candidates.map((c) => [c.id, c]));
+
+      let intros = parsedInput.force ? null : await readIntrosCache(ctx.user.uid, cacheKey);
+      if (!intros) {
+        intros = await callIntrosLlm(candidates);
+        if (!intros || intros.length === 0) {
+          return { ok: false, reason: "llm-failed" };
+        }
+        await writeIntrosCache(ctx.user.uid, cacheKey, intros);
+      } else {
+        // Re-validate cached cardIds against current candidate set so a
+        // recently-merged / deleted card doesn't surface a dangling pair.
+        const validIds = new Set(candidates.map((c) => c.id));
+        intros = parseIntrosResponse(JSON.stringify({ intros }), validIds);
+      }
+
+      const paired = intros
+        .map((intro) => {
+          const cardA = candidateById.get(intro.cardAId);
+          const cardB = candidateById.get(intro.cardBId);
+          return cardA && cardB ? { intro, cardA, cardB } : null;
+        })
+        .filter(
+          (
+            x,
+          ): x is {
+            intro: IntroSuggestion;
+            cardA: PriorityCandidate["card"];
+            cardB: PriorityCandidate["card"];
+          } => x !== null,
+        );
+
+      return { ok: true, intros: paired, cached: !parsedInput.force && paired.length > 0 };
     },
   );
 

--- a/src/app/(app)/intros/intros.module.css
+++ b/src/app/(app)/intros/intros.module.css
@@ -1,0 +1,75 @@
+.article {
+  max-width: var(--content-max);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding-bottom: var(--space-md);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h2);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+}
+
+.title em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-accent);
+}
+
+.lead {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  line-height: var(--leading-relaxed);
+  margin: var(--space-xs) 0 0;
+  max-width: 60ch;
+}
+
+.notReady {
+  padding: var(--space-2xl) var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  color: var(--color-ink-muted);
+  text-align: center;
+}
+
+.footer {
+  padding-top: var(--space-md);
+  border-top: var(--border-hair) solid var(--color-border);
+}
+
+.backLink {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  text-decoration: none;
+  letter-spacing: var(--tracking-wide);
+}
+
+.backLink:hover {
+  text-decoration: underline;
+}

--- a/src/app/(app)/intros/page.tsx
+++ b/src/app/(app)/intros/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+import { IntroSuggestionsList } from "@/components/coach/IntroSuggestionsList";
+import { isCoachConfigured } from "@/lib/coach/llm";
+
+import styles from "./intros.module.css";
+
+export const metadata = {
+  title: "AI 介紹建議",
+};
+
+export default function IntrosPage() {
+  const llmReady = isCoachConfigured();
+
+  return (
+    <article className={styles.article}>
+      <header className={styles.header}>
+        <p className={styles.kicker}>🤝 AI 介紹建議</p>
+        <h1 className={styles.title}>
+          你名片冊裡，<em>誰跟誰</em>應該認識？
+        </h1>
+        <p className={styles.lead}>
+          商務人士最有價值的不是「自己認識誰」，是「能介紹誰跟誰」。AI 掃過你的名片冊，找出 3-5
+          對應該認識的人 + 為什麼 + 寫好的 intro email。把你從 contact owner 升級成
+          super-connector。
+        </p>
+      </header>
+
+      {!llmReady ? (
+        <section className={styles.notReady}>
+          <p>AI 目前未啟用 — 管理員尚未設定 LLM 金鑰。</p>
+        </section>
+      ) : (
+        <IntroSuggestionsList />
+      )}
+
+      <footer className={styles.footer}>
+        <Link href="/cards" className={styles.backLink}>
+          ← 回名片冊
+        </Link>
+      </footer>
+    </article>
+  );
+}

--- a/src/components/coach/IntroSuggestionsList.module.css
+++ b/src/components/coach/IntroSuggestionsList.module.css
@@ -1,0 +1,323 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-lg);
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(
+    135deg,
+    color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 50%, var(--color-paper)) 0%,
+    var(--color-paper) 100%
+  );
+  position: relative;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h3);
+  font-weight: 500;
+  margin: 0;
+  color: var(--color-ink);
+}
+
+.regenerate {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-sm);
+  background: transparent;
+  color: var(--color-accent-ink);
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.regenerate:hover:not(:disabled) {
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.regenerate:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  align-items: flex-start;
+}
+
+.lead {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+  max-width: 60ch;
+}
+
+.primaryBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.primaryBtn:hover:not(:disabled) {
+  background: var(--color-accent-ink);
+}
+
+.primaryBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+}
+
+.spinner {
+  width: 1.1em;
+  height: 1.1em;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent-ink);
+  border-radius: 50%;
+  animation: introSpin 0.7s linear infinite;
+}
+
+@keyframes introSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.errorBox {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+}
+
+.errorBox p {
+  margin: 0;
+  color: var(--color-ink);
+}
+
+.smallBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.smallBtn:hover {
+  border-color: var(--color-accent-ink);
+}
+
+.smallLink {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-md);
+  color: var(--color-accent-ink);
+  text-decoration: none;
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-sm);
+}
+
+.smallLink:hover {
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.empty {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.pairList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.pair {
+  display: flex;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.rank {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 50%;
+  background: var(--color-ink);
+  color: var(--color-paper);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.pairBody {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.cards {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.connector {
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  color: var(--color-accent-ink);
+}
+
+.chip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15em;
+  padding: var(--space-xs) var(--space-sm);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  background: var(--color-paper);
+  flex: 1;
+  min-width: 14rem;
+}
+
+.chip:hover {
+  border-color: var(--color-accent-ink);
+}
+
+.chipName {
+  font-family: var(--font-display);
+  font-weight: 600;
+  color: var(--color-ink);
+  font-size: var(--text-body);
+}
+
+.chipSub {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+}
+
+.reason {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+}
+
+.draftWrap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.draftSummary {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  cursor: pointer;
+  letter-spacing: var(--tracking-wide);
+}
+
+.draft {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+  padding: var(--space-md);
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 30%,
+    var(--color-paper)
+  );
+  border-radius: var(--radius-sm);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.draftActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.cachedNote {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  color: var(--color-ink-muted);
+  font-style: italic;
+  margin: 0;
+}
+
+.toast {
+  position: fixed;
+  bottom: var(--space-lg);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  z-index: 100;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 20%);
+}

--- a/src/components/coach/IntroSuggestionsList.tsx
+++ b/src/components/coach/IntroSuggestionsList.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useTransition } from "react";
+
+import { getIntroSuggestionsAction } from "@/app/(app)/cards/actions";
+import type { CardSummary } from "@/db/cards";
+import type { IntroSuggestion } from "@/lib/coach/intros";
+
+import styles from "./IntroSuggestionsList.module.css";
+
+interface PairedIntro {
+  intro: IntroSuggestion;
+  cardA: CardSummary;
+  cardB: CardSummary;
+}
+
+type LoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; intros: PairedIntro[]; cached: boolean }
+  | { kind: "error"; message: string };
+
+function pickName(c: CardSummary): string {
+  return c.nameZh || c.nameEn || "（未命名）";
+}
+
+function pickSubtitle(c: CardSummary): string {
+  const role = c.jobTitleZh || c.jobTitleEn;
+  const company = c.companyZh || c.companyEn;
+  return [role, company].filter(Boolean).join(" · ");
+}
+
+/**
+ * Opt-in disclosure on /intros that calls the LLM intro matchmaker
+ * and renders 3-5 (cardA, cardB) pairs with a ready-to-send intro
+ * email body. Each pair has copy-email + open-mailto deep links to
+ * either party's primary email.
+ */
+export function IntroSuggestionsList() {
+  const [state, setState] = useState<LoadState>({ kind: "idle" });
+  const [pending, startTransition] = useTransition();
+  const [copyToast, setCopyToast] = useState<string | null>(null);
+
+  const fetchIntros = (force: boolean) => {
+    setState({ kind: "loading" });
+    startTransition(async () => {
+      const result = await getIntroSuggestionsAction({ force });
+      const data = result?.data;
+      if (result?.serverError) {
+        setState({ kind: "error", message: result.serverError });
+        return;
+      }
+      if (!data) {
+        setState({ kind: "error", message: "建議官沒回應，請稍後再試" });
+        return;
+      }
+      if (!data.ok) {
+        const messages: Record<string, string> = {
+          "no-llm": "AI 未啟用",
+          "too-few-cards": "名片冊還不夠 — 至少需要 4 張包含公司資訊的名片",
+          "llm-failed": "AI 暫時無法回應，請稍後再試",
+        };
+        setState({ kind: "error", message: messages[data.reason] ?? "未知錯誤" });
+        return;
+      }
+      setState({ kind: "ready", intros: data.intros, cached: data.cached });
+    });
+  };
+
+  const copy = async (text: string, what: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyToast(`已複製${what}`);
+      setTimeout(() => setCopyToast(null), 1800);
+    } catch {
+      setCopyToast("複製失敗");
+      setTimeout(() => setCopyToast(null), 1800);
+    }
+  };
+
+  return (
+    <section className={styles.section}>
+      <header className={styles.header}>
+        <h2 className={styles.title}>每週推薦的 intro 對</h2>
+        {state.kind === "ready" && (
+          <button
+            type="button"
+            className={styles.regenerate}
+            onClick={() => fetchIntros(true)}
+            disabled={pending}
+          >
+            {state.cached ? "重新產生" : "再來一輪"}
+          </button>
+        )}
+      </header>
+
+      {state.kind === "idle" && (
+        <div className={styles.emptyState}>
+          <p className={styles.lead}>
+            按下按鈕，AI 會掃過你的名片冊（會優先看 pinned + 最近聯絡的人），找出 3-5 對應該認識的人
+            + 為什麼 + 寫好的 intro email。
+          </p>
+          <button
+            type="button"
+            className={styles.primaryBtn}
+            onClick={() => fetchIntros(false)}
+            disabled={pending}
+          >
+            {pending ? "AI 配對中…" : "🤝 找出本週的 intro 對"}
+          </button>
+        </div>
+      )}
+
+      {state.kind === "loading" && (
+        <div className={styles.loading} aria-live="polite">
+          <span className={styles.spinner} aria-hidden="true" />
+          <span>AI 正在掃描你的名片冊找出最有 fit 的 pair…</span>
+        </div>
+      )}
+
+      {state.kind === "error" && (
+        <div className={styles.errorBox} role="alert">
+          <p>{state.message}</p>
+          <button
+            type="button"
+            className={styles.smallBtn}
+            onClick={() => fetchIntros(false)}
+            disabled={pending}
+          >
+            重試
+          </button>
+        </div>
+      )}
+
+      {state.kind === "ready" && (
+        <div className={styles.results}>
+          {state.intros.length === 0 ? (
+            <p className={styles.empty}>AI 這週沒找到明顯的 intro 對。下週再試試。</p>
+          ) : (
+            <ol className={styles.pairList}>
+              {state.intros.map((entry, i) => {
+                const emailA = entry.cardA.emails?.[0]?.value;
+                const emailB = entry.cardB.emails?.[0]?.value;
+                const recipientList = [emailA, emailB].filter(Boolean).join(",");
+                const subjectIntro = `Intro: ${pickName(entry.cardA)} ↔ ${pickName(entry.cardB)}`;
+                return (
+                  <li key={i} className={styles.pair}>
+                    <div className={styles.rank} aria-hidden="true">
+                      {i + 1}
+                    </div>
+                    <div className={styles.pairBody}>
+                      <div className={styles.cards}>
+                        <PairCardChip card={entry.cardA} />
+                        <span className={styles.connector} aria-hidden="true">
+                          ↔
+                        </span>
+                        <PairCardChip card={entry.cardB} />
+                      </div>
+                      <p className={styles.reason}>{entry.intro.reason}</p>
+                      <details className={styles.draftWrap}>
+                        <summary className={styles.draftSummary}>📧 看 intro email 草稿</summary>
+                        <pre className={styles.draft}>{entry.intro.draftEmail}</pre>
+                        <div className={styles.draftActions}>
+                          <button
+                            type="button"
+                            className={styles.smallBtn}
+                            onClick={() => copy(entry.intro.draftEmail, "草稿")}
+                          >
+                            複製草稿
+                          </button>
+                          {recipientList && (
+                            <a
+                              href={`mailto:${recipientList}?subject=${encodeURIComponent(subjectIntro)}&body=${encodeURIComponent(entry.intro.draftEmail)}`}
+                              className={styles.smallLink}
+                            >
+                              開信件 (寄給雙方) →
+                            </a>
+                          )}
+                        </div>
+                      </details>
+                    </div>
+                  </li>
+                );
+              })}
+            </ol>
+          )}
+          {state.cached && (
+            <p className={styles.cachedNote}>
+              這份建議來自本週的快取。新增名片或下週會自動重算；想立刻換組可點「重新產生」。
+            </p>
+          )}
+        </div>
+      )}
+
+      {copyToast && (
+        <p role="status" aria-live="polite" className={styles.toast}>
+          {copyToast}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function PairCardChip({ card }: { card: CardSummary }) {
+  return (
+    <Link href={`/cards/${card.id}`} className={styles.chip}>
+      <span className={styles.chipName}>{pickName(card)}</span>
+      <span className={styles.chipSub}>{pickSubtitle(card)}</span>
+    </Link>
+  );
+}

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -17,6 +17,7 @@ interface NavItem {
 const PRIMARY: NavItem[] = [
   { href: "/", label: "時間軸", description: "最近沒聯絡 · 本月認識" },
   { href: "/followups", label: "追蹤", description: "誰該 ping 了" },
+  { href: "/intros", label: "🤝 介紹建議", description: "AI 找誰跟誰應該認識" },
   { href: "/cards", label: "名片冊", description: "畫廊 · 清單" },
   { href: "/cards/new", label: "新增", description: "手動建立一張" },
   { href: "/cards/voice", label: "🎙️ 語音建卡", description: "講 30 秒讓 AI 解析" },

--- a/src/lib/coach/__tests__/briefing.test.ts
+++ b/src/lib/coach/__tests__/briefing.test.ts
@@ -84,6 +84,18 @@ describe("buildBriefingPrompt", () => {
     expect(prompt).toContain("已 30 天沒互動");
     expect(prompt).toContain("重要聯絡人");
   });
+
+  it("followup-due-today renders as 「提醒到期今天」", () => {
+    const c = mkCandidate({ reason: "followup-due-today", daysOffset: 0, score: 90 });
+    const prompt = buildBriefingPrompt([c], NOW);
+    expect(prompt).toContain("提醒到期今天");
+  });
+
+  it("uncontacted-long shows days-since-contact", () => {
+    const c = mkCandidate({ reason: "uncontacted-long", daysOffset: 90, score: 50 });
+    const prompt = buildBriefingPrompt([c], NOW);
+    expect(prompt).toContain("已 90 天沒互動");
+  });
 });
 
 describe("buildBriefingMessages", () => {

--- a/src/lib/coach/__tests__/intros.test.ts
+++ b/src/lib/coach/__tests__/intros.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import {
+  buildIntrosMessages,
+  buildIntrosPrompt,
+  introsCacheKey,
+  parseIntrosResponse,
+  selectIntroCandidates,
+} from "../intros";
+
+const NOW = new Date("2026-04-25T10:00:00Z");
+
+function mk(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "陳玉涵",
+    jobTitleZh: "PM",
+    companyZh: "智威",
+    whyRemember: "Computex 邊緣 AI",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    social: {},
+    isPinned: false,
+    createdAt: new Date("2025-01-01"),
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe("selectIntroCandidates", () => {
+  it("filters out cards without name or company", () => {
+    const noName = mk({ id: "noname", nameZh: undefined, nameEn: undefined });
+    const noCompany = mk({ id: "noco", companyZh: undefined, companyEn: undefined });
+    const ok = mk({ id: "ok" });
+    const out = selectIntroCandidates([noName, noCompany, ok]);
+    expect(out.map((c) => c.id)).toEqual(["ok"]);
+  });
+
+  it("excludes soft-deleted cards", () => {
+    const deleted = mk({ id: "del", deletedAt: new Date() });
+    const live = mk({ id: "live" });
+    expect(selectIntroCandidates([deleted, live]).map((c) => c.id)).toEqual(["live"]);
+  });
+
+  it("prefers pinned cards then most-recently contacted", () => {
+    const pinned = mk({ id: "p", isPinned: true });
+    const recent = mk({ id: "r", lastContactedAt: new Date("2026-04-20") });
+    const old = mk({ id: "o", lastContactedAt: new Date("2024-01-01") });
+    const out = selectIntroCandidates([old, recent, pinned], 3);
+    expect(out.map((c) => c.id)).toEqual(["p", "r", "o"]);
+  });
+
+  it("respects max parameter", () => {
+    const cards = Array.from({ length: 50 }, (_, i) => mk({ id: `c${i}` }));
+    expect(selectIntroCandidates(cards, 10)).toHaveLength(10);
+  });
+});
+
+describe("buildIntrosPrompt", () => {
+  it("includes each candidate's id, name, role, company", () => {
+    const a = mk({ id: "a", nameZh: "Alice", jobTitleZh: "PM", companyZh: "ACME" });
+    const b = mk({ id: "b", nameZh: "Bob", jobTitleZh: "BD", companyZh: "Pixel" });
+    const prompt = buildIntrosPrompt([a, b]);
+    expect(prompt).toContain("Alice");
+    expect(prompt).toContain("Bob");
+    expect(prompt).toContain("ACME");
+    expect(prompt).toContain("Pixel");
+    expect(prompt).toContain("a");
+    expect(prompt).toContain("b");
+  });
+
+  it("includes whyRemember + firstMetEventTag when present", () => {
+    const c = mk({ id: "c", whyRemember: "Computex meet", firstMetEventTag: "2024 COMPUTEX" });
+    const prompt = buildIntrosPrompt([c]);
+    expect(prompt).toContain("Computex meet");
+    expect(prompt).toContain("2024 COMPUTEX");
+  });
+});
+
+describe("buildIntrosMessages", () => {
+  it("returns system + user with the right schema hints", () => {
+    const msgs = buildIntrosMessages([mk()]);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.content).toContain("intros");
+    expect(msgs[0]!.content).toContain("cardAId");
+    expect(msgs[0]!.content).toContain("cardBId");
+    expect(msgs[0]!.content).toContain("draftEmail");
+  });
+});
+
+describe("parseIntrosResponse", () => {
+  const validIds = new Set(["a", "b", "c", "d"]);
+
+  it("parses a clean intros JSON", () => {
+    const raw = JSON.stringify({
+      intros: [
+        { cardAId: "a", cardBId: "b", reason: "互補", draftEmail: "Hi A and B..." },
+        { cardAId: "c", cardBId: "d", reason: "同產業", draftEmail: "Hi C and D..." },
+      ],
+    });
+    const out = parseIntrosResponse(raw, validIds);
+    expect(out).toHaveLength(2);
+    expect(out[0]!.cardAId).toBe("a");
+    expect(out[0]!.cardBId).toBe("b");
+  });
+
+  it("strips markdown json fence", () => {
+    const raw =
+      "```json\n" +
+      JSON.stringify({
+        intros: [{ cardAId: "a", cardBId: "b", reason: "x", draftEmail: "y" }],
+      }) +
+      "\n```";
+    expect(parseIntrosResponse(raw, validIds)).toHaveLength(1);
+  });
+
+  it("drops pairs with cardId not in valid set (anti-hallucination)", () => {
+    const raw = JSON.stringify({
+      intros: [
+        { cardAId: "a", cardBId: "MADE-UP", reason: "x", draftEmail: "y" },
+        { cardAId: "a", cardBId: "b", reason: "x", draftEmail: "y" },
+      ],
+    });
+    const out = parseIntrosResponse(raw, validIds);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.cardBId).toBe("b");
+  });
+
+  it("drops self-pairs (cardA === cardB)", () => {
+    const raw = JSON.stringify({
+      intros: [
+        { cardAId: "a", cardBId: "a", reason: "x", draftEmail: "y" },
+        { cardAId: "a", cardBId: "b", reason: "x", draftEmail: "y" },
+      ],
+    });
+    const out = parseIntrosResponse(raw, validIds);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.cardAId).toBe("a");
+    expect(out[0]!.cardBId).toBe("b");
+  });
+
+  it("dedupes (A,B) and (B,A) as the same pair", () => {
+    const raw = JSON.stringify({
+      intros: [
+        { cardAId: "a", cardBId: "b", reason: "x", draftEmail: "y" },
+        { cardAId: "b", cardBId: "a", reason: "different reason", draftEmail: "y" },
+      ],
+    });
+    expect(parseIntrosResponse(raw, validIds)).toHaveLength(1);
+  });
+
+  it("drops pairs missing reason or draftEmail", () => {
+    const raw = JSON.stringify({
+      intros: [
+        { cardAId: "a", cardBId: "b" },
+        { cardAId: "c", cardBId: "d", reason: "x" },
+        { cardAId: "a", cardBId: "c", reason: "x", draftEmail: "y" },
+      ],
+    });
+    const out = parseIntrosResponse(raw, validIds);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.cardAId).toBe("a");
+    expect(out[0]!.cardBId).toBe("c");
+  });
+
+  it("caps at 5 picks", () => {
+    const raw = JSON.stringify({
+      intros: Array.from({ length: 10 }, (_, i) => ({
+        cardAId: i % 2 === 0 ? "a" : "c",
+        cardBId: i % 2 === 0 ? "b" : "d",
+        reason: `r${i}`,
+        draftEmail: `e${i}`,
+      })),
+    });
+    expect(parseIntrosResponse(raw, validIds).length).toBeLessThanOrEqual(5);
+  });
+
+  it("returns empty on malformed JSON", () => {
+    expect(parseIntrosResponse("not json", validIds)).toEqual([]);
+  });
+});
+
+describe("introsCacheKey", () => {
+  it("is stable for same week + candidate set", () => {
+    const a = introsCacheKey(NOW, ["c1", "c2"]);
+    const b = introsCacheKey(NOW, ["c1", "c2"]);
+    expect(a).toBe(b);
+  });
+
+  it("is order-independent on candidate ids", () => {
+    const a = introsCacheKey(NOW, ["c1", "c2", "c3"]);
+    const b = introsCacheKey(NOW, ["c3", "c1", "c2"]);
+    expect(a).toBe(b);
+  });
+
+  it("changes when crossing a week boundary", () => {
+    const today = introsCacheKey(NOW, ["a"]);
+    const nextWeek = introsCacheKey(new Date(NOW.getTime() + 8 * 86400 * 1000), ["a"]);
+    expect(today).not.toBe(nextWeek);
+  });
+
+  it("changes when candidate set changes", () => {
+    const a = introsCacheKey(NOW, ["c1", "c2"]);
+    const b = introsCacheKey(NOW, ["c1", "c2", "c3"]);
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/lib/coach/__tests__/intros.test.ts
+++ b/src/lib/coach/__tests__/intros.test.ts
@@ -187,6 +187,39 @@ describe("parseIntrosResponse", () => {
   it("returns empty on malformed JSON", () => {
     expect(parseIntrosResponse("not json", validIds)).toEqual([]);
   });
+
+  it("returns empty on empty string", () => {
+    expect(parseIntrosResponse("", validIds)).toEqual([]);
+  });
+
+  it("returns empty on null/non-object root", () => {
+    expect(parseIntrosResponse("null", validIds)).toEqual([]);
+    expect(parseIntrosResponse('"a string"', validIds)).toEqual([]);
+  });
+
+  it("returns empty when intros field is missing or not an array", () => {
+    expect(parseIntrosResponse(JSON.stringify({}), validIds)).toEqual([]);
+    expect(parseIntrosResponse(JSON.stringify({ intros: "not-array" }), validIds)).toEqual([]);
+  });
+
+  it("drops null / non-object items inside intros array", () => {
+    const raw = JSON.stringify({
+      intros: [null, "string", 42, { cardAId: "a", cardBId: "b", reason: "x", draftEmail: "y" }],
+    });
+    expect(parseIntrosResponse(raw, validIds)).toHaveLength(1);
+  });
+
+  it("drops items where cardAId / cardBId is missing or non-string", () => {
+    const raw = JSON.stringify({
+      intros: [
+        { cardAId: "", cardBId: "b", reason: "x", draftEmail: "y" },
+        { cardAId: "a", cardBId: "", reason: "x", draftEmail: "y" },
+        { cardAId: 42, cardBId: "b", reason: "x", draftEmail: "y" },
+        { cardAId: "a", cardBId: "c", reason: "x", draftEmail: "y" },
+      ],
+    });
+    expect(parseIntrosResponse(raw, validIds)).toHaveLength(1);
+  });
 });
 
 describe("introsCacheKey", () => {

--- a/src/lib/coach/intros-llm.ts
+++ b/src/lib/coach/intros-llm.ts
@@ -1,0 +1,57 @@
+import "server-only";
+
+import type { CardSummary } from "@/db/cards";
+
+import { buildIntrosMessages, parseIntrosResponse, type IntroSuggestion } from "./intros";
+
+const DEFAULT_BASE_URL = "https://api.minimax.chat/v1";
+const DEFAULT_MODEL = "MiniMax-M2.7";
+const DEFAULT_TIMEOUT_MS = 18_000;
+
+interface MiniMaxChatResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+export async function callIntrosLlm(
+  candidates: readonly CardSummary[],
+  options: { timeoutMs?: number } = {},
+): Promise<IntroSuggestion[] | null> {
+  const apiKey = process.env.MINIMAX_API_KEY ?? "";
+  if (!apiKey) return null;
+  if (candidates.length < 2) return [];
+
+  const baseUrl = process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = process.env.MINIMAX_MODEL ?? DEFAULT_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const body = {
+    model,
+    temperature: 0.55,
+    max_tokens: 2000,
+    messages: buildIntrosMessages(candidates),
+  };
+
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: abort.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as MiniMaxChatResponse;
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) return null;
+    const validIds = new Set(candidates.map((c) => c.id));
+    return parseIntrosResponse(raw, validIds);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/coach/intros-store.ts
+++ b/src/lib/coach/intros-store.ts
@@ -1,0 +1,46 @@
+import "server-only";
+
+import { Timestamp } from "firebase-admin/firestore";
+
+import { getAdminFirestore } from "@/lib/firebase/server";
+import { COLLECTION_WORKSPACES, personalWorkspaceId } from "@/lib/firebase/shared";
+
+import type { IntroSuggestion } from "./intros";
+
+const INTROS_SUBCOLLECTION = "intros";
+
+interface CachedIntrosDoc {
+  cacheKey: string;
+  intros: IntroSuggestion[];
+  generatedAt: Timestamp;
+}
+
+export async function readIntrosCache(
+  uid: string,
+  cacheKey: string,
+): Promise<IntroSuggestion[] | null> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${COLLECTION_WORKSPACES}/${wid}/${INTROS_SUBCOLLECTION}/latest`);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const data = snap.data() as CachedIntrosDoc | undefined;
+  if (!data) return null;
+  if (data.cacheKey !== cacheKey) return null;
+  return data.intros;
+}
+
+export async function writeIntrosCache(
+  uid: string,
+  cacheKey: string,
+  intros: IntroSuggestion[],
+): Promise<void> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${COLLECTION_WORKSPACES}/${wid}/${INTROS_SUBCOLLECTION}/latest`);
+  await ref.set({
+    cacheKey,
+    intros,
+    generatedAt: Timestamp.now(),
+  });
+}

--- a/src/lib/coach/intros.ts
+++ b/src/lib/coach/intros.ts
@@ -1,0 +1,185 @@
+import { createHash } from "node:crypto";
+
+import type { CardSummary } from "@/db/cards";
+
+export interface IntroSuggestion {
+  cardAId: string;
+  cardBId: string;
+  /** 1-2 sentence rationale for why these two should know each other. */
+  reason: string;
+  /** Pre-written intro email body (no Subject — UI adds one). */
+  draftEmail: string;
+}
+
+const MAX_PICKS = 5;
+const MAX_REASON_LEN = 220;
+const MAX_EMAIL_LEN = 1200;
+const MAX_CANDIDATES = 30;
+
+function pickName(card: CardSummary): string {
+  return card.nameZh || card.nameEn || "（未命名）";
+}
+
+function pickRole(card: CardSummary): string {
+  return card.jobTitleZh || card.jobTitleEn || "";
+}
+
+function pickCompany(card: CardSummary): string {
+  return card.companyZh || card.companyEn || "";
+}
+
+/**
+ * Pick up to N candidates the LLM should consider. Prefer pinned cards
+ * (user's signal of importance), then recently-contacted, then a
+ * diversity sample across distinct companies. The LLM is bad at scaling
+ * to 200 cards, so we narrow first.
+ */
+export function selectIntroCandidates(
+  cards: readonly CardSummary[],
+  max: number = MAX_CANDIDATES,
+): CardSummary[] {
+  const live = cards.filter(
+    (c) => !c.deletedAt && (c.nameZh || c.nameEn) && (c.companyZh || c.companyEn),
+  );
+  if (live.length === 0) return [];
+
+  const picked: CardSummary[] = [];
+  const pickedIds = new Set<string>();
+  const pinned = live.filter((c) => c.isPinned);
+  for (const c of pinned) {
+    if (picked.length >= max) break;
+    if (!pickedIds.has(c.id)) {
+      picked.push(c);
+      pickedIds.add(c.id);
+    }
+  }
+
+  const recent = [...live]
+    .filter((c) => !pickedIds.has(c.id))
+    .sort((a, b) => {
+      const ta = a.lastContactedAt?.getTime() ?? a.createdAt?.getTime() ?? 0;
+      const tb = b.lastContactedAt?.getTime() ?? b.createdAt?.getTime() ?? 0;
+      return tb - ta;
+    });
+  for (const c of recent) {
+    if (picked.length >= max) break;
+    picked.push(c);
+    pickedIds.add(c.id);
+  }
+  return picked;
+}
+
+/**
+ * Stable cache key — picks shouldn't change minute-to-minute. Bucket
+ * by week (so refreshes feel "weekly digest" cadence) + sorted
+ * candidate ids (fresh card additions invalidate the cache, otherwise
+ * same set → same suggestions).
+ */
+export function introsCacheKey(now: Date, candidateIds: readonly string[]): string {
+  // week bucket: floor(epochDays / 7)
+  const weekBucket = Math.floor(now.getTime() / (7 * 24 * 60 * 60 * 1000));
+  const sortedIds = [...candidateIds].sort().join(",");
+  const hash = createHash("sha256").update(sortedIds).digest("hex").slice(0, 16);
+  return `w${weekBucket}::${hash}`;
+}
+
+const SYSTEM_PROMPT =
+  "你是 super-connector AI — 幫使用者從他名片冊中找出「應該介紹給彼此」的 pair。" +
+  "目標：提升使用者的網絡價值，把他變成 ecosystem 的 connector，不只是 contact owner。\n" +
+  "回答必須是合法 JSON，符合 schema：\n" +
+  '{"intros": [{"cardAId": string, "cardBId": string, "reason": string, "draftEmail": string}]}\n' +
+  "規則：\n" +
+  "- 找 3-5 對。少於 3 個明顯 fit 就回少一點，不要硬湊。\n" +
+  "- cardAId / cardBId 必須是候選人的卡片 ID。不准捏造。cardA !== cardB。\n" +
+  "- reason 220 字內：解釋為什麼這兩位應該認識（互補需求 / 同產業互補角色 / 互相需要對方資源）。要具體，引用兩位的職位、公司、為什麼記得。\n" +
+  "- draftEmail 1200 字內：使用者寄給他們的 intro email body（不含 subject）。包含三段：\n" +
+  "    1. Hi A 跟 B，介紹一下…\n" +
+  "    2. A 是 X 公司 Y 職位，目前在做 Z (來自 whyRemember)\n" +
+  "    3. B 是 …\n" +
+  "    結尾：「我覺得你們應該聊一下因為…，你們自己接手吧 :)」\n" +
+  "- 用繁體中文，但專有名詞英文保留。\n" +
+  "- 不要捏造對方的具體事；只根據提供的資料推理。\n" +
+  "- 同公司的兩人不要互介（已經知道彼此）。\n" +
+  "- 不要有任何說明文字、不要 markdown 圍欄。";
+
+export function buildIntrosPrompt(candidates: readonly CardSummary[]): string {
+  const lines: string[] = [];
+  lines.push(`從以下 ${candidates.length} 位候選人中找 3-5 對應該介紹的 pair。`);
+  lines.push("");
+  lines.push("=== 候選人 ===");
+  for (const c of candidates) {
+    lines.push("");
+    const role = pickRole(c);
+    const company = pickCompany(c);
+    lines.push(`# ${pickName(c)}`);
+    lines.push(`卡片 ID: ${c.id}`);
+    if (role) lines.push(`職稱: ${role}`);
+    if (company) lines.push(`公司: ${company}`);
+    if (c.department) lines.push(`部門: ${c.department}`);
+    if (c.firstMetEventTag) lines.push(`認識場合: ${c.firstMetEventTag}`);
+    if (c.whyRemember) lines.push(`為什麼記得: ${c.whyRemember}`);
+  }
+  return lines.join("\n");
+}
+
+export function buildIntrosMessages(
+  candidates: readonly CardSummary[],
+): Array<{ role: "system" | "user"; content: string }> {
+  return [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: buildIntrosPrompt(candidates) },
+  ];
+}
+
+function sanitizeStr(value: unknown, max: number): string {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, max);
+}
+
+/**
+ * Parse + harden the LLM response. Drops:
+ *   - non-object items
+ *   - cardId not in the candidate set (anti-hallucination)
+ *   - cardA === cardB (anti-self-pair)
+ *   - duplicate (A,B) pairs (regardless of order)
+ *   - missing reason or draftEmail
+ */
+export function parseIntrosResponse(
+  raw: string,
+  validCardIds: ReadonlySet<string>,
+): IntroSuggestion[] {
+  if (!raw) return [];
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const inner = fenced ? fenced[1]! : trimmed;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(inner);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object") return [];
+  const intros = (parsed as { intros?: unknown }).intros;
+  if (!Array.isArray(intros)) return [];
+
+  const seenPairs = new Set<string>();
+  const out: IntroSuggestion[] = [];
+  for (const item of intros) {
+    if (!item || typeof item !== "object") continue;
+    const obj = item as Record<string, unknown>;
+    const cardAId = sanitizeStr(obj.cardAId, 200);
+    const cardBId = sanitizeStr(obj.cardBId, 200);
+    if (!cardAId || !cardBId) continue;
+    if (cardAId === cardBId) continue;
+    if (!validCardIds.has(cardAId) || !validCardIds.has(cardBId)) continue;
+    const pairKey = [cardAId, cardBId].sort().join("|");
+    if (seenPairs.has(pairKey)) continue;
+    const reason = sanitizeStr(obj.reason, MAX_REASON_LEN);
+    const draftEmail = sanitizeStr(obj.draftEmail, MAX_EMAIL_LEN);
+    if (!reason || !draftEmail) continue;
+    seenPairs.add(pairKey);
+    out.push({ cardAId, cardBId, reason, draftEmail });
+    if (out.length >= MAX_PICKS) break;
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #94

## Summary
商務人士最有價值的不是「自己認識誰」，是「能介紹誰跟誰」。Super-connector 的角色靠 mental scanning：「咦 X 是 ML PM、Y 是 GPU infra 業務，他們應該認識…」這個 mental work 通常不會發生因為太累。

讓 AI 替你做：scan 整個名片冊，找出「應該認識」的 pair + 為什麼，配 intro email 草稿（mailto: 直接開信件寄給雙方）。

> 把使用者從 contact owner 升級成 super-connector。

## Demo (when MINIMAX_API_KEY is set)

```
🤝 AI 介紹建議 / 每週推薦的 intro 對

[1]  陳玉涵 (PM / 智威)  ↔  Alice Chen (BD / NVIDIA)
     兩位都在邊緣 AI 推論這條鏈上 — 玉涵在做 ML 加速器、Alice 在 NVIDIA
     負責台灣 partner 拓展，他們很可能可以對接合作。

     [📧 看 intro email 草稿]
     > Hi 玉涵, Alice,
     > 想介紹一下兩位給彼此。陳玉涵是智威科技的 PM，目前在做 ML 加速器…
     > Alice Chen 是 NVIDIA 台灣 partner manager…
     > 我覺得你們應該聊一下，自己接手吧 :)
     [複製草稿] [開信件 (寄給雙方) →]

[2]  ...
```

## Files
- `src/lib/coach/intros.ts` (+170) — pure prompt + JSON parser; weekly cache key; `selectIntroCandidates` (pinned-first, recent-then-rest, max 30)
- `src/lib/coach/intros-llm.ts` — MiniMax client (mirror briefing-llm)
- `src/lib/coach/intros-store.ts` — Firestore weekly cache
- Server Action `getIntroSuggestionsAction({ force })`
- `/intros` page + `<IntroSuggestionsList>` component
- AppShell nav entry
- 19 UT (candidate selection / prompt / parser robustness / cache key)

## Architecture
- **Hybrid scoring + LLM**: pure-fn `selectIntroCandidates` narrows N → 30 (pinned-first, recent-second). LLM only sees 30. Same pattern as daily briefing — keeps LLM bill bounded + result quality high.
- **Anti-hallucination guards**: parser drops cardId not in candidate set, drops self-pairs (cardA === cardB), dedupes (A,B)/(B,A) pairs.
- **Weekly cache key** = (week bucket + sorted candidate ids hash). Same week + same set → same suggestions. New cards / next week → fresh batch.
- **mailto: prefilled** with subject `Intro: A ↔ B` + body=draft + To=both emails. One click to open user's mail client with the intro ready.
- **Re-validate cached pairs** on read against current candidate set — if a card got merged/deleted between cache write and read, drop the dangling pair (defense-in-depth on top of the hash invalidation).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 588 pass (+19 new)
- [x] `pnpm lint` — clean (4 unrelated pre-existing)
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — `/intros` registered
- [ ] CI green → merge → mac mini deploy

## Out of scope
- 自動寄出 intro email (auth scope)
- 對方 consent 機制
- 跨 workspace intro