### PR TITLE
feat(coach): ✨ smart followup suggest — AI 建議下次聯絡日基於對話節奏

### DIFF
--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -40,6 +40,7 @@ import { callIntrosLlm } from "@/lib/coach/intros-llm";
 import { readIntrosCache, writeIntrosCache } from "@/lib/coach/intros-store";
 import { callCoachLlm, isCoachConfigured } from "@/lib/coach/llm";
 import { selectTodayPriorityCards, type PriorityCandidate } from "@/lib/coach/priority";
+import { suggestNextFollowupDate, type FollowupSuggestion } from "@/lib/coach/followup-suggest";
 import { reengageCacheKey, type ReengageContext, type ReengageDrafts } from "@/lib/coach/reengage";
 import { callReengageLlm } from "@/lib/coach/reengage-llm";
 import { readReengageCache, writeReengageCache } from "@/lib/coach/reengage-store";
@@ -631,3 +632,26 @@ export const touchCardAction = authedAction
     revalidatePath(`/cards/${parsedInput.id}`);
     return { ok: true as const };
   });
+
+/**
+ * ✨ Smart followup suggest — returns a date for the next ping based on
+ * the user's actual conversation cadence with this card. No LLM call;
+ * pure math over recent contact-events. Falls back to a default 30 days
+ * when there's not enough history to compute a rhythm.
+ */
+export const getFollowupSuggestionAction = authedAction
+  .inputSchema(z.object({ cardId: z.string().min(1) }))
+  .action(
+    async ({
+      parsedInput,
+      ctx,
+    }): Promise<
+      { ok: true; suggestion: FollowupSuggestion } | { ok: false; reason: "card-not-found" }
+    > => {
+      const card = await getCardForUser(ctx.user.uid, parsedInput.cardId);
+      if (!card || card.deletedAt) return { ok: false, reason: "card-not-found" };
+      const events = await listContactEventsForUser(card.id, ctx.user.uid, 10);
+      const suggestion = suggestNextFollowupDate(card, events, new Date());
+      return { ok: true, suggestion };
+    },
+  );

--- a/src/components/cards/CardActions.module.css
+++ b/src/components/cards/CardActions.module.css
@@ -176,6 +176,14 @@
   padding: var(--space-xs) var(--space-sm);
 }
 
+.hint {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  font-style: italic;
+  color: var(--color-ink-muted);
+  margin: var(--space-xs) 0 0;
+}
+
 .pickerWrap {
   position: relative;
   display: inline-block;

--- a/src/components/cards/CardActions.tsx
+++ b/src/components/cards/CardActions.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, useTransition } from "react";
 
 import {
   deleteCardAction,
+  getFollowupSuggestionAction,
   logContactAction,
   setFollowUpAction,
   toggleCardPinAction,
@@ -75,6 +76,20 @@ export function CardActions({
   const [noteDraft, setNoteDraft] = useState("");
   const [followUpOpen, setFollowUpOpen] = useState(false);
   const [followUpDraft, setFollowUpDraft] = useState(followUpAt ?? "");
+  const [suggestionHint, setSuggestionHint] = useState<string | null>(null);
+
+  const requestFollowupSuggestion = () => {
+    setSuggestionHint(null);
+    startTransition(async () => {
+      const res = await getFollowupSuggestionAction({ cardId });
+      if (!res?.data || !res.data.ok) {
+        setSuggestionHint("無法取得建議");
+        return;
+      }
+      setFollowUpDraft(res.data.suggestion.isoDate);
+      setSuggestionHint(res.data.suggestion.reasonZh);
+    });
+  };
 
   useEffect(() => {
     if (!toast) return;
@@ -353,6 +368,15 @@ export function CardActions({
               <button
                 type="button"
                 className={styles.secondary}
+                onClick={requestFollowupSuggestion}
+                disabled={pending}
+                title="根據對話節奏 AI 建議下次聯絡日"
+              >
+                ✨ AI 建議
+              </button>
+              <button
+                type="button"
+                className={styles.secondary}
                 onClick={() => submitFollowUp(followUpDraft || null)}
                 disabled={pending || !followUpDraft}
               >
@@ -369,6 +393,7 @@ export function CardActions({
                 </button>
               )}
             </div>
+            {suggestionHint && <p className={styles.hint}>{suggestionHint}</p>}
           </div>
         )}
         <button

--- a/src/lib/coach/__tests__/followup-suggest.test.ts
+++ b/src/lib/coach/__tests__/followup-suggest.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary, ContactEvent } from "@/db/cards";
+
+import { suggestNextFollowupDate } from "../followup-suggest";
+
+const NOW = new Date(2026, 3, 25, 12, 0, 0); // 2026-04-25 12:00 local
+
+function aCard(over: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "card-x",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "X",
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...over,
+  } as CardSummary;
+}
+
+function ev(at: Date, id?: string): ContactEvent {
+  return {
+    id: id ?? `e-${at.getTime()}`,
+    at,
+    note: "n",
+    authorUid: "u",
+    authorDisplay: null,
+  };
+}
+
+function dayOffset(base: Date, days: number): Date {
+  return new Date(base.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+describe("suggestNextFollowupDate", () => {
+  it("falls back to default 30 days when no events", () => {
+    const out = suggestNextFollowupDate(aCard(), [], NOW);
+    expect(out.basedOn).toBe("default");
+    expect(out.offsetDays).toBe(30);
+    expect(out.isoDate).toBe("2026-05-25");
+    expect(out.reasonZh).toContain("預設");
+  });
+
+  it("falls back to default with only one event (need >= 2 to compute gap)", () => {
+    const out = suggestNextFollowupDate(aCard(), [ev(dayOffset(NOW, -7))], NOW);
+    expect(out.basedOn).toBe("default");
+    expect(out.offsetDays).toBe(30);
+  });
+
+  it("uses median gap with 2 evenly spaced events", () => {
+    const events = [ev(dayOffset(NOW, -10)), ev(dayOffset(NOW, -30))];
+    const out = suggestNextFollowupDate(aCard(), events, NOW);
+    expect(out.basedOn).toBe("rhythm");
+    expect(out.offsetDays).toBe(20);
+    expect(out.reasonZh).toContain("20 天");
+  });
+
+  it("uses median (not mean) for irregular gaps", () => {
+    // Gaps (consecutive): 15, 15, 15, 145 days
+    // Median of [15, 15, 15, 145] = (15+15)/2 = 15
+    // Mean would be 47.5 — proves we picked median, not mean.
+    const events = [
+      ev(dayOffset(NOW, -10)),
+      ev(dayOffset(NOW, -25)),
+      ev(dayOffset(NOW, -40)),
+      ev(dayOffset(NOW, -55)),
+      ev(dayOffset(NOW, -200)),
+    ];
+    const out = suggestNextFollowupDate(aCard(), events, NOW);
+    expect(out.basedOn).toBe("rhythm");
+    expect(out.offsetDays).toBe(15);
+  });
+
+  it("clamps suggestion to MIN_OFFSET_DAYS (7) when median < 7", () => {
+    // Gap of 3 days → would suggest 3 → clamps to 7
+    const events = [ev(dayOffset(NOW, -3)), ev(dayOffset(NOW, -6))];
+    const out = suggestNextFollowupDate(aCard(), events, NOW);
+    expect(out.offsetDays).toBe(7);
+    expect(out.reasonZh).toContain("3 天");
+    expect(out.reasonZh).toContain("7 天後");
+  });
+
+  it("clamps suggestion to MAX_OFFSET_DAYS (180) when median > 180", () => {
+    const events = [ev(dayOffset(NOW, -200)), ev(dayOffset(NOW, -600))];
+    const out = suggestNextFollowupDate(aCard(), events, NOW);
+    expect(out.offsetDays).toBe(180);
+  });
+
+  it("ignores events with epoch / invalid at timestamps", () => {
+    const events = [ev(new Date(0)), ev(dayOffset(NOW, -10)), ev(dayOffset(NOW, -30))];
+    const out = suggestNextFollowupDate(aCard(), events, NOW);
+    expect(out.basedOn).toBe("rhythm");
+    expect(out.offsetDays).toBe(20);
+  });
+
+  it("returns valid YYYY-MM-DD format usable in <input type=date>", () => {
+    const out = suggestNextFollowupDate(aCard(), [], NOW);
+    expect(out.isoDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("falls back to default when all events collapse to zero gaps", () => {
+    // Same timestamp twice → no positive gap → no rhythm
+    const at = dayOffset(NOW, -10);
+    const events = [ev(at, "a"), ev(at, "b")];
+    const out = suggestNextFollowupDate(aCard(), events, NOW);
+    expect(out.basedOn).toBe("default");
+  });
+});

--- a/src/lib/coach/followup-suggest.ts
+++ b/src/lib/coach/followup-suggest.ts
@@ -1,0 +1,98 @@
+import type { CardSummary, ContactEvent } from "@/db/cards";
+
+export interface FollowupSuggestion {
+  /** YYYY-MM-DD; safe to drop straight into <input type="date">. */
+  isoDate: string;
+  /** Short human zh-Hant explanation for tooltip / aria-label. */
+  reasonZh: string;
+  /** Source of the cadence — lets the UI label it differently. */
+  basedOn: "rhythm" | "default";
+  /** Days from `now` that this suggestion lands on. UI may surface for context. */
+  offsetDays: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const DEFAULT_GAP_DAYS = 30;
+const MIN_OFFSET_DAYS = 7;
+const MAX_OFFSET_DAYS = 180;
+/** Need at least 2 valid events to compute a gap, so 2 is the minimum. */
+const MIN_EVENTS_FOR_RHYTHM = 2;
+
+function startOfLocalDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+function isoDay(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const da = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${da}`;
+}
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, value));
+}
+
+/**
+ * Median (not mean) of consecutive gaps — robust against the
+ * one-off-burst pattern (e.g. user hammered 3 conversations during a
+ * conference week, then nothing for a month).
+ */
+function medianGapDays(events: readonly ContactEvent[]): number | null {
+  // Filter to valid timestamps, sort newest first → walk pairs.
+  const sorted = events
+    .filter((e) => e.at && e.at.getTime() > 0)
+    .map((e) => e.at.getTime())
+    .sort((a, b) => b - a);
+  if (sorted.length < MIN_EVENTS_FOR_RHYTHM) return null;
+
+  const gaps: number[] = [];
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const ms = sorted[i]! - sorted[i + 1]!;
+    if (ms > 0) gaps.push(ms / MS_PER_DAY);
+  }
+  if (gaps.length === 0) return null;
+
+  gaps.sort((a, b) => a - b);
+  const mid = Math.floor(gaps.length / 2);
+  return gaps.length % 2 === 0 ? (gaps[mid - 1]! + gaps[mid]!) / 2 : gaps[mid]!;
+}
+
+/**
+ * Pure suggestion. No LLM, no I/O. Caller owns fetching the card +
+ * recent events; we just do the date math.
+ */
+export function suggestNextFollowupDate(
+  _card: Readonly<CardSummary>,
+  events: readonly ContactEvent[],
+  now: Date,
+): FollowupSuggestion {
+  const median = medianGapDays(events);
+
+  if (median === null) {
+    const offset = DEFAULT_GAP_DAYS;
+    const next = startOfLocalDay(new Date(now.getTime() + offset * MS_PER_DAY));
+    return {
+      isoDate: isoDay(next),
+      reasonZh: `預設每 ${offset} 天提醒一次（還沒有足夠的對話節奏資料）`,
+      basedOn: "default",
+      offsetDays: offset,
+    };
+  }
+
+  const rounded = Math.round(median);
+  const offset = clamp(rounded, MIN_OFFSET_DAYS, MAX_OFFSET_DAYS);
+  const next = startOfLocalDay(new Date(now.getTime() + offset * MS_PER_DAY));
+  const clamped = offset !== rounded;
+  const reasonZh = clamped
+    ? `你跟他平均每 ${rounded} 天聊一次，建議 ${offset} 天後（範圍 ${MIN_OFFSET_DAYS}–${MAX_OFFSET_DAYS} 天）`
+    : `你跟他平均每 ${offset} 天聊一次`;
+  return {
+    isoDate: isoDay(next),
+    reasonZh,
+    basedOn: "rhythm",
+    offsetDays: offset,
+  };
+}


### PR DESCRIPTION
## Summary
- **One-tap suggestion based on actual cadence.** Card detail's followup picker now has 「✨ AI 建議」 alongside +3/+7/+14. Click it → date input prefills with median-gap-based suggestion + a 1-line reason ("你跟他平均每 21 天聊一次").
- **Pure math, zero LLM cost.** Reads recent contact-events, computes median consecutive gap, clamps 7-180 days. The /log data finally pays back at the moment users actually decide when to ping next.
- **Median, not mean.** A burst of 3 conversations during a conference week shouldn\\'t pull the suggested cadence to "every 5 days". 9 UT lock the math.

## Why now
Followup-date setting is the single most-tapped action on the card detail page. Yet users have always done the math themselves: "三週還是兩週？". With /log accumulating cadence data and PR #103 surfacing it, this is the natural next click — turn that data into a one-tap default that the user can accept or override.

## Files
- \`src/lib/coach/followup-suggest.ts\` — pure: \`suggestNextFollowupDate(card, events, now)\` → \`{isoDate, reasonZh, basedOn, offsetDays}\`
- \`src/lib/coach/__tests__/followup-suggest.test.ts\` — 9 UT
- \`src/app/(app)/cards/actions.ts\` — \`getFollowupSuggestionAction({cardId})\` (no LLM)
- \`src/components/cards/CardActions.tsx\` — wires the new button + hint line
- \`src/components/cards/CardActions.module.css\` — \`.hint\` italic muted label

## Test plan
- [x] \`pnpm test\` — 9 new UT pass
- [x] \`pnpm test:coverage\` — branches 81.46% (above gate)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — no new warnings
- [x] \`pnpm format\` — clean
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\` — green
- [ ] Live smoke after merge: open card with 3+ events → 「📅 設定下次聯絡」 → 「✨ AI 建議」 → expect date input to prefill + italic hint to appear

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)