### PR TITLE
feat(recap): 對話日誌 — visible journal of /log entries

### DIFF
--- a/src/app/(app)/recap/page.tsx
+++ b/src/app/(app)/recap/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+
+import { RecapList } from "@/components/recap/RecapList";
+import { listRecentContactEventsForUser } from "@/db/cards";
+import { readSession } from "@/lib/firebase/session";
+import { groupRecapByDay } from "@/lib/recap/group";
+
+import styles from "./recap.module.css";
+
+export const metadata = {
+  title: "對話日誌",
+};
+
+export default async function RecapPage() {
+  const user = await readSession();
+  if (!user) return null;
+
+  const items = await listRecentContactEventsForUser(user.uid, 14);
+  const groups = groupRecapByDay(items, new Date());
+
+  return (
+    <article className={styles.article}>
+      <header className={styles.header}>
+        <p className={styles.kicker}>📓 對話日誌</p>
+        <h1 className={styles.title}>
+          最近 14 天，你<em>跟誰聊了什麼</em>
+        </h1>
+        <p className={styles.lead}>
+          每筆 /log 速記在這裡都看得到。下次見面前掃一眼，就知道上次談到哪。
+        </p>
+      </header>
+
+      {groups.length === 0 ? (
+        <section className={styles.empty}>
+          <p className={styles.emptyLead}>
+            還沒有任何對話記錄。剛跟人聊完？去
+            <Link href="/log">/log 對話速記</Link>留一筆。
+          </p>
+        </section>
+      ) : (
+        <RecapList groups={groups} />
+      )}
+    </article>
+  );
+}

--- a/src/app/(app)/recap/recap.module.css
+++ b/src/app/(app)/recap/recap.module.css
@@ -1,0 +1,69 @@
+.article {
+  max-width: var(--content-max);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding-bottom: var(--space-md);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h2);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+}
+
+.title em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-accent);
+}
+
+.lead {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  line-height: var(--leading-relaxed);
+  margin: var(--space-xs) 0 0;
+  max-width: 60ch;
+}
+
+.empty {
+  padding: var(--space-2xl) var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) dashed var(--color-border);
+  border-radius: var(--radius-md);
+  text-align: center;
+}
+
+.emptyLead {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.empty a {
+  color: var(--color-accent-ink);
+  margin: 0 0.25em;
+}

--- a/src/components/recap/RecapList.module.css
+++ b/src/components/recap/RecapList.module.css
@@ -1,0 +1,80 @@
+.groupList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.groupLabel {
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  font-weight: 500;
+  margin: 0;
+  color: var(--color-ink);
+  letter-spacing: var(--tracking-tight);
+}
+
+.itemList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.item {
+  display: flex;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  align-items: flex-start;
+}
+
+.time {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  min-width: 3.5em;
+  letter-spacing: var(--tracking-wide);
+}
+
+.body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25em;
+}
+
+.name {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-ink);
+  text-decoration: none;
+  letter-spacing: var(--tracking-tight);
+}
+
+.name:hover {
+  color: var(--color-accent-ink);
+  text-decoration: underline;
+}
+
+.note {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  margin: 0;
+  line-height: var(--leading-relaxed);
+  white-space: pre-wrap;
+}

--- a/src/components/recap/RecapList.tsx
+++ b/src/components/recap/RecapList.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+
+import type { RecapGroup } from "@/lib/recap/group";
+
+import styles from "./RecapList.module.css";
+
+interface RecapListProps {
+  groups: readonly RecapGroup[];
+}
+
+function formatTime(d: Date): string {
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+function pickName(card: RecapGroup["items"][number]["card"]): string {
+  return card.nameZh || card.nameEn || "（未命名）";
+}
+
+export function RecapList({ groups }: RecapListProps) {
+  return (
+    <ol className={styles.groupList}>
+      {groups.map((group) => (
+        <li key={group.key} className={styles.group}>
+          <h2 className={styles.groupLabel}>{group.label}</h2>
+          <ul className={styles.itemList}>
+            {group.items.map((item) => (
+              <li key={`${item.card.id}::${item.event.id}`} className={styles.item}>
+                <span className={styles.time}>{formatTime(item.event.at)}</span>
+                <div className={styles.body}>
+                  <Link href={`/cards/${item.card.id}`} className={styles.name}>
+                    {pickName(item.card)}
+                  </Link>
+                  <p className={styles.note}>{item.event.note || "（無內容）"}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -22,6 +22,7 @@ const PRIMARY: NavItem[] = [
   { href: "/cards/new", label: "新增", description: "手動建立一張" },
   { href: "/cards/voice", label: "🎙️ 語音建卡", description: "講 30 秒讓 AI 解析" },
   { href: "/log", label: "🗣️ 對話速記", description: "講一句 log 進對方的卡" },
+  { href: "/recap", label: "📓 對話日誌", description: "最近 14 天 log 過的對話" },
   { href: "/companies", label: "公司", description: "同公司聯絡人聚合" },
   { href: "/events", label: "場合", description: "同場合認識的人" },
   { href: "/tags", label: "標籤", description: "分類 · 重新命名" },

--- a/src/db/cards.ts
+++ b/src/db/cards.ts
@@ -795,4 +795,43 @@ export async function listContactEventsForUser(
   });
 }
 
+/**
+ * Recent contact-events across all of the user's cards, newest first.
+ * Used by /recap (對話日誌). Avoids a collectionGroup index by riding
+ * the existing lastContactedAt-desc query — `logContactEvent` bumps
+ * that field, so cards-with-recent-events naturally cluster at the top.
+ *
+ * Bounded I/O: stops walking once a card's lastContactedAt is older
+ * than `sinceDays`. For a real user this is ~tens of cards/day, not
+ * the whole rolodex.
+ */
+export async function listRecentContactEventsForUser(
+  uid: string,
+  sinceDays = 14,
+  perCardLimit = 5,
+): Promise<Array<{ card: CardSummary; event: ContactEvent }>> {
+  const now = Date.now();
+  const sinceMs = sinceDays * 24 * 60 * 60 * 1000;
+  const cutoff = now - sinceMs;
+
+  const cards = await listCardsForUser(uid, {
+    orderBy: "lastContactedAt",
+    order: "desc",
+    limit: 200,
+  });
+
+  const items: Array<{ card: CardSummary; event: ContactEvent }> = [];
+  for (const card of cards) {
+    if (!card.lastContactedAt) continue;
+    if (card.lastContactedAt.getTime() < cutoff) break;
+    const events = await listContactEventsForUser(card.id, uid, perCardLimit);
+    for (const event of events) {
+      if (event.at.getTime() < cutoff) continue;
+      items.push({ card, event });
+    }
+  }
+  items.sort((a, b) => b.event.at.getTime() - a.event.at.getTime());
+  return items;
+}
+
 export { COLLECTION_WORKSPACES, SUB_COLLECTION_CARDS };

--- a/src/lib/recap/__tests__/group.test.ts
+++ b/src/lib/recap/__tests__/group.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary, ContactEvent } from "@/db/cards";
+
+import { groupRecapByDay, type RecapItem } from "../group";
+
+function aCard(over: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "card-x",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "陳玉涵",
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...over,
+  } as CardSummary;
+}
+
+function anEvent(at: Date, note = "n", id = "e"): ContactEvent {
+  return { id, at, note, authorUid: "u", authorDisplay: null };
+}
+
+function mkItem(card: CardSummary, at: Date, note = "n"): RecapItem {
+  return { card, event: anEvent(at, note) };
+}
+
+describe("groupRecapByDay", () => {
+  // Use an explicit local-time anchor (00:00) so the day arithmetic doesn't
+  // straddle UTC boundaries and the labels stay deterministic regardless of
+  // the runner's TZ.
+  const NOW = new Date(2026, 3, 25, 12, 0, 0); // 2026-04-25 12:00 local
+
+  it("returns [] for empty input", () => {
+    expect(groupRecapByDay([], NOW)).toEqual([]);
+  });
+
+  it("labels today and yesterday correctly", () => {
+    const today = new Date(2026, 3, 25, 9, 0);
+    const yesterday = new Date(2026, 3, 24, 9, 0);
+    const groups = groupRecapByDay(
+      [mkItem(aCard({ id: "a" }), today), mkItem(aCard({ id: "b" }), yesterday)],
+      NOW,
+    );
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.label).toBe("今天");
+    expect(groups[1]!.label).toBe("昨天");
+  });
+
+  it("labels within last week as 本週X", () => {
+    const fourDaysAgo = new Date(2026, 3, 21, 9, 0); // Tuesday
+    const groups = groupRecapByDay([mkItem(aCard({ id: "a" }), fourDaysAgo)], NOW);
+    expect(groups[0]!.label).toMatch(/^本週/);
+  });
+
+  it("labels week+ ago as 上週X", () => {
+    const tenDaysAgo = new Date(2026, 3, 15, 9, 0);
+    const groups = groupRecapByDay([mkItem(aCard({ id: "a" }), tenDaysAgo)], NOW);
+    expect(groups[0]!.label).toMatch(/^上週/);
+  });
+
+  it("labels older as M 月 D 日", () => {
+    const old = new Date(2026, 0, 15, 9, 0);
+    const groups = groupRecapByDay([mkItem(aCard({ id: "a" }), old)], NOW);
+    expect(groups[0]!.label).toBe("1 月 15 日");
+  });
+
+  it("groups multiple items on the same day into one bucket", () => {
+    const at = new Date(2026, 3, 25, 9, 0);
+    const groups = groupRecapByDay(
+      [mkItem(aCard({ id: "a" }), at, "first"), mkItem(aCard({ id: "b" }), at, "second")],
+      NOW,
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.items).toHaveLength(2);
+  });
+
+  it("orders buckets newest-day-first", () => {
+    const yesterday = new Date(2026, 3, 24, 9, 0);
+    const today = new Date(2026, 3, 25, 9, 0);
+    const groups = groupRecapByDay(
+      [mkItem(aCard({ id: "old" }), yesterday), mkItem(aCard({ id: "new" }), today)],
+      NOW,
+    );
+    expect(groups[0]!.label).toBe("今天");
+    expect(groups[1]!.label).toBe("昨天");
+  });
+
+  it("preserves caller's intra-day ordering", () => {
+    const at = new Date(2026, 3, 25, 9, 0);
+    const groups = groupRecapByDay(
+      [mkItem(aCard({ id: "first" }), at, "1"), mkItem(aCard({ id: "second" }), at, "2")],
+      NOW,
+    );
+    expect(groups[0]!.items.map((i) => i.event.note)).toEqual(["1", "2"]);
+  });
+
+  it("drops items with epoch / invalid event.at", () => {
+    const groups = groupRecapByDay(
+      [
+        mkItem(aCard({ id: "good" }), new Date(2026, 3, 25, 9, 0)),
+        mkItem(aCard({ id: "bad" }), new Date(0)),
+      ],
+      NOW,
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.items).toHaveLength(1);
+    expect(groups[0]!.items[0]!.card.id).toBe("good");
+  });
+});

--- a/src/lib/recap/group.ts
+++ b/src/lib/recap/group.ts
@@ -1,0 +1,75 @@
+import type { CardSummary, ContactEvent } from "@/db/cards";
+
+export interface RecapItem {
+  card: CardSummary;
+  event: ContactEvent;
+}
+
+export interface RecapGroup {
+  /** Stable sort key — ISO date YYYY-MM-DD of the bucket's local day. */
+  key: string;
+  /** Human-readable label in zh-Hant ("今天" / "昨天" / "本週三" / "M 月 D 日"). */
+  label: string;
+  /** Items in this bucket, newest first. */
+  items: RecapItem[];
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const WEEKDAYS_ZH = ["日", "一", "二", "三", "四", "五", "六"] as const;
+
+function isoDay(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function startOfLocalDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+function diffDays(later: Date, earlier: Date): number {
+  return Math.floor(
+    (startOfLocalDay(later).getTime() - startOfLocalDay(earlier).getTime()) / MS_PER_DAY,
+  );
+}
+
+function labelFor(eventAt: Date, now: Date): string {
+  const days = diffDays(now, eventAt);
+  if (days <= 0) return "今天";
+  if (days === 1) return "昨天";
+  if (days < 7) {
+    const wd = WEEKDAYS_ZH[eventAt.getDay()]!;
+    return `本週${wd}`;
+  }
+  if (days < 14) {
+    const wd = WEEKDAYS_ZH[eventAt.getDay()]!;
+    return `上週${wd}`;
+  }
+  return `${eventAt.getMonth() + 1} 月 ${eventAt.getDate()} 日`;
+}
+
+/**
+ * Bucket recap items by local day. Within each bucket, items keep the
+ * caller's ordering (callers should pass newest-first). Buckets
+ * themselves are returned newest-first by date key.
+ *
+ * Skips items whose event timestamp is null/epoch (defensive — a bad
+ * Firestore read could yield Date(0); we don't want a "1970-01-01"
+ * bucket polluting the recap).
+ */
+export function groupRecapByDay(items: readonly RecapItem[], now: Date): RecapGroup[] {
+  const buckets = new Map<string, RecapGroup>();
+  for (const item of items) {
+    const at = item.event.at;
+    if (!at || at.getTime() <= 0) continue;
+    const key = isoDay(at);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { key, label: labelFor(at, now), items: [] };
+      buckets.set(key, bucket);
+    }
+    bucket.items.push(item);
+  }
+  // Stable order: newest day first via reverse-lex on YYYY-MM-DD
+  return [...buckets.values()].sort((a, b) => (a.key < b.key ? 1 : a.key > b.key ? -1 : 0));
+}


### PR DESCRIPTION
## Summary
- **Closes the visibility gap.** /log writes events. Briefing reads them silently. Now /recap *shows* them — a 14-day day-grouped view that lets users scan \"what did we talk about lately\" before a meeting, or audit their week on Friday.
- **No new index, no Typesense rebuild.** Rides the existing \`lastContactedAt-desc\` query: \`logContactEvent\` bumps that field, so cards-with-recent-events naturally cluster at the top. Walk stops early when a card's \`lastContactedAt\` is older than the cutoff.
- **Pure grouping function, fully tested.** \`groupRecapByDay\` produces zh-Hant labels (今天 / 昨天 / 本週X / 上週X / M 月 D 日). 9 UT cover the boundaries + epoch drop + intra-day order preservation.

## Why this slice now
PR #99 made it cheap to log a conversation. PR #101 made the briefing smarter because of those logs. But until users can *see* the accumulated record, they don't trust the system enough to keep logging — the AI's improvements happen invisibly. /recap is the visible payoff that closes the motivation loop.

## Files
- \`src/lib/recap/group.ts\` — pure \`groupRecapByDay(items, now)\` → \`RecapGroup[]\`
- \`src/lib/recap/__tests__/group.test.ts\` — 9 UT
- \`src/db/cards.ts\` — \`listRecentContactEventsForUser(uid, sinceDays=14, perCardLimit=5)\`; bounded I/O via early-stop
- \`src/app/(app)/recap/{page.tsx,recap.module.css}\` — RSC page; empty state points at /log
- \`src/components/recap/RecapList.{tsx,module.css}\` — server component
- \`src/components/shell/AppShell.tsx\` — 「📓 對話日誌」 nav link after 對話速記

## Test plan
- [x] \`pnpm test\` — 9 new UT pass
- [x] \`pnpm test:coverage\` — branches 81.04% (above 80% gate); recap module 100% lines
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — no new warnings
- [x] \`pnpm format\` — clean
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\` — green; route table includes \`/recap\`
- [ ] Live smoke after merge: log via /log → reload /recap → confirm new entry shows under 「今天」 bucket

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)