### PR TITLE
feat(cards): 💬 per-card AI Q&A — 問問這個人

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { CardActions } from "@/components/cards/CardActions";
+import { CardChatBox } from "@/components/cards/CardChatBox";
 import { CardInlineEdit } from "@/components/cards/CardInlineEdit";
 import { CoachInsightSection } from "@/components/cards/CoachInsightSection";
 import { ContactEventList } from "@/components/cards/ContactEventList";
@@ -237,6 +238,10 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
               <h2 className={styles.sectionTitle}>備註</h2>
               <p className={styles.notesBody}>{card.notes}</p>
             </section>
+          )}
+
+          {isCoachConfigured() && (
+            <CardChatBox cardId={card.id} displayName={card.nameZh || card.nameEn} />
           )}
 
           <ContactEventList events={contactEvents} />

--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -41,6 +41,7 @@ import { readIntrosCache, writeIntrosCache } from "@/lib/coach/intros-store";
 import { callCoachLlm, isCoachConfigured } from "@/lib/coach/llm";
 import { selectTodayPriorityCards, type PriorityCandidate } from "@/lib/coach/priority";
 import { suggestNextFollowupDate, type FollowupSuggestion } from "@/lib/coach/followup-suggest";
+import { callCardChatLlm } from "@/lib/coach/chat-llm";
 import { reengageCacheKey, type ReengageContext, type ReengageDrafts } from "@/lib/coach/reengage";
 import { callReengageLlm } from "@/lib/coach/reengage-llm";
 import { readReengageCache, writeReengageCache } from "@/lib/coach/reengage-store";
@@ -653,5 +654,37 @@ export const getFollowupSuggestionAction = authedAction
       const events = await listContactEventsForUser(card.id, ctx.user.uid, 10);
       const suggestion = suggestNextFollowupDate(card, events, new Date());
       return { ok: true, suggestion };
+    },
+  );
+
+/**
+ * 💬 Per-card AI Q&A — answer a free-form question about a contact
+ * grounded in their card + recent events. Single-shot (no multi-turn
+ * memory yet); cache disabled because questions are unique-per-call.
+ * The pure module enforces an anti-hallucination prompt; LLM is told
+ * to refuse when context is insufficient instead of guessing.
+ */
+export const askCardQuestionAction = authedAction
+  .inputSchema(
+    z.object({
+      cardId: z.string().min(1),
+      question: z.string().min(2).max(500),
+    }),
+  )
+  .action(
+    async ({
+      parsedInput,
+      ctx,
+    }): Promise<
+      | { ok: true; answer: string }
+      | { ok: false; reason: "no-llm" | "card-not-found" | "llm-failed" }
+    > => {
+      if (!isCoachConfigured()) return { ok: false, reason: "no-llm" };
+      const card = await getCardForUser(ctx.user.uid, parsedInput.cardId);
+      if (!card || card.deletedAt) return { ok: false, reason: "card-not-found" };
+      const events = await listContactEventsForUser(card.id, ctx.user.uid, 10);
+      const answer = await callCardChatLlm({ card, events }, parsedInput.question);
+      if (!answer) return { ok: false, reason: "llm-failed" };
+      return { ok: true, answer };
     },
   );

--- a/src/components/cards/CardChatBox.module.css
+++ b/src/components/cards/CardChatBox.module.css
@@ -1,0 +1,161 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 30%, var(--color-paper)) 0%,
+    var(--color-paper) 100%
+  );
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-md);
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  font-weight: 500;
+  margin: 0;
+  color: var(--color-ink);
+  letter-spacing: var(--tracking-tight);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.input {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  padding: var(--space-sm);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  resize: vertical;
+  min-height: 4rem;
+  outline: none;
+  line-height: var(--leading-relaxed);
+}
+
+.input:focus {
+  border-color: var(--color-accent-ink);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.askBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-lg);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.askBtn:hover:not(:disabled) {
+  background: var(--color-accent-ink);
+}
+
+.askBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.suggested {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.suggestedLabel {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+  margin: 0;
+}
+
+.suggestedList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.suggestedBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-ink);
+  cursor: pointer;
+}
+
+.suggestedBtn:hover:not(:disabled) {
+  border-color: var(--color-accent-ink);
+}
+
+.history {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.qa {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-paper);
+  border-left: 3px solid var(--color-accent-ink);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.q {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.a {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  margin: 0;
+  line-height: var(--leading-relaxed);
+  white-space: pre-wrap;
+}
+
+.thinking {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.err {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-error, #b00020);
+  margin: 0;
+}

--- a/src/components/cards/CardChatBox.tsx
+++ b/src/components/cards/CardChatBox.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { askCardQuestionAction } from "@/app/(app)/cards/actions";
+
+import styles from "./CardChatBox.module.css";
+
+interface CardChatBoxProps {
+  cardId: string;
+  /** Display name for the placeholder hint, e.g. "陳玉涵". */
+  displayName?: string;
+}
+
+interface QAPair {
+  q: string;
+  a: string | null;
+  err?: string;
+}
+
+const SUGGESTED_QUESTIONS = [
+  "上次他提到什麼重要的事？",
+  "他公司在做什麼？",
+  "下次見面該帶什麼話題？",
+  "我跟他關係深嗎？",
+];
+
+const MAX_HISTORY = 3;
+
+/**
+ * 💬 Free-form Q&A about this card. Single-shot per question — we
+ * don't carry conversation history into the LLM (each call sends only
+ * card + events as context). UI keeps the last 3 Q&A pairs visible so
+ * the user can scan; older ones scroll out of mind.
+ */
+export function CardChatBox({ cardId, displayName }: CardChatBoxProps) {
+  const [question, setQuestion] = useState("");
+  const [history, setHistory] = useState<QAPair[]>([]);
+  const [pending, startTransition] = useTransition();
+
+  const ask = (q: string) => {
+    const trimmed = q.trim();
+    if (!trimmed || trimmed.length < 2) return;
+    const pair: QAPair = { q: trimmed, a: null };
+    setHistory((prev) => [pair, ...prev].slice(0, MAX_HISTORY));
+    setQuestion("");
+    startTransition(async () => {
+      const res = await askCardQuestionAction({ cardId, question: trimmed });
+      setHistory((prev) =>
+        prev.map((p) => {
+          if (p !== pair) return p;
+          if (!res?.data) return { ...p, err: "送出失敗（網路）" };
+          if (!res.data.ok) {
+            const msg =
+              res.data.reason === "no-llm"
+                ? "AI 未啟用"
+                : res.data.reason === "card-not-found"
+                  ? "找不到卡片"
+                  : "AI 解析失敗，請換個問法";
+            return { ...p, err: msg };
+          }
+          return { ...p, a: res.data.answer };
+        }),
+      );
+    });
+  };
+
+  const placeholder = displayName ? `問問關於 ${displayName} 的任何事…` : "問問關於這個人的任何事…";
+
+  return (
+    <section className={styles.section} aria-label="問問 AI 這個人">
+      <h2 className={styles.title}>💬 問問 AI 這個人</h2>
+
+      <form
+        className={styles.form}
+        onSubmit={(e) => {
+          e.preventDefault();
+          ask(question);
+        }}
+      >
+        <textarea
+          className={styles.input}
+          value={question}
+          onChange={(e) => setQuestion(e.target.value.slice(0, 500))}
+          rows={2}
+          placeholder={placeholder}
+          maxLength={500}
+          disabled={pending}
+        />
+        <div className={styles.actions}>
+          <button
+            type="submit"
+            className={styles.askBtn}
+            disabled={pending || question.trim().length < 2}
+          >
+            {pending ? "AI 思考中…" : "問"}
+          </button>
+        </div>
+      </form>
+
+      {history.length === 0 && (
+        <div className={styles.suggested}>
+          <p className={styles.suggestedLabel}>試試問：</p>
+          <ul className={styles.suggestedList}>
+            {SUGGESTED_QUESTIONS.map((s) => (
+              <li key={s}>
+                <button
+                  type="button"
+                  className={styles.suggestedBtn}
+                  onClick={() => ask(s)}
+                  disabled={pending}
+                >
+                  {s}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {history.length > 0 && (
+        <ol className={styles.history}>
+          {history.map((p, i) => (
+            <li key={`${i}-${p.q}`} className={styles.qa}>
+              <p className={styles.q}>Q：{p.q}</p>
+              {p.err ? (
+                <p className={styles.err}>{p.err}</p>
+              ) : p.a === null ? (
+                <p className={styles.thinking}>思考中…</p>
+              ) : (
+                <p className={styles.a}>{p.a}</p>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/src/lib/coach/__tests__/chat.test.ts
+++ b/src/lib/coach/__tests__/chat.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary, ContactEvent } from "@/db/cards";
+
+import { buildChatMessages, parseChatAnswer, type CardChatContext } from "../chat";
+
+function aCard(over: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "card-x",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "陳玉涵",
+    whyRemember: "Computex 攤位聊邊緣 AI",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...over,
+  } as CardSummary;
+}
+
+function ev(at: Date, note: string, id?: string): ContactEvent {
+  return {
+    id: id ?? `e-${at.getTime()}`,
+    at,
+    note,
+    authorUid: "u",
+    authorDisplay: null,
+  };
+}
+
+describe("buildChatMessages", () => {
+  const ctx: CardChatContext = {
+    card: aCard({
+      jobTitleZh: "PM",
+      companyZh: "智威",
+      firstMetEventTag: "2024 COMPUTEX",
+    }),
+    events: [
+      ev(new Date(2026, 3, 20), "她公司在募 A 輪"),
+      ev(new Date(2026, 3, 10), "demo day pitch deck"),
+    ],
+  };
+
+  it("returns system + user messages", () => {
+    const msgs = buildChatMessages(ctx, "她公司做什麼？");
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.role).toBe("system");
+    expect(msgs[1]!.role).toBe("user");
+  });
+
+  it("system prompt forbids hallucination", () => {
+    const msgs = buildChatMessages(ctx, "x");
+    expect(msgs[0]!.content).toContain("不要編造");
+  });
+
+  it("user prompt includes card name + role + company + question", () => {
+    const msgs = buildChatMessages(ctx, "她公司做什麼？");
+    expect(msgs[1]!.content).toContain("陳玉涵");
+    expect(msgs[1]!.content).toContain("PM");
+    expect(msgs[1]!.content).toContain("智威");
+    expect(msgs[1]!.content).toContain("她公司做什麼？");
+  });
+
+  it("user prompt enumerates events with day prefix", () => {
+    const msgs = buildChatMessages(ctx, "x");
+    expect(msgs[1]!.content).toContain("- 2026-04-20: 她公司在募 A 輪");
+    expect(msgs[1]!.content).toContain("- 2026-04-10: demo day pitch deck");
+  });
+
+  it("renders a placeholder when no events", () => {
+    const msgs = buildChatMessages({ card: ctx.card, events: [] }, "x");
+    expect(msgs[1]!.content).toContain("還沒有 log 任何對話");
+  });
+
+  it("drops events with epoch / invalid at", () => {
+    const messy: CardChatContext = {
+      card: ctx.card,
+      events: [ev(new Date(0), "skip me"), ev(new Date(2026, 3, 25), "keep me")],
+    };
+    const msgs = buildChatMessages(messy, "x");
+    expect(msgs[1]!.content).not.toContain("skip me");
+    expect(msgs[1]!.content).toContain("keep me");
+  });
+
+  it("includes lastContactedAt when present", () => {
+    const ctx2: CardChatContext = {
+      card: aCard({ lastContactedAt: new Date(2026, 3, 25) }),
+      events: [],
+    };
+    const msgs = buildChatMessages(ctx2, "x");
+    expect(msgs[1]!.content).toContain("上次互動: 2026-04-25");
+  });
+
+  it("trims whitespace from question", () => {
+    const msgs = buildChatMessages(ctx, "   有趣的問題   ");
+    expect(msgs[1]!.content).toContain("=== 問題 ===\n有趣的問題");
+  });
+
+  it("falls back to nameEn when nameZh missing", () => {
+    const msgs = buildChatMessages(
+      { card: aCard({ nameZh: undefined, nameEn: "Alice Chen" }), events: [] },
+      "x",
+    );
+    expect(msgs[1]!.content).toContain("姓名: Alice Chen");
+  });
+});
+
+describe("parseChatAnswer", () => {
+  it("returns trimmed string for clean input", () => {
+    expect(parseChatAnswer("   她公司在募 A 輪   ")).toBe("她公司在募 A 輪");
+  });
+
+  it("strips markdown fence", () => {
+    expect(parseChatAnswer("```\nhello\n```")).toBe("hello");
+    expect(parseChatAnswer("```text\nhello\n```")).toBe("hello");
+  });
+
+  it("returns empty string for empty / whitespace-only", () => {
+    expect(parseChatAnswer("")).toBe("");
+    expect(parseChatAnswer("   ")).toBe("");
+  });
+
+  it("returns empty string for non-string input", () => {
+    // @ts-expect-error testing runtime guard
+    expect(parseChatAnswer(undefined)).toBe("");
+    // @ts-expect-error testing runtime guard
+    expect(parseChatAnswer(null)).toBe("");
+    // @ts-expect-error testing runtime guard
+    expect(parseChatAnswer(42)).toBe("");
+  });
+
+  it("clamps long answers at 1500 chars", () => {
+    const long = "x".repeat(3000);
+    expect(parseChatAnswer(long).length).toBe(1500);
+  });
+});

--- a/src/lib/coach/chat-llm.ts
+++ b/src/lib/coach/chat-llm.ts
@@ -1,0 +1,57 @@
+import "server-only";
+
+import { buildChatMessages, parseChatAnswer, type CardChatContext } from "./chat";
+
+const DEFAULT_BASE_URL = "https://api.minimax.chat/v1";
+const DEFAULT_MODEL = "MiniMax-M2.7";
+const DEFAULT_TIMEOUT_MS = 12_000;
+
+interface MiniMaxChatResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+export async function callCardChatLlm(
+  ctx: CardChatContext,
+  question: string,
+  options: { timeoutMs?: number } = {},
+): Promise<string | null> {
+  const apiKey = process.env.MINIMAX_API_KEY ?? "";
+  if (!apiKey) return null;
+  const trimmed = question.trim();
+  if (!trimmed) return null;
+
+  const baseUrl = process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = process.env.MINIMAX_MODEL ?? DEFAULT_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const body = {
+    model,
+    temperature: 0.3,
+    max_tokens: 600,
+    messages: buildChatMessages(ctx, trimmed),
+  };
+
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: abort.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as MiniMaxChatResponse;
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) return null;
+    const parsed = parseChatAnswer(raw);
+    return parsed || null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/coach/chat.ts
+++ b/src/lib/coach/chat.ts
@@ -1,0 +1,91 @@
+import type { CardSummary, ContactEvent } from "@/db/cards";
+
+const SYSTEM_PROMPT =
+  "你是一個個人關係助理。" +
+  "使用者會問你關於某位聯絡人的問題，你只能根據以下提供的卡片資料 + 對話紀錄回答。" +
+  "嚴格規則：\n" +
+  "- 只用提供的 context 回答；context 沒寫的事不要編造、不要推測該人的私生活/政治立場/八卦。\n" +
+  "- 如果 context 不足以回答，就直接說「資料中沒有提到」+ 建議下一步可問什麼。\n" +
+  "- 用繁體中文，1-3 句話內回完，避免冗長。\n" +
+  "- 不要 markdown 標題、不要 bullet、不要圍欄；純文字段落。\n" +
+  "- 回答前先確認問題是不是真的關於這個人；若不是，禮貌地請使用者把問題聚焦回這個人。";
+
+export interface CardChatContext {
+  card: CardSummary;
+  events: readonly ContactEvent[];
+}
+
+function pickName(card: CardSummary): string {
+  return card.nameZh || card.nameEn || "（未命名）";
+}
+
+function isoDate(d: Date | null | undefined): string | null {
+  if (!d || d.getTime() <= 0) return null;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const da = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${da}`;
+}
+
+export function buildChatMessages(
+  ctx: CardChatContext,
+  question: string,
+): Array<{ role: "system" | "user"; content: string }> {
+  const card = ctx.card;
+  const lines: string[] = [];
+
+  lines.push("=== 聯絡人卡片 ===");
+  lines.push(`姓名: ${pickName(card)}`);
+  if (card.nameEn && card.nameZh) lines.push(`英文名: ${card.nameEn}`);
+  const role = card.jobTitleZh || card.jobTitleEn;
+  if (role) lines.push(`職稱: ${role}`);
+  const company = card.companyZh || card.companyEn;
+  if (company) lines.push(`公司: ${company}`);
+  if (card.department) lines.push(`部門: ${card.department}`);
+  if (card.firstMetEventTag) lines.push(`認識場合: ${card.firstMetEventTag}`);
+  if (card.firstMetDate) lines.push(`首次見面: ${card.firstMetDate}`);
+  if (card.firstMetContext) lines.push(`認識情境: ${card.firstMetContext}`);
+  lines.push(`為什麼記得: ${card.whyRemember}`);
+  if (card.notes) lines.push(`備註: ${card.notes}`);
+  const last = isoDate(card.lastContactedAt);
+  if (last) lines.push(`上次互動: ${last}`);
+
+  if (ctx.events.length > 0) {
+    lines.push("");
+    lines.push(`=== 最近對話紀錄（最新在前，共 ${ctx.events.length} 筆）===`);
+    for (const e of ctx.events) {
+      const day = isoDate(e.at);
+      if (!day) continue;
+      const note = e.note?.trim() || "（無備註）";
+      lines.push(`- ${day}: ${note}`);
+    }
+  } else {
+    lines.push("");
+    lines.push("=== 最近對話紀錄 ===\n（還沒有 log 任何對話）");
+  }
+
+  lines.push("");
+  lines.push("=== 問題 ===");
+  lines.push(question.trim());
+
+  return [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: lines.join("\n") },
+  ];
+}
+
+const MAX_ANSWER_LEN = 1500;
+
+/**
+ * Permissive parser. The chat reply isn't structured JSON — it's free
+ * prose. We strip stray markdown fences (some models still wrap), trim,
+ * and clamp. Returns "" on empty / non-string so callers can branch.
+ */
+export function parseChatAnswer(raw: string): string {
+  if (typeof raw !== "string") return "";
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  const fenced = trimmed.match(/^```(?:\w*)?\s*([\s\S]*?)\s*```$/);
+  const inner = fenced ? fenced[1]!.trim() : trimmed;
+  return inner.slice(0, MAX_ANSWER_LEN);
+}


### PR DESCRIPTION
## Summary
- **Card detail becomes conversational.** New \`<CardChatBox>\` lets users ask free-form questions about a contact ("what did she say about pricing?", "what should I bring up next time?"). Answers are grounded in the card + last 10 events.
- **Anti-hallucination by construction.** SYSTEM_PROMPT explicitly forbids inventing details and instructs the LLM to say "資料中沒有提到" when context is insufficient. The pure module wraps every event with a date prefix so the model can cite when something was said.
- **No persistence yet.** Single-shot Q&A — each call sends only card + events as fresh context. UI keeps the latest 3 pairs visible; older ones scroll out.

## Why this slice now
After the conversation-loop work (PR #97 → #109), a card has rich data — recent events, cadence rhythm, AI insights. But every existing surface is *preset*: pick this contact today, suggest this date, generate this draft. Q&A is the first surface where users can ask anything. It compresses the "scan events list manually" pattern into one query.

## Subtle fix landed in this PR
\`isoDate\` for prompt building switched from \`.toISOString().slice(0, 10)\` (UTC) to a local-component formatter — otherwise a Taipei user logging "今天" would see the prompt say a date one day off. Caught by tests running locally vs CI.

## Files
- \`src/lib/coach/chat.ts\` — pure: \`buildChatMessages\`, \`parseChatAnswer\` (defensive: fence-strip, clamp, empty-on-non-string)
- \`src/lib/coach/chat-llm.ts\` — MiniMax client (600 max_tokens, 0.3 temp)
- \`src/app/(app)/cards/actions.ts\` — \`askCardQuestionAction({cardId, question})\`
- \`src/components/cards/CardChatBox.{tsx,module.css}\` — input + suggested chips + 3-pair history
- \`src/app/(app)/cards/[id]/page.tsx\` — wires section between notes and ContactEventList when LLM configured

## Test plan
- [x] \`pnpm test\` — 14 new UT in chat.test.ts
- [x] \`pnpm test:coverage\` — branches 81.52% (above gate)
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open card with 3+ events → \`💬 問問 AI 這個人\` appears → ask preset question → answer references events; ask "what about her hobbies?" (not in context) → expect "資料中沒有提到"

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)