### PR TITLE
feat(log): 對話速記 — voice/text → AI matches person → log in one step

### DIFF
--- a/src/app/(app)/home.module.css
+++ b/src/app/(app)/home.module.css
@@ -47,6 +47,37 @@
   max-width: 40rem;
 }
 
+.quickActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+}
+
+.quickAction {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: 999px;
+  text-decoration: none;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.quickAction:hover {
+  border-color: var(--color-accent-ink);
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 30%,
+    var(--color-paper)
+  );
+}
+
 .sections {
   display: flex;
   flex-direction: column;

--- a/src/app/(app)/log/actions.ts
+++ b/src/app/(app)/log/actions.ts
@@ -1,0 +1,76 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { authedAction } from "@/lib/auth/safe-action";
+import { listCardsForUser, logContactEvent, type CardSummary } from "@/db/cards";
+import { isCoachConfigured } from "@/lib/coach/llm";
+import { callConversationLogLlm } from "@/lib/conversations/extract-llm";
+import { matchPersonName } from "@/lib/conversations/match";
+
+export type ExtractConversationResult =
+  | {
+      ok: true;
+      personName: string;
+      summary: string;
+      candidates: CardSummary[];
+    }
+  | { ok: false; reason: "no-llm" | "llm-failed" };
+
+/**
+ * Pure-extract step. Sends the user's free-form sentence to the LLM,
+ * normalizes the response, then runs an in-memory fuzzy name match
+ * against the caller's existing cards.
+ *
+ * No mutation here — the second action does the actual write so the user
+ * gets a chance to confirm / pick / edit the summary first.
+ */
+export const extractConversationAction = authedAction
+  .inputSchema(z.object({ text: z.string().min(3).max(2000) }))
+  .action(async ({ parsedInput, ctx }): Promise<ExtractConversationResult> => {
+    if (!isCoachConfigured()) return { ok: false, reason: "no-llm" };
+    const extracted = await callConversationLogLlm(parsedInput.text);
+    if (!extracted) return { ok: false, reason: "llm-failed" };
+
+    const cards = await listCardsForUser(ctx.user.uid, { limit: 1000 });
+    const candidates = matchPersonName(extracted.personName, cards);
+    return {
+      ok: true,
+      personName: extracted.personName,
+      summary: extracted.summary,
+      candidates,
+    };
+  });
+
+export type LogConversationResult = { ok: true; eventId: string } | { ok: false; reason: string };
+
+/**
+ * Append a contact-event to a chosen card. Reuses the existing
+ * `logContactEvent` (db) and `revalidatePath` plumbing so this flow
+ * stays consistent with the in-card-detail "log interaction" button.
+ */
+export const logConversationAction = authedAction
+  .inputSchema(
+    z.object({
+      cardId: z.string().min(1),
+      summary: z.string().min(1).max(500),
+    }),
+  )
+  .action(async ({ parsedInput, ctx }): Promise<LogConversationResult> => {
+    try {
+      const eventId = await logContactEvent(parsedInput.cardId, {
+        uid: ctx.user.uid,
+        note: parsedInput.summary,
+        authorDisplay: ctx.user.displayName ?? null,
+      });
+      revalidatePath("/");
+      revalidatePath(`/cards/${parsedInput.cardId}`);
+      return { ok: true, eventId };
+    } catch (err) {
+      return {
+        ok: false,
+        reason: err instanceof Error ? err.message : "記錄失敗",
+      };
+    }
+  });

--- a/src/app/(app)/log/log.module.css
+++ b/src/app/(app)/log/log.module.css
@@ -1,0 +1,62 @@
+.article {
+  max-width: var(--content-max);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding-bottom: var(--space-md);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h2);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+}
+
+.title em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-accent);
+}
+
+.lead {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  line-height: var(--leading-relaxed);
+  margin: var(--space-xs) 0 0;
+  max-width: 60ch;
+}
+
+.notReady {
+  padding: var(--space-2xl) var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  color: var(--color-ink-muted);
+  text-align: center;
+}
+
+.notReady a {
+  color: var(--color-accent-ink);
+}

--- a/src/app/(app)/log/page.tsx
+++ b/src/app/(app)/log/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+
+import { ConversationLog } from "@/components/conversations/ConversationLog";
+import { isCoachConfigured } from "@/lib/coach/llm";
+
+import styles from "./log.module.css";
+
+export const metadata = {
+  title: "對話速記",
+};
+
+export default function LogPage() {
+  const llmReady = isCoachConfigured();
+  return (
+    <article className={styles.article}>
+      <header className={styles.header}>
+        <p className={styles.kicker}>🗣️ 對話速記</p>
+        <h1 className={styles.title}>
+          剛聊完？<em>講一句</em>就 log 進對方的卡
+        </h1>
+        <p className={styles.lead}>
+          不用滑名片冊找人、不用點開卡片填表 ——「今天跟陳玉涵聊到他公司在募 A 輪、看 SaaS 估值」。AI
+          自動找到對方的卡、把對話內容記下來、更新最後聯絡時間。下次見面前看一眼就知道上次談到哪。
+        </p>
+      </header>
+
+      {!llmReady ? (
+        <section className={styles.notReady}>
+          <p>
+            AI 目前未啟用 — 管理員尚未設定 LLM 金鑰。請改在卡片內手動點「記錄互動」
+            <Link href="/cards"> 回名片冊</Link>。
+          </p>
+        </section>
+      ) : (
+        <ConversationLog />
+      )}
+    </article>
+  );
+}

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -37,6 +37,16 @@ export default async function HomePage() {
         <p className={styles.lead}>
           把「關係脈絡」放在第一位—— 這裡不是名片列表，是你的人脈節奏表。
         </p>
+        {cards.length > 0 && (
+          <div className={styles.quickActions}>
+            <Link href="/log" className={styles.quickAction}>
+              🗣️ 對話速記
+            </Link>
+            <Link href="/cards/voice" className={styles.quickAction}>
+              🎙️ 語音建卡
+            </Link>
+          </div>
+        )}
       </header>
 
       {cards.length === 0 ? (

--- a/src/components/conversations/ConversationLog.module.css
+++ b/src/components/conversations/ConversationLog.module.css
@@ -1,0 +1,266 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-lg);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-paper);
+}
+
+.label {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-ink);
+}
+
+.textarea {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  padding: var(--space-md);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  resize: vertical;
+  min-height: 6rem;
+  outline: none;
+  line-height: var(--leading-relaxed);
+}
+
+.textarea:focus {
+  border-color: var(--color-accent-ink);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--color-accent-ink) 25%, transparent);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.interim {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  margin: 0;
+  padding: var(--space-xs) var(--space-sm);
+  border-left: 3px solid var(--color-accent-ink);
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 50%,
+    var(--color-paper)
+  );
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.primaryBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.primaryBtn:hover:not(:disabled) {
+  background: var(--color-accent-ink);
+}
+
+.primaryBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.smallBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.smallBtn:hover {
+  border-color: var(--color-accent-ink);
+}
+
+.examples {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+}
+
+.examples summary {
+  cursor: pointer;
+  color: var(--color-accent-ink);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) 0;
+}
+
+.exampleList {
+  list-style: none;
+  margin: var(--space-xs) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.exampleBtn {
+  display: block;
+  width: 100%;
+  text-align: left;
+  font-family: var(--font-serif);
+  font-size: var(--text-caption);
+  font-style: italic;
+  padding: var(--space-sm);
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 40%,
+    var(--color-paper)
+  );
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-ink);
+  cursor: pointer;
+  line-height: var(--leading-relaxed);
+}
+
+.exampleBtn:hover {
+  border-color: var(--color-accent-ink);
+}
+
+.error {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-error, #b00020);
+  margin: 0;
+}
+
+.preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 30%, var(--color-paper)) 0%,
+    var(--color-paper) 100%
+  );
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-md);
+}
+
+.previewTitle {
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  font-weight: 500;
+  margin: 0;
+  color: var(--color-ink);
+}
+
+.previewActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.candidateList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.candidate,
+.candidatePicked {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15em;
+  width: 100%;
+  text-align: left;
+  padding: var(--space-sm);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.candidate:hover {
+  border-color: var(--color-accent-ink);
+}
+
+.candidatePicked {
+  border-color: var(--color-accent-ink);
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 35%,
+    var(--color-paper)
+  );
+}
+
+.candidateName {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.candidateMeta {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+}
+
+.summaryBox {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.fieldLabel {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.summaryTextarea {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  padding: var(--space-sm);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  resize: vertical;
+  min-height: 4rem;
+  outline: none;
+  line-height: var(--leading-relaxed);
+}
+
+.summaryRead {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  margin: 0;
+  line-height: var(--leading-relaxed);
+}

--- a/src/components/conversations/ConversationLog.tsx
+++ b/src/components/conversations/ConversationLog.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { extractConversationAction, logConversationAction } from "@/app/(app)/log/actions";
+import { VoiceMicButton } from "@/components/cards/VoiceMicButton";
+import type { CardSummary } from "@/db/cards";
+import { encodePrefill } from "@/lib/voice/extract";
+
+import styles from "./ConversationLog.module.css";
+
+const EXAMPLES = [
+  "今天跟陳玉涵聊到他公司在募 A 輪、看 SaaS 估值",
+  "中午跟 Karen Chen 對 demo day pitch deck，她建議拿掉第 5 頁的 TAM 圖表",
+  "上午跟王小明電話，確認下週合約走 OEM 而不是 reseller",
+];
+
+type Phase =
+  | { kind: "input" }
+  | { kind: "loading" }
+  | {
+      kind: "matched";
+      personName: string;
+      summary: string;
+      candidates: CardSummary[];
+      pickedCardId: string | null;
+    }
+  | { kind: "noMatch"; personName: string; summary: string }
+  | { kind: "creating" }
+  | { kind: "done"; cardId: string }
+  | { kind: "error"; message: string };
+
+/**
+ * 對話速記 — voice/text → AI extracts {person, summary} → fuzzy match
+ * → log contact event in one step. Phase machine kept colocated to
+ * avoid premature abstraction; each phase is a discrete render branch.
+ */
+export function ConversationLog() {
+  const [text, setText] = useState("");
+  const [interim, setInterim] = useState("");
+  const [phase, setPhase] = useState<Phase>({ kind: "input" });
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const submit = () => {
+    const trimmed = text.trim();
+    if (!trimmed || trimmed.length < 3) return;
+    setPhase({ kind: "loading" });
+    startTransition(async () => {
+      const res = await extractConversationAction({ text: trimmed });
+      if (!res?.data) {
+        setPhase({ kind: "error", message: "AI 沒回應，請稍後再試或檢查網路。" });
+        return;
+      }
+      if (!res.data.ok) {
+        setPhase({
+          kind: "error",
+          message:
+            res.data.reason === "no-llm"
+              ? "AI 未啟用 — 管理員尚未設定 LLM 金鑰。"
+              : "AI 解析失敗，請換句話重試。",
+        });
+        return;
+      }
+      const { personName, summary, candidates } = res.data;
+      if (candidates.length === 0) {
+        setPhase({ kind: "noMatch", personName, summary });
+      } else {
+        setPhase({
+          kind: "matched",
+          personName,
+          summary,
+          candidates,
+          pickedCardId: candidates[0]!.id,
+        });
+      }
+    });
+  };
+
+  const reset = () => {
+    setText("");
+    setInterim("");
+    setPhase({ kind: "input" });
+  };
+
+  const confirmLog = (cardId: string, summary: string) => {
+    setPhase({ kind: "creating" });
+    startTransition(async () => {
+      const res = await logConversationAction({ cardId, summary });
+      if (!res?.data) {
+        setPhase({ kind: "error", message: "送出失敗（網路）" });
+        return;
+      }
+      if (!res.data.ok) {
+        setPhase({ kind: "error", message: res.data.reason });
+        return;
+      }
+      setPhase({ kind: "done", cardId });
+    });
+  };
+
+  const handleExample = (example: string) => {
+    setText(example);
+    setPhase({ kind: "input" });
+  };
+
+  if (phase.kind === "input" || phase.kind === "loading") {
+    const loading = phase.kind === "loading" || pending;
+    return (
+      <section className={styles.section}>
+        <label htmlFor="log-text" className={styles.label}>
+          講一句剛剛聊了什麼
+        </label>
+        <textarea
+          id="log-text"
+          className={styles.textarea}
+          value={text + (interim ? `（${interim}）` : "")}
+          onChange={(e) => setText(e.target.value)}
+          rows={4}
+          placeholder="例：今天跟陳玉涵聊到他公司在募 A 輪、看 SaaS 估值"
+          disabled={loading}
+        />
+        <VoiceMicButton
+          onFinalTranscript={(t) => setText((prev) => (prev ? `${prev}${t}` : t))}
+          onInterimTranscript={setInterim}
+          disabled={loading}
+        />
+        {interim && <p className={styles.interim}>聆聽中：「{interim}」</p>}
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.primaryBtn}
+            onClick={submit}
+            disabled={loading || text.trim().length < 3}
+          >
+            {loading ? "AI 解析中…" : "🪄 解析並記錄"}
+          </button>
+        </div>
+        <details className={styles.examples}>
+          <summary>看範例</summary>
+          <ul className={styles.exampleList}>
+            {EXAMPLES.map((ex) => (
+              <li key={ex}>
+                <button
+                  type="button"
+                  className={styles.exampleBtn}
+                  onClick={() => handleExample(ex)}
+                  disabled={loading}
+                >
+                  {ex}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </details>
+      </section>
+    );
+  }
+
+  if (phase.kind === "matched") {
+    const picked =
+      phase.candidates.find((c) => c.id === phase.pickedCardId) ?? phase.candidates[0]!;
+    return (
+      <section className={styles.preview}>
+        <h2 className={styles.previewTitle}>
+          找到 {phase.candidates.length} 位「{phase.personName}」
+        </h2>
+
+        {phase.candidates.length > 1 && (
+          <ul className={styles.candidateList}>
+            {phase.candidates.map((card) => (
+              <li key={card.id}>
+                <button
+                  type="button"
+                  className={card.id === picked.id ? styles.candidatePicked : styles.candidate}
+                  onClick={() =>
+                    setPhase({
+                      ...phase,
+                      pickedCardId: card.id,
+                    })
+                  }
+                  aria-pressed={card.id === picked.id}
+                >
+                  <span className={styles.candidateName}>
+                    {card.nameZh ?? card.nameEn ?? "（未命名）"}
+                  </span>
+                  {(card.companyZh || card.companyEn || card.jobTitleZh || card.jobTitleEn) && (
+                    <span className={styles.candidateMeta}>
+                      {[card.jobTitleZh ?? card.jobTitleEn, card.companyZh ?? card.companyEn]
+                        .filter(Boolean)
+                        .join(" @ ")}
+                    </span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className={styles.summaryBox}>
+          <p className={styles.fieldLabel}>對話內容</p>
+          <textarea
+            className={styles.summaryTextarea}
+            value={phase.summary}
+            onChange={(e) => setPhase({ ...phase, summary: e.target.value })}
+            rows={3}
+            maxLength={500}
+          />
+        </div>
+
+        <div className={styles.previewActions}>
+          <button
+            type="button"
+            className={styles.primaryBtn}
+            onClick={() => confirmLog(picked.id, phase.summary)}
+            disabled={pending || !phase.summary.trim()}
+          >
+            ✅ 記錄到「{picked.nameZh ?? picked.nameEn}」
+          </button>
+          <button type="button" className={styles.smallBtn} onClick={reset} disabled={pending}>
+            重來
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  if (phase.kind === "noMatch") {
+    const goCreateNew = () => {
+      const prefill = encodePrefill({
+        nameZh: phase.personName,
+        whyRemember: phase.summary,
+      });
+      router.push(`/cards/new?prefill=${prefill}`);
+    };
+    return (
+      <section className={styles.preview}>
+        <h2 className={styles.previewTitle}>名片冊裡找不到「{phase.personName}」</h2>
+        <p className={styles.fieldLabel}>對話內容</p>
+        <p className={styles.summaryRead}>{phase.summary}</p>
+        <div className={styles.previewActions}>
+          <button type="button" className={styles.primaryBtn} onClick={goCreateNew}>
+            ➕ 建立新卡（已預填名字 + 內容）
+          </button>
+          <button type="button" className={styles.smallBtn} onClick={reset}>
+            改名稱重試
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  if (phase.kind === "creating") {
+    return (
+      <section className={styles.preview}>
+        <p>記錄中…</p>
+      </section>
+    );
+  }
+
+  if (phase.kind === "done") {
+    return (
+      <section className={styles.preview}>
+        <h2 className={styles.previewTitle}>已記錄 ✅</h2>
+        <div className={styles.previewActions}>
+          <Link href={`/cards/${phase.cardId}`} className={styles.primaryBtn}>
+            看卡片詳細
+          </Link>
+          <button type="button" className={styles.smallBtn} onClick={reset}>
+            再記下一次
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.section}>
+      <p className={styles.error}>{phase.message}</p>
+      <button type="button" className={styles.smallBtn} onClick={reset}>
+        重試
+      </button>
+    </section>
+  );
+}

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -21,6 +21,7 @@ const PRIMARY: NavItem[] = [
   { href: "/cards", label: "名片冊", description: "畫廊 · 清單" },
   { href: "/cards/new", label: "新增", description: "手動建立一張" },
   { href: "/cards/voice", label: "🎙️ 語音建卡", description: "講 30 秒讓 AI 解析" },
+  { href: "/log", label: "🗣️ 對話速記", description: "講一句 log 進對方的卡" },
   { href: "/companies", label: "公司", description: "同公司聯絡人聚合" },
   { href: "/events", label: "場合", description: "同場合認識的人" },
   { href: "/tags", label: "標籤", description: "分類 · 重新命名" },

--- a/src/lib/conversations/__tests__/extract.test.ts
+++ b/src/lib/conversations/__tests__/extract.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { buildConversationMessages, parseConversationLog } from "../extract";
+
+describe("buildConversationMessages", () => {
+  it("returns system + user messages with the user's text", () => {
+    const msgs = buildConversationMessages("今天跟陳玉涵聊到 A 輪");
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.role).toBe("system");
+    expect(msgs[1]!.role).toBe("user");
+    expect(msgs[1]!.content).toContain("陳玉涵");
+  });
+
+  it("system prompt includes both personName and summary fields", () => {
+    const msgs = buildConversationMessages("x");
+    expect(msgs[0]!.content).toContain("personName");
+    expect(msgs[0]!.content).toContain("summary");
+  });
+});
+
+describe("parseConversationLog", () => {
+  it("parses a clean response", () => {
+    const raw = JSON.stringify({
+      personName: "陳玉涵",
+      summary: "他公司在募 A 輪、看 SaaS 估值",
+    });
+    const result = parseConversationLog(raw, "fallback");
+    expect(result).toEqual({
+      personName: "陳玉涵",
+      summary: "他公司在募 A 輪、看 SaaS 估值",
+    });
+  });
+
+  it("strips markdown json fence", () => {
+    const raw = "```json\n" + JSON.stringify({ personName: "A", summary: "x" }) + "\n```";
+    expect(parseConversationLog(raw, "fb")?.personName).toBe("A");
+  });
+
+  it("returns null on malformed JSON", () => {
+    expect(parseConversationLog("not json", "fb")).toBeNull();
+  });
+
+  it("returns null on empty raw", () => {
+    expect(parseConversationLog("", "fb")).toBeNull();
+  });
+
+  it("returns null on array root", () => {
+    expect(parseConversationLog("[1,2]", "fb")).toBeNull();
+  });
+
+  it("returns null on primitive root", () => {
+    expect(parseConversationLog("42", "fb")).toBeNull();
+  });
+
+  it("returns null when personName missing", () => {
+    const raw = JSON.stringify({ summary: "x" });
+    expect(parseConversationLog(raw, "fb")).toBeNull();
+  });
+
+  it("returns null when personName is empty string", () => {
+    const raw = JSON.stringify({ personName: "  ", summary: "x" });
+    expect(parseConversationLog(raw, "fb")).toBeNull();
+  });
+
+  it("returns null when personName is a non-string", () => {
+    const raw = JSON.stringify({ personName: 42, summary: "x" });
+    expect(parseConversationLog(raw, "fb")).toBeNull();
+  });
+
+  it("falls back to truncated input when summary missing", () => {
+    const raw = JSON.stringify({ personName: "陳玉涵" });
+    const result = parseConversationLog(raw, "原始輸入");
+    expect(result?.personName).toBe("陳玉涵");
+    expect(result?.summary).toBe("原始輸入");
+  });
+
+  it("uses placeholder when both summary and fallback are empty", () => {
+    const raw = JSON.stringify({ personName: "X" });
+    expect(parseConversationLog(raw, "")?.summary).toBe("（對話）");
+  });
+
+  it("clamps long summary to 500 chars", () => {
+    const longText = "x".repeat(2000);
+    const raw = JSON.stringify({ personName: "Alice", summary: longText });
+    const result = parseConversationLog(raw, "fb")!;
+    expect(result.summary.length).toBe(500);
+  });
+
+  it("clamps long personName to 100 chars", () => {
+    const longText = "n".repeat(2000);
+    const raw = JSON.stringify({ personName: longText, summary: "x" });
+    const result = parseConversationLog(raw, "fb")!;
+    expect(result.personName.length).toBe(100);
+  });
+
+  it("trims surrounding whitespace from both fields", () => {
+    const raw = JSON.stringify({ personName: "  陳玉涵  ", summary: "  hello  " });
+    const result = parseConversationLog(raw, "fb")!;
+    expect(result.personName).toBe("陳玉涵");
+    expect(result.summary).toBe("hello");
+  });
+});

--- a/src/lib/conversations/__tests__/match.test.ts
+++ b/src/lib/conversations/__tests__/match.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import { matchPersonName } from "../match";
+
+function aSummary(over: Partial<CardSummary>): CardSummary {
+  return {
+    id: over.id ?? "card-x",
+    workspaceId: "wid",
+    ownerUid: "uid",
+    memberUids: ["uid"],
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...over,
+  } as CardSummary;
+}
+
+describe("matchPersonName", () => {
+  it("returns [] for empty needle", () => {
+    expect(matchPersonName("", [aSummary({ id: "a", nameZh: "陳玉涵" })])).toEqual([]);
+    expect(matchPersonName("   ", [aSummary({ id: "a", nameZh: "陳玉涵" })])).toEqual([]);
+  });
+
+  it("returns [] when no cards have any name", () => {
+    expect(matchPersonName("陳", [aSummary({ id: "a" })])).toEqual([]);
+  });
+
+  it("exact CJK match wins over prefix", () => {
+    const cards = [
+      aSummary({ id: "pre", nameZh: "陳玉涵雯" }),
+      aSummary({ id: "exact", nameZh: "陳玉涵" }),
+    ];
+    const result = matchPersonName("陳玉涵", cards);
+    expect(result.map((c) => c.id)).toEqual(["exact", "pre"]);
+  });
+
+  it("exact English match (case-insensitive)", () => {
+    const cards = [
+      aSummary({ id: "a", nameEn: "Bob" }),
+      aSummary({ id: "b", nameEn: "Karen Chen" }),
+    ];
+    expect(matchPersonName("karen chen", cards).map((c) => c.id)).toEqual(["b"]);
+    expect(matchPersonName("KAREN CHEN", cards).map((c) => c.id)).toEqual(["b"]);
+  });
+
+  it("prefix beats substring", () => {
+    const cards = [
+      aSummary({ id: "sub", nameZh: "李大同" }),
+      aSummary({ id: "pre", nameZh: "李志強" }),
+    ];
+    expect(matchPersonName("李", cards).map((c) => c.id)).toEqual(["sub", "pre"]);
+  });
+
+  it("returns multiple substring matches in DB order", () => {
+    const cards = [
+      aSummary({ id: "first", nameZh: "陳志明" }),
+      aSummary({ id: "second", nameZh: "陳玉涵" }),
+      aSummary({ id: "third", nameZh: "王小明" }),
+    ];
+    expect(matchPersonName("陳", cards).map((c) => c.id)).toEqual(["first", "second"]);
+  });
+
+  it("matches across nameZh, nameEn, namePhonetic and uses best tier", () => {
+    const cards = [
+      aSummary({ id: "phon", namePhonetic: "Wang Xiaoming", nameZh: "王小明" }),
+      aSummary({ id: "en", nameEn: "Karen Chen" }),
+    ];
+    expect(matchPersonName("Karen Chen", cards).map((c) => c.id)).toEqual(["en"]);
+  });
+
+  it("trims whitespace in needle", () => {
+    const cards = [aSummary({ id: "a", nameZh: "陳玉涵" })];
+    expect(matchPersonName("  陳玉涵  ", cards).map((c) => c.id)).toEqual(["a"]);
+  });
+
+  it("returns [] when no card matches", () => {
+    const cards = [aSummary({ id: "a", nameZh: "陳玉涵" })];
+    expect(matchPersonName("Karen", cards)).toEqual([]);
+  });
+
+  it("ignores blank name fields (whitespace only)", () => {
+    const cards = [aSummary({ id: "blank", nameZh: "   ", nameEn: "" })];
+    expect(matchPersonName("陳", cards)).toEqual([]);
+  });
+});

--- a/src/lib/conversations/extract-llm.ts
+++ b/src/lib/conversations/extract-llm.ts
@@ -1,0 +1,59 @@
+import "server-only";
+
+import {
+  buildConversationMessages,
+  parseConversationLog,
+  type ExtractedConversation,
+} from "./extract";
+
+const DEFAULT_BASE_URL = "https://api.minimax.chat/v1";
+const DEFAULT_MODEL = "MiniMax-M2.7";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+interface MiniMaxChatResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+export async function callConversationLogLlm(
+  text: string,
+  options: { timeoutMs?: number } = {},
+): Promise<ExtractedConversation | null> {
+  const apiKey = process.env.MINIMAX_API_KEY ?? "";
+  if (!apiKey) return null;
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  const baseUrl = process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = process.env.MINIMAX_MODEL ?? DEFAULT_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const body = {
+    model,
+    temperature: 0.2,
+    max_tokens: 600,
+    messages: buildConversationMessages(trimmed),
+  };
+
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: abort.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as MiniMaxChatResponse;
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) return null;
+    return parseConversationLog(raw, trimmed);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/conversations/extract.ts
+++ b/src/lib/conversations/extract.ts
@@ -1,0 +1,91 @@
+/**
+ * 對話速記 — turn a free-form sentence about a meeting/chat into the
+ * minimum tuple we need to call `logContactEvent`:
+ *   { personName, summary }
+ *
+ * Date inference ("yesterday", "last week") is intentionally out of scope
+ * for v1 — server defaults to `now`. Adding it later only changes the
+ * server action, not this parser.
+ *
+ * Mirrors src/lib/voice/extract.ts: prompt + defensive JSON parse +
+ * length clamps + fence stripping. Kept side-effect free so tests can
+ * exercise it without mocks.
+ */
+
+const SYSTEM_PROMPT =
+  "你是對話記錄抽取器。" +
+  "使用者剛剛和某人講完話，用一句話描述見面/通話的內容。" +
+  "把這句話拆成兩件事：(1) 對方是誰 (2) 聊了什麼。\n" +
+  "回答必須是合法 JSON：\n" +
+  "{\n" +
+  '  "personName": string,   // 對方的名字（中文或英文皆可，原樣保留）\n' +
+  '  "summary": string       // 聊天內容精華，繁體中文，<= 300 字\n' +
+  "}\n" +
+  "規則：\n" +
+  "- 只回傳 JSON，不要 markdown 圍欄、不要說明文字。\n" +
+  "- personName 必填。如果原句沒有明確人名（只說「他」「那個 PM」），回傳空字串。\n" +
+  "- summary 必填。沒明確內容就用整句話濃縮版。\n" +
+  "- 不要編造對方說過的具體事；只根據輸入推理。\n" +
+  '- 不要把時間詞（"今天"、"剛剛"）放進 summary，那是 metadata。';
+
+export interface ExtractedConversation {
+  personName: string;
+  summary: string;
+}
+
+export function buildConversationMessages(
+  text: string,
+): Array<{ role: "system" | "user"; content: string }> {
+  return [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: text },
+  ];
+}
+
+const MAX_NAME_LEN = 100;
+const MAX_SUMMARY_LEN = 500;
+
+function sanitizeStr(value: unknown, max: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, max);
+}
+
+/**
+ * Parse the LLM JSON. Returns null if:
+ *   - input is not parseable JSON
+ *   - root isn't an object (array / primitive)
+ *   - personName is missing or non-string-after-trim
+ *
+ * If summary is missing, falls back to the truncated original input so
+ * the contact-event still has *something* useful — better than dropping
+ * the whole call. UI can let the user edit before saving.
+ */
+export function parseConversationLog(
+  raw: string,
+  fallbackText: string,
+): ExtractedConversation | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const inner = fenced ? fenced[1]! : trimmed;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(inner);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const obj = parsed as Record<string, unknown>;
+
+  const personName = sanitizeStr(obj.personName, MAX_NAME_LEN);
+  if (!personName) return null;
+
+  const summary = sanitizeStr(obj.summary, MAX_SUMMARY_LEN);
+  if (summary) {
+    return { personName, summary };
+  }
+  const fallback = fallbackText.trim().slice(0, MAX_SUMMARY_LEN);
+  return { personName, summary: fallback || "（對話）" };
+}

--- a/src/lib/conversations/match.ts
+++ b/src/lib/conversations/match.ts
@@ -1,0 +1,53 @@
+import type { CardSummary } from "@/db/cards";
+
+/**
+ * Fuzzy person-name → card matcher used by the 對話速記 flow.
+ *
+ * Scope is intentionally narrow: cards already filtered to the caller's
+ * workspace. We never reach across users; matching is purely a string
+ * problem on the in-memory list.
+ *
+ * Match tiers (each card emits its best tier across nameZh/nameEn/
+ * namePhonetic; lower number wins; ties keep DB order):
+ *   0 — exact (case-insensitive, trimmed)
+ *   1 — prefix
+ *   2 — substring
+ *
+ * Cards with no name fields are dropped. Empty/whitespace input returns [].
+ */
+export function matchPersonName(name: string, cards: readonly CardSummary[]): CardSummary[] {
+  const needle = name.trim().toLowerCase();
+  if (!needle) return [];
+
+  const scored: Array<{ card: CardSummary; tier: number; index: number }> = [];
+  cards.forEach((card, index) => {
+    const tier = bestTierFor(card, needle);
+    if (tier !== null) scored.push({ card, tier, index });
+  });
+
+  scored.sort((a, b) => a.tier - b.tier || a.index - b.index);
+  return scored.map((s) => s.card);
+}
+
+function bestTierFor(card: CardSummary, needle: string): number | null {
+  const candidates = [card.nameZh, card.nameEn, card.namePhonetic]
+    .map((v) => v?.trim().toLowerCase())
+    .filter((v): v is string => Boolean(v));
+  if (candidates.length === 0) return null;
+
+  let best: number | null = null;
+  for (const candidate of candidates) {
+    const tier = scoreString(candidate, needle);
+    if (tier === null) continue;
+    if (best === null || tier < best) best = tier;
+    if (best === 0) return 0;
+  }
+  return best;
+}
+
+function scoreString(haystack: string, needle: string): number | null {
+  if (haystack === needle) return 0;
+  if (haystack.startsWith(needle)) return 1;
+  if (haystack.includes(needle)) return 2;
+  return null;
+}


### PR DESCRIPTION
## Summary
- **Two steps replace five.** Today, logging a conversation requires: find the person → open card → tap log → fill form → submit. New flow: open `/log` → speak/type one sentence → confirm. Server does the matching + writing.
- **The AI does the boring part.** Sentence in (\"今天跟陳玉涵聊到他公司在募 A 輪、看 SaaS 估值\") → MiniMax extracts \`{personName, summary}\` → server fuzzy-matches across nameZh/nameEn/namePhonetic with exact > prefix > substring tiers → calls existing \`logContactEvent\`.
- **Three branches kept honest.** 1 match → one-tap confirm. 2+ matches → picker. 0 matches → \"create new card with name + summary prefilled\" using the existing voice-prefill encoder.

## Why this slice
The card detail page already has a 「記錄互動」 button + ContactEventList, but in practice nobody logs anything because the friction is too high right after a meeting. This means:
- The AI Coach / Daily Briefing has no recent conversational context to work from
- Returning to a card a month later, you don\\'t remember what you talked about
- 商務人士 — for whom \"what you talked about last time\" *is* the relationship — get a static rolodex instead of a memory aid

By moving the entry point to a dedicated /log surface and letting the AI handle person-matching, the cost-per-log drops near zero. That changes the economics of using the app at all.

## Scope kept tight
- ✅ Single-person, today-only logging
- ⛔ Date inference (\"yesterday\", \"last week\") — server defaults to now()
- ⛔ Multi-person (\"talked to A about X, B about Y\") — single-person only
- ⛔ Auto-fallback to literal search when LLM fails — user retries

These can all extend the same \`extractConversationAction\` later without changing the UX shape.

## Files
- \`src/lib/conversations/extract.ts\` — pure: \`buildConversationMessages\`, \`parseConversationLog\` (fence-stripped, length-clamped, drops non-string fields, summary fallback)
- \`src/lib/conversations/match.ts\` — pure tier-scored matcher (case-insensitive trim)
- \`src/lib/conversations/extract-llm.ts\` — MiniMax client (600 max_tokens vs 800 for card extract)
- \`src/app/(app)/log/{actions.ts,page.tsx,log.module.css}\` — \`extractConversationAction\` + \`logConversationAction\` + RSC with LLM-disabled fallback
- \`src/components/conversations/ConversationLog.{tsx,module.css}\` — phase machine \`input → loading → matched|noMatch → creating → done|error\`
- \`src/components/shell/AppShell.tsx\` — 「🗣️ 對話速記」 in PRIMARY nav after 語音建卡
- \`src/app/(app)/page.tsx\` + \`home.module.css\` — pill-shaped quick-actions row in header (visible when cards.length > 0)

## Test plan
- [x] \`pnpm test\` — 26 new UT pass (extract: 16, match: 10)
- [x] \`pnpm test:coverage\` — branches 80.81% (above gate); \`lib/conversations\` 100% lines / 92.68% branches
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — no new warnings
- [x] \`pnpm format\` — clean
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\` — green; route table includes \`/log\`
- [ ] Live smoke after merge + deploy: speak \"今天跟<existing-card-name>聊到 X\" → expect 1-card match → tap confirm → land on card detail page with new contact-event at top + lastContactedAt updated

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)