### PR TITLE
feat(recap): ✨ AI 本週主題 — extract themes from /log entries

### DIFF
--- a/src/app/(app)/recap/actions.ts
+++ b/src/app/(app)/recap/actions.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import { z } from "zod";
+
+import { authedAction } from "@/lib/auth/safe-action";
+import { listRecentContactEventsForUser } from "@/db/cards";
+import { isCoachConfigured } from "@/lib/coach/llm";
+import { callRecapThemesLlm } from "@/lib/recap/themes-llm";
+import { themesCacheMarker } from "@/lib/recap/themes";
+import { readThemesCache, writeThemesCache } from "@/lib/recap/themes-store";
+
+export type RecapThemesResult =
+  | { ok: true; themes: string[]; cached: boolean }
+  | { ok: false; reason: "no-llm" | "no-items" | "llm-failed" };
+
+/**
+ * AI 本週主題 — extract 3-5 short themes from the user's recent /log
+ * entries. Cached at workspaces/{wid}/recap/themes; cache key includes
+ * an items-fingerprint marker so a new event invalidates it but a
+ * no-op page reload doesn't reburn the LLM call.
+ */
+export const getRecapThemesAction = authedAction
+  .inputSchema(
+    z.object({
+      sinceDays: z.number().int().min(1).max(60).default(14),
+      force: z.boolean().optional().default(false),
+    }),
+  )
+  .action(async ({ parsedInput, ctx }): Promise<RecapThemesResult> => {
+    if (!isCoachConfigured()) return { ok: false, reason: "no-llm" };
+    const items = await listRecentContactEventsForUser(ctx.user.uid, parsedInput.sinceDays);
+    if (items.length === 0) return { ok: false, reason: "no-items" };
+
+    const marker = themesCacheMarker(items);
+    const cacheKey = `v1::since=${parsedInput.sinceDays}::${marker}`;
+
+    if (!parsedInput.force) {
+      const cached = await readThemesCache(ctx.user.uid, cacheKey);
+      if (cached && cached.length > 0) {
+        return { ok: true, themes: cached, cached: true };
+      }
+    }
+
+    const themes = await callRecapThemesLlm(items);
+    if (!themes || themes.length === 0) return { ok: false, reason: "llm-failed" };
+    await writeThemesCache(ctx.user.uid, cacheKey, themes);
+    return { ok: true, themes, cached: false };
+  });

--- a/src/app/(app)/recap/page.tsx
+++ b/src/app/(app)/recap/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 
 import { RecapList } from "@/components/recap/RecapList";
+import { RecapThemesSection } from "@/components/recap/RecapThemesSection";
 import { listRecentContactEventsForUser } from "@/db/cards";
+import { isCoachConfigured } from "@/lib/coach/llm";
 import { readSession } from "@/lib/firebase/session";
 import { groupRecapByDay } from "@/lib/recap/group";
 
@@ -38,7 +40,10 @@ export default async function RecapPage() {
           </p>
         </section>
       ) : (
-        <RecapList groups={groups} />
+        <>
+          {isCoachConfigured() && items.length >= 2 && <RecapThemesSection />}
+          <RecapList groups={groups} />
+        </>
       )}
     </article>
   );

--- a/src/components/recap/RecapThemesSection.module.css
+++ b/src/components/recap/RecapThemesSection.module.css
@@ -1,0 +1,50 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 35%, var(--color-paper)) 0%,
+    var(--color-paper) 100%
+  );
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-md);
+}
+
+.label {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.placeholder {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.themeList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.themeChip {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-ink);
+}

--- a/src/components/recap/RecapThemesSection.tsx
+++ b/src/components/recap/RecapThemesSection.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getRecapThemesAction } from "@/app/(app)/recap/actions";
+
+import styles from "./RecapThemesSection.module.css";
+
+type State =
+  | { kind: "loading" }
+  | { kind: "ready"; themes: string[]; cached: boolean }
+  | { kind: "hidden" };
+
+/**
+ * Shows AI-extracted themes from the user's recent /log entries. Calls
+ * `getRecapThemesAction` on mount; degrades silently to a hidden render
+ * on any failure (no LLM key, zero items, parser failure). The point is
+ * to surface insight when available — not to clutter the page when not.
+ */
+export function RecapThemesSection() {
+  const [state, setState] = useState<State>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    void getRecapThemesAction({ sinceDays: 14 }).then((res) => {
+      if (cancelled) return;
+      if (!res?.data || !res.data.ok) {
+        setState({ kind: "hidden" });
+        return;
+      }
+      setState({ kind: "ready", themes: res.data.themes, cached: res.data.cached });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state.kind === "hidden") return null;
+
+  if (state.kind === "loading") {
+    return (
+      <section className={styles.section} aria-label="本週主題">
+        <p className={styles.label}>✨ 本週主題</p>
+        <p className={styles.placeholder}>AI 整理中…</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.section} aria-label="本週主題">
+      <p className={styles.label}>✨ 本週主題</p>
+      <ul className={styles.themeList}>
+        {state.themes.map((theme) => (
+          <li key={theme} className={styles.themeChip}>
+            {theme}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/lib/recap/__tests__/themes.test.ts
+++ b/src/lib/recap/__tests__/themes.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary, ContactEvent } from "@/db/cards";
+
+import type { RecapItem } from "../group";
+import { buildThemesMessages, parseThemes, themesCacheMarker } from "../themes";
+
+function aCard(over: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "card-x",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "陳玉涵",
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...over,
+  } as CardSummary;
+}
+
+function mkItem(at: Date, note: string, name?: string): RecapItem {
+  const event: ContactEvent = {
+    id: `e-${at.getTime()}`,
+    at,
+    note,
+    authorUid: "u",
+    authorDisplay: null,
+  };
+  return { card: aCard({ id: name || "x", nameZh: name }), event };
+}
+
+describe("buildThemesMessages", () => {
+  it("returns system + user messages with each item enumerated", () => {
+    const msgs = buildThemesMessages([
+      mkItem(new Date("2026-04-25"), "她公司在募 A 輪", "陳玉涵"),
+      mkItem(new Date("2026-04-24"), "demo day pitch deck", "Karen"),
+    ]);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.role).toBe("system");
+    expect(msgs[1]!.role).toBe("user");
+    expect(msgs[1]!.content).toContain("1. 跟 陳玉涵 聊：");
+    expect(msgs[1]!.content).toContain("2. 跟 Karen 聊：");
+    expect(msgs[1]!.content).toContain("demo day pitch deck");
+  });
+
+  it("falls back to （人 N） when card has no name", () => {
+    const item: RecapItem = {
+      card: aCard({ id: "no-name", nameZh: undefined, nameEn: undefined }),
+      event: {
+        id: "e",
+        at: new Date(),
+        note: "聊到 X",
+        authorUid: "u",
+        authorDisplay: null,
+      },
+    };
+    const msgs = buildThemesMessages([item]);
+    expect(msgs[1]!.content).toContain("（人 1）");
+  });
+});
+
+describe("parseThemes", () => {
+  it("parses a clean JSON array", () => {
+    const raw = JSON.stringify({ themes: ["AI 政策", "SaaS 估值", "demo day"] });
+    expect(parseThemes(raw)).toEqual(["AI 政策", "SaaS 估值", "demo day"]);
+  });
+
+  it("strips markdown json fence", () => {
+    const raw = "```json\n" + JSON.stringify({ themes: ["X"] }) + "\n```";
+    expect(parseThemes(raw)).toEqual(["X"]);
+  });
+
+  it("returns [] on malformed JSON", () => {
+    expect(parseThemes("not json")).toEqual([]);
+  });
+
+  it("returns [] on empty input", () => {
+    expect(parseThemes("")).toEqual([]);
+  });
+
+  it("returns [] when root is not an object", () => {
+    expect(parseThemes("[1,2,3]")).toEqual([]);
+    expect(parseThemes("42")).toEqual([]);
+  });
+
+  it("returns [] when themes field missing or not array", () => {
+    expect(parseThemes(JSON.stringify({ other: 1 }))).toEqual([]);
+    expect(parseThemes(JSON.stringify({ themes: "string" }))).toEqual([]);
+  });
+
+  it("drops non-string items", () => {
+    const raw = JSON.stringify({ themes: ["good", 42, null, "also-good"] });
+    expect(parseThemes(raw)).toEqual(["good", "also-good"]);
+  });
+
+  it("drops empty / whitespace-only items", () => {
+    const raw = JSON.stringify({ themes: ["", "  ", "good"] });
+    expect(parseThemes(raw)).toEqual(["good"]);
+  });
+
+  it("drops oversized items (>30 chars)", () => {
+    const longText = "x".repeat(50);
+    const raw = JSON.stringify({ themes: [longText, "ok"] });
+    expect(parseThemes(raw)).toEqual(["ok"]);
+  });
+
+  it("caps at 5 themes even if LLM returns more", () => {
+    const raw = JSON.stringify({ themes: ["a", "b", "c", "d", "e", "f", "g"] });
+    expect(parseThemes(raw)).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  it("trims surrounding whitespace from items", () => {
+    const raw = JSON.stringify({ themes: ["  spaced  ", "tight"] });
+    expect(parseThemes(raw)).toEqual(["spaced", "tight"]);
+  });
+});
+
+describe("themesCacheMarker", () => {
+  it("returns 'empty' for no items", () => {
+    expect(themesCacheMarker([])).toBe("empty");
+  });
+
+  it("includes count and max timestamp", () => {
+    const a = mkItem(new Date(2026, 3, 25, 9), "x");
+    const b = mkItem(new Date(2026, 3, 26, 9), "y");
+    const marker = themesCacheMarker([a, b]);
+    expect(marker).toContain("n=2");
+    expect(marker).toContain(`max=${b.event.at.getTime()}`);
+  });
+
+  it("changes when a new event arrives", () => {
+    const a = mkItem(new Date(2026, 3, 25), "x");
+    const before = themesCacheMarker([a]);
+    const b = mkItem(new Date(2026, 3, 26), "y");
+    const after = themesCacheMarker([a, b]);
+    expect(before).not.toBe(after);
+  });
+
+  it("stable for identical inputs (no LLM credit burn on reload)", () => {
+    const a = mkItem(new Date(2026, 3, 25), "x");
+    const m1 = themesCacheMarker([a]);
+    const m2 = themesCacheMarker([a]);
+    expect(m1).toBe(m2);
+  });
+});

--- a/src/lib/recap/themes-llm.ts
+++ b/src/lib/recap/themes-llm.ts
@@ -1,0 +1,55 @@
+import "server-only";
+
+import type { RecapItem } from "./group";
+import { buildThemesMessages, parseThemes } from "./themes";
+
+const DEFAULT_BASE_URL = "https://api.minimax.chat/v1";
+const DEFAULT_MODEL = "MiniMax-M2.7";
+const DEFAULT_TIMEOUT_MS = 12_000;
+
+interface MiniMaxChatResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+export async function callRecapThemesLlm(
+  items: readonly RecapItem[],
+  options: { timeoutMs?: number } = {},
+): Promise<string[] | null> {
+  const apiKey = process.env.MINIMAX_API_KEY ?? "";
+  if (!apiKey) return null;
+  if (items.length === 0) return [];
+
+  const baseUrl = process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = process.env.MINIMAX_MODEL ?? DEFAULT_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const body = {
+    model,
+    temperature: 0.4,
+    max_tokens: 400,
+    messages: buildThemesMessages(items),
+  };
+
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: abort.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as MiniMaxChatResponse;
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) return null;
+    return parseThemes(raw);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/recap/themes-store.ts
+++ b/src/lib/recap/themes-store.ts
@@ -1,0 +1,42 @@
+import "server-only";
+
+import { Timestamp } from "firebase-admin/firestore";
+
+import { getAdminFirestore } from "@/lib/firebase/server";
+import { COLLECTION_WORKSPACES, personalWorkspaceId } from "@/lib/firebase/shared";
+
+const RECAP_SUBCOLLECTION = "recap";
+const THEMES_DOC = "themes";
+
+interface CachedThemesDoc {
+  cacheKey: string;
+  themes: string[];
+  generatedAt: Timestamp;
+}
+
+export async function readThemesCache(uid: string, cacheKey: string): Promise<string[] | null> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${COLLECTION_WORKSPACES}/${wid}/${RECAP_SUBCOLLECTION}/${THEMES_DOC}`);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const data = snap.data() as CachedThemesDoc | undefined;
+  if (!data) return null;
+  if (data.cacheKey !== cacheKey) return null;
+  return data.themes;
+}
+
+export async function writeThemesCache(
+  uid: string,
+  cacheKey: string,
+  themes: string[],
+): Promise<void> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${COLLECTION_WORKSPACES}/${wid}/${RECAP_SUBCOLLECTION}/${THEMES_DOC}`);
+  await ref.set({
+    cacheKey,
+    themes,
+    generatedAt: Timestamp.now(),
+  });
+}

--- a/src/lib/recap/themes.ts
+++ b/src/lib/recap/themes.ts
@@ -1,0 +1,73 @@
+import type { RecapItem } from "./group";
+
+const SYSTEM_PROMPT =
+  "你是商務人脈本週主題抽取器。" +
+  "使用者最近 14 天的對話速記如下，每筆是一段你跟某人的對話內容。" +
+  "把這些對話的主題抽成 3 到 5 個短標籤（每個標籤 2-12 個中文字），讓 user 一眼看出自己最近在談什麼。\n" +
+  "回答必須是合法 JSON：\n" +
+  '{"themes": ["標籤一", "標籤二", "標籤三"]}\n' +
+  "規則：\n" +
+  "- 只回傳 JSON，不要 markdown 圍欄、不要任何說明文字。\n" +
+  "- themes 是 array of string。\n" +
+  "- 標籤要*具體*：「AI 政策」、「SaaS 估值」、「demo day」優於「商務」「科技」這種空泛詞。\n" +
+  "- 用繁體中文，避免 emoji。\n" +
+  "- 不要超過 5 個；少於 3 個對話時可以只回 1-2 個。";
+
+export function buildThemesMessages(
+  items: readonly RecapItem[],
+): Array<{ role: "system" | "user"; content: string }> {
+  const lines = items.map((it, i) => {
+    const name = it.card.nameZh || it.card.nameEn || `（人 ${i + 1}）`;
+    return `${i + 1}. 跟 ${name} 聊：${it.event.note}`;
+  });
+  return [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: lines.join("\n") },
+  ];
+}
+
+const MAX_THEMES = 5;
+const MAX_THEME_LEN = 30;
+const MIN_THEME_LEN = 1;
+
+/**
+ * Defensive parser. Drops empty/oversize/non-string entries; caps total
+ * count. Returns [] on any structural failure.
+ */
+export function parseThemes(raw: string): string[] {
+  if (!raw) return [];
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const inner = fenced ? fenced[1]! : trimmed;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(inner);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+  const themes = (parsed as { themes?: unknown }).themes;
+  if (!Array.isArray(themes)) return [];
+
+  const out: string[] = [];
+  for (const item of themes) {
+    if (typeof item !== "string") continue;
+    const value = item.trim();
+    if (value.length < MIN_THEME_LEN || value.length > MAX_THEME_LEN) continue;
+    out.push(value);
+    if (out.length >= MAX_THEMES) break;
+  }
+  return out;
+}
+
+/**
+ * Cache marker that flips whenever the underlying recap items change —
+ * either the list shrinks/grows or a new event timestamp pushes the
+ * latest forward. Stable across no-op page reloads so /recap doesn't
+ * burn LLM credits when nothing has changed since this morning.
+ */
+export function themesCacheMarker(items: readonly RecapItem[]): string {
+  if (items.length === 0) return "empty";
+  const maxAt = items.reduce((acc, it) => Math.max(acc, it.event.at?.getTime() ?? 0), 0);
+  return `n=${items.length}::max=${maxAt}`;
+}


### PR DESCRIPTION
## Summary
- **Surfaces the so-what.** /recap (PR #103) shows every logged conversation. /recap themes adds 3-5 short pills above the list — \"AI 政策 · SaaS 估值 · demo day\" — extracted by MiniMax from the actual notes.
- **Cost-controlled via fingerprint marker.** Items count + max event timestamp form a cache key. No new event = no LLM call. New event = exactly one regen. Active users typically pay one round-trip per day.
- **Hides silently on failure.** No LLM key, zero items, parser failure all degrade to a hidden render — no scary error banners on the recap page.

## Why now
After the 4-PR conversation loop (capture → log → briefing → recap), users can *see* their conversations but still have to read each note to spot patterns. Themes give them the summary view in one glance — important for business users tracking their own focus shifts week-to-week.

## Files
- \`src/lib/recap/themes.ts\` — pure: \`buildThemesMessages\`, \`parseThemes\` (defensive: 1-30 char len, dedup-via-cap, fence-stripped), \`themesCacheMarker\`
- \`src/lib/recap/themes-llm.ts\` — MiniMax client
- \`src/lib/recap/themes-store.ts\` — Firestore read/write at \`workspaces/{wid}/recap/themes\`
- \`src/app/(app)/recap/actions.ts\` — \`getRecapThemesAction({sinceDays, force?})\` with cache-hit/miss
- \`src/components/recap/RecapThemesSection.{tsx,module.css}\` — client component, mount fetch, loading placeholder, hide-on-fail
- \`src/app/(app)/recap/page.tsx\` — render the section when \`isCoachConfigured && items.length >= 2\`

## Test plan
- [x] \`pnpm test\` — 14 new UT pass (themes parser × 11, builder × 2, marker × 4 — actually 17 tests total in themes.test.ts)
- [x] \`pnpm test:coverage\` — branches 81.29% (above 80% gate)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — no new warnings
- [x] \`pnpm format\` — clean
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\` — green
- [ ] Live smoke after merge: /recap with 3+ logged events → expect themes pills appear; reload → expect cache hit (no second LLM round-trip)

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)