### PR TITLE
feat(cards): voice mic on card-detail 「記錄」 textarea

### DIFF
--- a/src/components/cards/CardActions.tsx
+++ b/src/components/cards/CardActions.tsx
@@ -14,6 +14,7 @@ import {
 import { shareCardVcard } from "@/lib/share/card-share";
 
 import styles from "./CardActions.module.css";
+import { VoiceMicButton } from "./VoiceMicButton";
 
 interface PhoneEntry {
   label: string;
@@ -267,6 +268,12 @@ export function CardActions({
             rows={2}
             autoFocus
             aria-label="互動備註（500 字以內）"
+          />
+          <VoiceMicButton
+            onFinalTranscript={(t) =>
+              setNoteDraft((prev) => (prev ? `${prev}${t}` : t).slice(0, 500))
+            }
+            disabled={pending}
           />
           <div className={styles.noteActions}>
             <button


### PR DESCRIPTION
## Summary
- Adds the existing \`VoiceMicButton\` to the in-card quick-log textarea so mobile users speak instead of type.
- 7-line wiring change. No new tests (VoiceMicButton is already covered by /log + /cards/voice tests).

## Why
Voice flow now exists at /log (PR #99) and /cards/voice (PR #97). The card-detail 「已聯絡 → 記錄」 disclosure was the last text-only input — completing voice-everywhere closes the mobile capture story.

## Test plan
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` — CardActions.test.tsx 20/20 still pass
- [x] \`pnpm test:coverage\` — branches 81.46% (above gate)
- [x] \`pnpm lint\` / \`pnpm format\` — clean
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open card detail → 「已聯絡」 → expect mic button below textarea → speak → text appends

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)