### PR TITLE
feat(cards): voice-to-card phase 3 — describe multiple people in one go

### DIFF
--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -46,7 +46,7 @@ import { readReengageCache, writeReengageCache } from "@/lib/coach/reengage-stor
 import { readCoachCache, writeCoachCache } from "@/lib/coach/store";
 import { pickCanonicalCompany } from "@/lib/companies/group";
 import { encodePrefill, type ExtractedCard } from "@/lib/voice/extract";
-import { callExtractLlm } from "@/lib/voice/extract-llm";
+import { callExtractLlm, callExtractLlmMulti } from "@/lib/voice/extract-llm";
 
 export const createCardAction = authedAction
   .inputSchema(cardCreateSchema)
@@ -529,6 +529,68 @@ export const extractCardFromTextAction = authedAction
       const extracted = await callExtractLlm(parsedInput.text);
       if (!extracted) return { ok: false, reason: "llm-failed" };
       return { ok: true, extracted, prefillToken: encodePrefill(extracted) };
+    },
+  );
+
+/**
+ * 🎙️ Voice-to-card *multi*-extract — same MiniMax hop as single, but
+ * returns ALL cards the LLM detected. Networking event 後 user 一次說
+ * 「認識三個人：A 是…、B 是…、C 是…」會回 3 張卡。
+ */
+export const extractMultipleCardsAction = authedAction
+  .inputSchema(z.object({ text: z.string().min(3).max(4000) }))
+  .action(
+    async ({
+      parsedInput,
+    }): Promise<
+      { ok: true; extracted: ExtractedCard[] } | { ok: false; reason: "no-llm" | "llm-failed" }
+    > => {
+      if (!isCoachConfigured()) return { ok: false, reason: "no-llm" };
+      const cards = await callExtractLlmMulti(parsedInput.text);
+      if (cards.length === 0) return { ok: false, reason: "llm-failed" };
+      return { ok: true, extracted: cards };
+    },
+  );
+
+/**
+ * Batch-create N cards in one Server Action call. Used by the
+ * voice-multi flow after the user reviews the AI-extracted preview.
+ * Each card runs through the same `createCardForUser` so memberUids /
+ * Typesense reindex / etc. all behave identically to single create.
+ */
+export const createCardsBatchAction = authedAction
+  .inputSchema(
+    z.object({
+      cards: z.array(cardCreateSchema).min(1).max(20),
+    }),
+  )
+  .action(
+    async ({
+      parsedInput,
+      ctx,
+    }): Promise<{ ok: true; ids: string[] } | { ok: false; reason: string }> => {
+      const ids: string[] = [];
+      for (const card of parsedInput.cards) {
+        try {
+          const { id } = await createCardForUser(card, {
+            uid: ctx.user.uid,
+            displayName: ctx.user.displayName,
+          });
+          ids.push(id);
+        } catch (err) {
+          if (ids.length > 0) {
+            revalidatePath("/");
+            revalidatePath("/cards");
+          }
+          return {
+            ok: false,
+            reason: err instanceof Error ? err.message : "建立失敗",
+          };
+        }
+      }
+      revalidatePath("/");
+      revalidatePath("/cards");
+      return { ok: true, ids };
     },
   );
 

--- a/src/components/cards/VoiceCardCapture.module.css
+++ b/src/components/cards/VoiceCardCapture.module.css
@@ -221,3 +221,45 @@
   flex-wrap: wrap;
   gap: var(--space-sm);
 }
+
+.cardItem,
+.cardItemExcluded {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    opacity var(--duration-fast) var(--ease-standard);
+}
+
+.cardItemExcluded {
+  opacity: 0.45;
+  border-style: dashed;
+}
+
+.cardItemHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.cardItemRank {
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  font-weight: 600;
+  color: var(--color-accent-ink);
+}
+
+.cardItemName {
+  flex: 1;
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-ink);
+  min-width: 0;
+}

--- a/src/components/cards/VoiceCardCapture.tsx
+++ b/src/components/cards/VoiceCardCapture.tsx
@@ -3,8 +3,9 @@
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
-import { extractCardFromTextAction } from "@/app/(app)/cards/actions";
-import type { ExtractedCard } from "@/lib/voice/extract";
+import { createCardsBatchAction, extractMultipleCardsAction } from "@/app/(app)/cards/actions";
+import type { CardCreateInput } from "@/db/schema";
+import { encodePrefill, type ExtractedCard } from "@/lib/voice/extract";
 
 import styles from "./VoiceCardCapture.module.css";
 import { VoiceMicButton } from "./VoiceMicButton";
@@ -12,13 +13,15 @@ import { VoiceMicButton } from "./VoiceMicButton";
 const EXAMPLES = [
   "陳玉涵 PM 智威科技 在 2024 Computex 攤位上聊邊緣 AI 推論很投緣，提到他們公司在做 ML 加速器",
   "李大同 沛理科技業務 BD 上週 Web Summit Lisbon 認識，欠他一個 referral 給 NVIDIA 的 contact",
-  "王秘書長 國發會 在 AI 高峰會上聊 sovereign AI 政策，他想知道民間如何配合",
+  "今天 Demo Day 認識三個人：A 是 GreenLeaf 共同創辦人 Sarah Wang 在做永續供應鏈，B 是 Pixel 的 PM Tom Chen 在開發 AR 眼鏡，C 是創投 Mike 在找早期 hardware 案",
 ];
 
 type Phase =
   | { kind: "input" }
   | { kind: "loading" }
-  | { kind: "ready"; extracted: ExtractedCard; prefillToken: string }
+  | { kind: "ready"; extracted: ExtractedCard[]; excluded: Set<number> }
+  | { kind: "creating" }
+  | { kind: "created"; ids: string[] }
   | { kind: "error"; message: string };
 
 /**
@@ -43,7 +46,7 @@ export function VoiceCardCapture() {
     }
     setPhase({ kind: "loading" });
     startTransition(async () => {
-      const result = await extractCardFromTextAction({ text: trimmed });
+      const result = await extractMultipleCardsAction({ text: trimmed });
       const data = result?.data;
       if (result?.serverError) {
         setPhase({ kind: "error", message: result.serverError });
@@ -61,7 +64,7 @@ export function VoiceCardCapture() {
         });
         return;
       }
-      setPhase({ kind: "ready", extracted: data.extracted, prefillToken: data.prefillToken });
+      setPhase({ kind: "ready", extracted: data.extracted, excluded: new Set() });
     });
   };
 
@@ -70,9 +73,71 @@ export function VoiceCardCapture() {
     setPhase({ kind: "input" });
   };
 
+  const toggleExclude = (i: number) => {
+    if (phase.kind !== "ready") return;
+    const next = new Set(phase.excluded);
+    if (next.has(i)) next.delete(i);
+    else next.add(i);
+    setPhase({ ...phase, excluded: next });
+  };
+
   const goCreate = () => {
     if (phase.kind !== "ready") return;
-    router.push(`/cards/new?prefill=${encodeURIComponent(phase.prefillToken)}`);
+    const selected = phase.extracted.filter((_, i) => !phase.excluded.has(i));
+    if (selected.length === 0) return;
+
+    // Single card → use the prefill flow (lets user fine-tune fields).
+    if (selected.length === 1) {
+      const token = encodePrefill(selected[0]!);
+      router.push(`/cards/new?prefill=${encodeURIComponent(token)}`);
+      return;
+    }
+
+    // Multi-card → batch create directly. The user already reviewed
+    // the AI extraction in the preview grid; per-card editing would
+    // turn this into a tabbed mega-form (out of scope).
+    setPhase({ kind: "creating" });
+    startTransition(async () => {
+      const payload: CardCreateInput[] = selected.map((c) => ({
+        nameZh: c.nameZh,
+        nameEn: c.nameEn,
+        namePhonetic: c.namePhonetic,
+        jobTitleZh: c.jobTitleZh,
+        jobTitleEn: c.jobTitleEn,
+        department: c.department,
+        companyZh: c.companyZh,
+        companyEn: c.companyEn,
+        companyWebsite: c.companyWebsite,
+        phones: c.phones ?? [],
+        emails: c.emails ?? [],
+        addresses: c.addresses ?? [],
+        social: c.social ?? {},
+        whyRemember: c.whyRemember || "（剛認識）",
+        firstMetDate: c.firstMetDate,
+        firstMetContext: c.firstMetContext,
+        firstMetEventTag: c.firstMetEventTag,
+        notes: c.notes,
+        tagIds: c.tagIds ?? [],
+        tagNames: c.tagNames ?? [],
+        frontImagePath: c.frontImagePath,
+        backImagePath: c.backImagePath,
+        ocrProvider: c.ocrProvider,
+        ocrConfidence: c.ocrConfidence,
+        ocrRawJson: c.ocrRawJson,
+      }));
+      const result = await createCardsBatchAction({ cards: payload });
+      const data = result?.data;
+      if (result?.serverError) {
+        setPhase({ kind: "error", message: result.serverError });
+        return;
+      }
+      if (!data || !data.ok) {
+        const reason = data && !data.ok ? data.reason : "建立失敗";
+        setPhase({ kind: "error", message: reason });
+        return;
+      }
+      setPhase({ kind: "created", ids: data.ids });
+    });
   };
 
   return (
@@ -136,27 +201,57 @@ export function VoiceCardCapture() {
 
       {phase.kind === "ready" && (
         <div className={styles.preview} aria-live="polite">
-          <h2 className={styles.previewTitle}>✨ AI 解析結果</h2>
-          <dl className={styles.fieldGrid}>
-            <PreviewField label="姓名（中）" value={phase.extracted.nameZh} />
-            <PreviewField label="姓名（英）" value={phase.extracted.nameEn} />
-            <PreviewField label="職稱（中）" value={phase.extracted.jobTitleZh} />
-            <PreviewField label="職稱（英）" value={phase.extracted.jobTitleEn} />
-            <PreviewField label="公司（中）" value={phase.extracted.companyZh} />
-            <PreviewField label="公司（英）" value={phase.extracted.companyEn} />
-            <PreviewField label="部門" value={phase.extracted.department} />
-            <PreviewField label="認識場合" value={phase.extracted.firstMetEventTag} />
-            <PreviewField label="情境" value={phase.extracted.firstMetContext} />
-            <PreviewField
-              label="為什麼記得（必填）"
-              value={phase.extracted.whyRemember}
-              highlight
-            />
-            <PreviewField label="備註" value={phase.extracted.notes} />
-          </dl>
+          <h2 className={styles.previewTitle}>
+            ✨ AI 解析了 {phase.extracted.length} 張卡
+            {phase.extracted.length > 1 ? "（可以剔除不要的）" : ""}
+          </h2>
+          {phase.extracted.map((card, i) => {
+            const excluded = phase.excluded.has(i);
+            return (
+              <div
+                key={i}
+                className={excluded ? styles.cardItemExcluded : styles.cardItem}
+                aria-label={`卡片 ${i + 1}${excluded ? "（已剔除）" : ""}`}
+              >
+                <div className={styles.cardItemHeader}>
+                  <span className={styles.cardItemRank}>#{i + 1}</span>
+                  <span className={styles.cardItemName}>
+                    {card.nameZh || card.nameEn || "（未命名）"}
+                  </span>
+                  <button
+                    type="button"
+                    className={styles.smallBtn}
+                    onClick={() => toggleExclude(i)}
+                  >
+                    {excluded ? "↩ 取消剔除" : "✕ 剔除"}
+                  </button>
+                </div>
+                <dl className={styles.fieldGrid}>
+                  <PreviewField label="姓名（中）" value={card.nameZh} />
+                  <PreviewField label="姓名（英）" value={card.nameEn} />
+                  <PreviewField label="職稱（中）" value={card.jobTitleZh} />
+                  <PreviewField label="職稱（英）" value={card.jobTitleEn} />
+                  <PreviewField label="公司（中）" value={card.companyZh} />
+                  <PreviewField label="公司（英）" value={card.companyEn} />
+                  <PreviewField label="部門" value={card.department} />
+                  <PreviewField label="認識場合" value={card.firstMetEventTag} />
+                  <PreviewField label="情境" value={card.firstMetContext} />
+                  <PreviewField label="為什麼記得（必填）" value={card.whyRemember} highlight />
+                  <PreviewField label="備註" value={card.notes} />
+                </dl>
+              </div>
+            );
+          })}
           <div className={styles.previewActions}>
-            <button type="button" className={styles.primaryBtn} onClick={goCreate}>
-              使用此解析建立 →
+            <button
+              type="button"
+              className={styles.primaryBtn}
+              onClick={goCreate}
+              disabled={pending || phase.excluded.size === phase.extracted.length}
+            >
+              {phase.extracted.length - phase.excluded.size <= 1
+                ? "使用此解析建立 →"
+                : `✅ 一鍵建立 ${phase.extracted.length - phase.excluded.size} 張`}
             </button>
             <button
               type="button"
@@ -174,6 +269,37 @@ export function VoiceCardCapture() {
               }}
             >
               🔄 重新解析
+            </button>
+          </div>
+        </div>
+      )}
+
+      {phase.kind === "creating" && (
+        <p className={styles.error} role="status">
+          ⏳ 建立中…
+        </p>
+      )}
+
+      {phase.kind === "created" && (
+        <div className={styles.preview} aria-live="polite">
+          <h2 className={styles.previewTitle}>✅ 已建立 {phase.ids.length} 張卡</h2>
+          <div className={styles.previewActions}>
+            <button
+              type="button"
+              className={styles.primaryBtn}
+              onClick={() => router.push("/cards")}
+            >
+              到名片冊看 →
+            </button>
+            <button
+              type="button"
+              className={styles.smallBtn}
+              onClick={() => {
+                setText("");
+                setPhase({ kind: "input" });
+              }}
+            >
+              再建立一批
             </button>
           </div>
         </div>

--- a/src/lib/voice/__tests__/extract.test.ts
+++ b/src/lib/voice/__tests__/extract.test.ts
@@ -5,6 +5,7 @@ import {
   decodePrefill,
   encodePrefill,
   parseExtractedCard,
+  parseMultipleExtractedCards,
   type ExtractedCard,
 } from "../extract";
 
@@ -90,6 +91,79 @@ describe("parseExtractedCard", () => {
     const raw = JSON.stringify({ nameZh: "  ", whyRemember: "x" });
     const result = parseExtractedCard(raw, "f");
     expect(result?.nameZh).toBeUndefined();
+  });
+});
+
+describe("parseMultipleExtractedCards", () => {
+  it("parses new {cards: [...]} schema with multiple entries", () => {
+    const raw = JSON.stringify({
+      cards: [
+        { nameZh: "陳玉涵", whyRemember: "Computex 邊緣 AI" },
+        { nameZh: "李大同", whyRemember: "Web Summit BD" },
+        { nameZh: "王秘書長", whyRemember: "AI 政策" },
+      ],
+    });
+    const result = parseMultipleExtractedCards(raw, "fallback");
+    expect(result).toHaveLength(3);
+    expect(result.map((c) => c.nameZh)).toEqual(["陳玉涵", "李大同", "王秘書長"]);
+  });
+
+  it("returns single-element array for legacy {...singleCard} shape", () => {
+    const raw = JSON.stringify({ nameZh: "陳玉涵", whyRemember: "x" });
+    const result = parseMultipleExtractedCards(raw, "fb");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.nameZh).toBe("陳玉涵");
+  });
+
+  it("returns [] for malformed JSON", () => {
+    expect(parseMultipleExtractedCards("not json", "fb")).toEqual([]);
+  });
+
+  it("returns [] for top-level array root", () => {
+    expect(parseMultipleExtractedCards("[1,2,3]", "fb")).toEqual([]);
+  });
+
+  it("drops invalid items inside cards array but keeps valid ones", () => {
+    const raw = JSON.stringify({
+      cards: [
+        null,
+        "string",
+        { nameZh: "Alice", whyRemember: "x" },
+        42,
+        { nameZh: "Bob", whyRemember: "y" },
+      ],
+    });
+    const result = parseMultipleExtractedCards(raw, "fb");
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.nameZh)).toEqual(["Alice", "Bob"]);
+  });
+
+  it("falls back whyRemember per card when missing", () => {
+    const raw = JSON.stringify({
+      cards: [{ nameZh: "Alice" }, { nameZh: "Bob" }],
+    });
+    const result = parseMultipleExtractedCards(raw, "originals");
+    expect(result[0]!.whyRemember).toBe("originals");
+    expect(result[1]!.whyRemember).toBe("originals");
+  });
+});
+
+describe("parseExtractedCard backward-compat through multi parser", () => {
+  it("returns first card from new schema when single is requested", () => {
+    const raw = JSON.stringify({
+      cards: [
+        { nameZh: "First", whyRemember: "x" },
+        { nameZh: "Second", whyRemember: "y" },
+      ],
+    });
+    const result = parseExtractedCard(raw, "fb");
+    expect(result?.nameZh).toBe("First");
+  });
+
+  it("still parses legacy single-object payload", () => {
+    const raw = JSON.stringify({ nameZh: "陳玉涵", whyRemember: "legacy" });
+    const result = parseExtractedCard(raw, "fb");
+    expect(result?.nameZh).toBe("陳玉涵");
   });
 });
 

--- a/src/lib/voice/extract-llm.ts
+++ b/src/lib/voice/extract-llm.ts
@@ -1,6 +1,11 @@
 import "server-only";
 
-import { buildExtractMessages, parseExtractedCard, type ExtractedCard } from "./extract";
+import {
+  buildExtractMessages,
+  parseExtractedCard,
+  parseMultipleExtractedCards,
+  type ExtractedCard,
+} from "./extract";
 
 const DEFAULT_BASE_URL = "https://api.minimax.chat/v1";
 const DEFAULT_MODEL = "MiniMax-M2.7";
@@ -49,6 +54,56 @@ export async function callExtractLlm(
     return parseExtractedCard(raw, trimmed);
   } catch {
     return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Multi-card variant: returns all cards the LLM extracted (length 0..N).
+ * Same MiniMax round-trip; only the parser differs (`parseMultipleExtractedCards`).
+ * Empty array on failure.
+ */
+export async function callExtractLlmMulti(
+  text: string,
+  options: { timeoutMs?: number } = {},
+): Promise<ExtractedCard[]> {
+  const apiKey = process.env.MINIMAX_API_KEY ?? "";
+  if (!apiKey) return [];
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+
+  const baseUrl = process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = process.env.MINIMAX_MODEL ?? DEFAULT_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // Bigger token budget than single — 5 cards × ~100 tokens each + headroom.
+  const body = {
+    model,
+    temperature: 0.2,
+    max_tokens: 1800,
+    messages: buildExtractMessages(trimmed),
+  };
+
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: abort.signal,
+    });
+    if (!res.ok) return [];
+    const json = (await res.json()) as MiniMaxChatResponse;
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) return [];
+    return parseMultipleExtractedCards(raw, trimmed);
+  } catch {
+    return [];
   } finally {
     clearTimeout(timer);
   }

--- a/src/lib/voice/extract.ts
+++ b/src/lib/voice/extract.ts
@@ -2,10 +2,7 @@ import type { CardCreateInput } from "@/db/schema";
 
 export type ExtractedCard = Partial<CardCreateInput>;
 
-const SYSTEM_PROMPT =
-  "你是名片資訊抽取器。" +
-  "使用者剛 networking event 結束，用自然語言描述他剛遇到的人。" +
-  "把以下這段話抽出結構化欄位，用 JSON 回答：\n" +
+const FIELD_SCHEMA =
   "{\n" +
   '  "nameZh"?: string,        // 中文姓名\n' +
   '  "nameEn"?: string,        // 英文姓名\n' +
@@ -18,14 +15,26 @@ const SYSTEM_PROMPT =
   '  "firstMetContext"?: string,    // 認識的情境細節\n' +
   '  "whyRemember": string,    // 「為什麼記得這個人」(必填，沒有就用整段話的精華)\n' +
   '  "notes"?: string\n' +
-  "}\n" +
+  "}";
+
+const SYSTEM_PROMPT =
+  "你是名片資訊抽取器。" +
+  "使用者剛 networking event 結束，用自然語言描述他剛遇到的人。可能描述一個人，也可能一次描述好幾個人（「認識三個人：A 是…、B 是…、C 是…」）。" +
+  "把這段話抽出結構化欄位。\n" +
+  "回答必須是合法 JSON，schema：\n" +
+  '{ "cards": [ <Card>, <Card>, ... ] }\n' +
+  "其中 <Card> 是：\n" +
+  FIELD_SCHEMA +
+  "\n" +
   "規則：\n" +
   "- 只回傳 JSON，不要任何說明文字、不要 markdown 圍欄。\n" +
+  "- 「cards」 是 *array*。一個人就回 length=1 的 array，多個人就回多個元素。\n" +
   "- 沒提到的欄位就 omit，不要填空字串。\n" +
-  "- whyRemember 是 *必填*。沒有明確線索時，把整段話最有 hook 的一句當作 whyRemember。\n" +
+  "- whyRemember 每張卡都 *必填*。沒有明確線索時，把該人提到的最有 hook 的一句當作 whyRemember。\n" +
   "- 中英文混雜的內容：name、jobTitle、company 各填到對應的中/英欄位。\n" +
   "- whyRemember 一定用繁體中文。\n" +
-  "- 不要編造對方說過的具體事；只根據輸入推理。";
+  "- 不要編造對方說過的具體事；只根據輸入推理。\n" +
+  "- 共同 context（同個 event 場合）每張卡都帶上 firstMetEventTag。";
 
 export function buildExtractMessages(
   text: string,
@@ -47,27 +56,9 @@ function sanitizeStr(value: unknown, max: number): string | undefined {
   return trimmed.slice(0, max);
 }
 
-/**
- * Parse the LLM's JSON into a Partial<CardCreateInput>. Defensive:
- *   - strips markdown fences
- *   - drops non-string fields
- *   - clamps lengths
- *   - guarantees `whyRemember` is at least the truncated input if the
- *     LLM didn't pick one (the schema requires it; UI can edit before save)
- */
-export function parseExtractedCard(raw: string, fallbackText: string): ExtractedCard | null {
-  if (!raw) return null;
-  const trimmed = raw.trim();
-  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
-  const inner = fenced ? fenced[1]! : trimmed;
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(inner);
-  } catch {
-    return null;
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-  const obj = parsed as Record<string, unknown>;
+function parseSingleCard(value: unknown, fallbackText: string): ExtractedCard | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const obj = value as Record<string, unknown>;
 
   const out: ExtractedCard = {};
   const nameZh = sanitizeStr(obj.nameZh, MAX_FIELD_LEN);
@@ -94,12 +85,65 @@ export function parseExtractedCard(raw: string, fallbackText: string): Extracted
   if (why) {
     out.whyRemember = why;
   } else {
-    // Schema requires whyRemember — fall back to truncated input so the
-    // form has *something* the user can refine.
     const fallback = fallbackText.trim().slice(0, MAX_WHY_LEN);
     out.whyRemember = fallback || "（剛認識）";
   }
   return out;
+}
+
+/**
+ * Parse the LLM's JSON into a Partial<CardCreateInput>. Defensive:
+ *   - strips markdown fences
+ *   - drops non-string fields
+ *   - clamps lengths
+ *   - guarantees `whyRemember` is at least the truncated input if the
+ *     LLM didn't pick one (the schema requires it; UI can edit before save)
+ *
+ * Backward-compat: if the LLM returns the new `{cards: [...]}` schema,
+ * returns the *first* card (Phase 1 callers expect a single result).
+ * Use `parseMultipleExtractedCards` for the multi-person flow.
+ */
+export function parseExtractedCard(raw: string, fallbackText: string): ExtractedCard | null {
+  const all = parseMultipleExtractedCards(raw, fallbackText);
+  return all.length > 0 ? all[0]! : null;
+}
+
+/**
+ * Parse one or more cards from the LLM JSON. Accepts:
+ *   - new shape: { cards: [...] }  (preferred — multi-card support)
+ *   - legacy shape: { ...singleCard } (backward-compat with Phase 1)
+ * Returns [] on malformed input or zero valid cards. Each card runs
+ * through parseSingleCard which guarantees whyRemember (falls back to
+ * truncated input).
+ */
+export function parseMultipleExtractedCards(raw: string, fallbackText: string): ExtractedCard[] {
+  if (!raw) return [];
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const inner = fenced ? fenced[1]! : trimmed;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(inner);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object") return [];
+
+  // New shape: {cards: [...]}
+  const root = parsed as { cards?: unknown };
+  if (Array.isArray(root.cards)) {
+    const out: ExtractedCard[] = [];
+    for (const item of root.cards) {
+      const card = parseSingleCard(item, fallbackText);
+      if (card) out.push(card);
+    }
+    return out;
+  }
+
+  // Legacy single-card shape: {...fields}
+  if (Array.isArray(parsed)) return [];
+  const single = parseSingleCard(parsed, fallbackText);
+  return single ? [single] : [];
 }
 
 /**


### PR DESCRIPTION
## Summary
- **One-shot, many people.** After a networking event, business users meet 3-5 people back to back. Phase 1/2 forced them to fire the voice flow once per person. Phase 3 lets them dump the whole event in one shot — *"剛剛 demo day 認識三個人：A 是…、B 是…、C 是…"* — and the LLM splits it into N cards.
- **Preview-then-batch.** Each extracted card is shown in a numbered grid with the same field detail as the single-card preview. Per-card 剔除 toggle if the LLM hallucinated someone or merged two people. Single card → existing prefill redirect to `/cards/new`. Multi card → batch create via new Server Action.
- **Backward-compat.** `parseExtractedCard` now delegates to `parseMultipleExtractedCards` and returns the first card from the new `{cards: [...]}` shape, so the legacy single-card prompt response keeps working.

## Why this slice
Business users describe themselves as "認識很多人很重要的職業" (jobs where meeting many people matters). The voice flow was already the fastest input on mobile, but the round-trip-per-person friction cancelled out that speed gain at the exact moment it mattered most — right after an event with 5 fresh contacts in working memory.

## Files changed
- `src/lib/voice/extract.ts` — new `{cards: [...]}` system prompt, `parseSingleCard` helper, `parseMultipleExtractedCards`, refactored `parseExtractedCard` to delegate
- `src/lib/voice/extract-llm.ts` — `callExtractLlmMulti` (1800-token ceiling vs 800)
- `src/app/(app)/cards/actions.ts` — `extractMultipleCardsAction` (preview), `createCardsBatchAction` (loop with revalidate on partial success)
- `src/components/cards/VoiceCardCapture.tsx` — phase machine extended (`loading → ready{extracted, excluded} → creating → created`), per-card 剔除, single vs multi branch
- `src/components/cards/VoiceCardCapture.module.css` — `.cardItem`, `.cardItemExcluded` (dashed + 0.45 opacity), `.cardItemHeader`, `.cardItemRank`
- `src/lib/voice/__tests__/extract.test.ts` — 8 new UT covering new schema, legacy fallback, malformed, hostile array items, per-card whyRemember fallback

## Test plan
- [x] `pnpm test src/lib/voice/` — 23/23 pass
- [x] `pnpm test:coverage` — branches 80.47% (above 80% gate); `lib/voice/extract.ts` 100% lines / 92.04% stmt / 85.93% branch
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no new warnings
- [x] `pnpm format` — clean
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build` — green, route table includes `/cards/voice`
- [ ] Live smoke after merge + deploy: speak "認識三個人：陳玉涵 是 PM 智威，李大同 是 BD 在 Web Summit 認識，王秘書長 講 AI 政策" → expect 3 cards in preview → toggle middle one off → batch create only 2

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)