### PR TITLE
feat(recap): 🔍 search filter on /recap

### DIFF
--- a/src/app/(app)/recap/page.tsx
+++ b/src/app/(app)/recap/page.tsx
@@ -1,11 +1,10 @@
 import Link from "next/link";
 
-import { RecapList } from "@/components/recap/RecapList";
+import { RecapBrowser } from "@/components/recap/RecapBrowser";
 import { RecapThemesSection } from "@/components/recap/RecapThemesSection";
 import { listRecentContactEventsForUser } from "@/db/cards";
 import { isCoachConfigured } from "@/lib/coach/llm";
 import { readSession } from "@/lib/firebase/session";
-import { groupRecapByDay } from "@/lib/recap/group";
 
 import styles from "./recap.module.css";
 
@@ -18,7 +17,6 @@ export default async function RecapPage() {
   if (!user) return null;
 
   const items = await listRecentContactEventsForUser(user.uid, 14);
-  const groups = groupRecapByDay(items, new Date());
 
   return (
     <article className={styles.article}>
@@ -32,7 +30,7 @@ export default async function RecapPage() {
         </p>
       </header>
 
-      {groups.length === 0 ? (
+      {items.length === 0 ? (
         <section className={styles.empty}>
           <p className={styles.emptyLead}>
             還沒有任何對話記錄。剛跟人聊完？去
@@ -42,7 +40,7 @@ export default async function RecapPage() {
       ) : (
         <>
           {isCoachConfigured() && items.length >= 2 && <RecapThemesSection />}
-          <RecapList groups={groups} />
+          <RecapBrowser items={items} />
         </>
       )}
     </article>

--- a/src/components/recap/RecapBrowser.module.css
+++ b/src/components/recap/RecapBrowser.module.css
@@ -1,0 +1,45 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.searchRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.input {
+  flex: 1;
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  padding: var(--space-sm) var(--space-md);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--color-accent-ink);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--color-accent-ink) 25%, transparent);
+}
+
+.count {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+  white-space: nowrap;
+}
+
+.empty {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-ink-muted);
+  text-align: center;
+  padding: var(--space-xl) var(--space-md);
+  margin: 0;
+}

--- a/src/components/recap/RecapBrowser.tsx
+++ b/src/components/recap/RecapBrowser.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { groupRecapByDay, type RecapItem } from "@/lib/recap/group";
+import { filterRecapItems } from "@/lib/recap/search";
+
+import { RecapList } from "./RecapList";
+import styles from "./RecapBrowser.module.css";
+
+interface RecapBrowserProps {
+  items: RecapItem[];
+}
+
+/**
+ * Client wrapper that lets the user filter the server-loaded recap
+ * items by free-text query. Re-runs `groupRecapByDay` on the filtered
+ * subset so the day labels update naturally as items disappear.
+ *
+ * Re-creates a fresh `now` per render so that long-lived sessions get
+ * accurate "今天 / 昨天" labels without needing a server refresh — the
+ * cost is negligible since groupRecapByDay is pure and small.
+ */
+export function RecapBrowser({ items }: RecapBrowserProps) {
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => filterRecapItems(items, query), [items, query]);
+  const groups = useMemo(() => groupRecapByDay(filtered, new Date()), [filtered]);
+
+  const hasQuery = query.trim().length > 0;
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.searchRow}>
+        <input
+          type="search"
+          className={styles.input}
+          placeholder="🔍 搜尋對話 — 試試「SaaS」、「陳玉涵」、「demo day」"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label="搜尋對話內容、人名、公司"
+        />
+        {hasQuery && <span className={styles.count}>{filtered.length} 筆</span>}
+      </div>
+
+      {hasQuery && filtered.length === 0 ? (
+        <p className={styles.empty}>找不到符合「{query.trim()}」的對話 — 試試別的關鍵字。</p>
+      ) : (
+        <RecapList groups={groups} />
+      )}
+    </div>
+  );
+}

--- a/src/lib/recap/__tests__/search.test.ts
+++ b/src/lib/recap/__tests__/search.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary, ContactEvent } from "@/db/cards";
+
+import type { RecapItem } from "../group";
+import { filterRecapItems } from "../search";
+
+function aCard(over: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "card-x",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "陳玉涵",
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...over,
+  } as CardSummary;
+}
+
+function mkItem(card: CardSummary, note: string): RecapItem {
+  const event: ContactEvent = {
+    id: `e-${Math.random()}`,
+    at: new Date(),
+    note,
+    authorUid: "u",
+    authorDisplay: null,
+  };
+  return { card, event };
+}
+
+describe("filterRecapItems", () => {
+  const items: RecapItem[] = [
+    mkItem(
+      aCard({ id: "a", nameZh: "陳玉涵", companyZh: "智威科技" }),
+      "她公司在募 A 輪、看 SaaS 估值",
+    ),
+    mkItem(
+      aCard({ id: "b", nameZh: "李大同", nameEn: "Tom Lee", companyEn: "GreenLeaf" }),
+      "demo day pitch deck 第 5 頁",
+    ),
+    mkItem(
+      aCard({ id: "c", nameZh: "王小明", jobTitleZh: "CTO", companyZh: "Pixel" }),
+      "OEM 合約細節討論",
+    ),
+  ];
+
+  it("returns full list when query is empty", () => {
+    expect(filterRecapItems(items, "")).toHaveLength(3);
+    expect(filterRecapItems(items, "   ")).toHaveLength(3);
+  });
+
+  it("filters by event note (substring)", () => {
+    const result = filterRecapItems(items, "SaaS");
+    expect(result.map((i) => i.card.id)).toEqual(["a"]);
+  });
+
+  it("is case-insensitive on English fields", () => {
+    expect(filterRecapItems(items, "saas").map((i) => i.card.id)).toEqual(["a"]);
+    expect(filterRecapItems(items, "SAAS").map((i) => i.card.id)).toEqual(["a"]);
+  });
+
+  it("matches by Chinese name", () => {
+    const result = filterRecapItems(items, "陳玉涵");
+    expect(result.map((i) => i.card.id)).toEqual(["a"]);
+  });
+
+  it("matches by English name", () => {
+    const result = filterRecapItems(items, "Tom");
+    expect(result.map((i) => i.card.id)).toEqual(["b"]);
+  });
+
+  it("matches by company (zh)", () => {
+    const result = filterRecapItems(items, "智威");
+    expect(result.map((i) => i.card.id)).toEqual(["a"]);
+  });
+
+  it("matches by company (en)", () => {
+    const result = filterRecapItems(items, "greenleaf");
+    expect(result.map((i) => i.card.id)).toEqual(["b"]);
+  });
+
+  it("matches by job title", () => {
+    const result = filterRecapItems(items, "CTO");
+    expect(result.map((i) => i.card.id)).toEqual(["c"]);
+  });
+
+  it("returns empty array when nothing matches", () => {
+    expect(filterRecapItems(items, "完全不存在的關鍵字")).toEqual([]);
+  });
+
+  it("returns multiple items when query matches multiple", () => {
+    // "公司" matches "智威科技" no, but matches event notes mentioning "公司"
+    const items2: RecapItem[] = [
+      mkItem(aCard({ id: "x" }), "公司 A"),
+      mkItem(aCard({ id: "y" }), "公司 B"),
+      mkItem(aCard({ id: "z" }), "個人事務"),
+    ];
+    expect(filterRecapItems(items2, "公司").map((i) => i.card.id)).toEqual(["x", "y"]);
+  });
+
+  it("preserves caller's input order", () => {
+    expect(filterRecapItems(items, "").map((i) => i.card.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("trims whitespace in query", () => {
+    expect(filterRecapItems(items, "  SaaS  ").map((i) => i.card.id)).toEqual(["a"]);
+  });
+
+  it("doesn't crash when card fields are undefined", () => {
+    const sparse: RecapItem[] = [
+      mkItem(aCard({ id: "sparse", nameZh: undefined, nameEn: undefined }), "X"),
+    ];
+    expect(filterRecapItems(sparse, "X").map((i) => i.card.id)).toEqual(["sparse"]);
+  });
+});

--- a/src/lib/recap/search.ts
+++ b/src/lib/recap/search.ts
@@ -1,0 +1,33 @@
+import type { RecapItem } from "./group";
+
+/**
+ * Pure in-memory filter over already-loaded recap items. Case-insensitive
+ * substring match across event note + card name + company. Empty query
+ * returns the input list as-is (no filtering). Whitespace-trimmed.
+ *
+ * Designed as a stop-gap before a real full-text index — covers the
+ * 90% use case ("find the one where I talked about X") without
+ * touching Typesense or adding new I/O.
+ */
+export function filterRecapItems(items: readonly RecapItem[], query: string): RecapItem[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [...items];
+
+  return items.filter((item) => {
+    const haystacks = [
+      item.event.note,
+      item.card.nameZh,
+      item.card.nameEn,
+      item.card.companyZh,
+      item.card.companyEn,
+      item.card.jobTitleZh,
+      item.card.jobTitleEn,
+      item.card.firstMetEventTag,
+    ];
+    for (const field of haystacks) {
+      if (typeof field !== "string") continue;
+      if (field.toLowerCase().includes(needle)) return true;
+    }
+    return false;
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a client-side search input on /recap that filters the already-loaded 14-day window in real time.
- Matches across event note + card name + company + job title + first-met event tag, case-insensitively.
- No new I/O, no Typesense touch. Covers the 90% \"find the one where I talked about X\" case immediately; full-text index over older history can come later without changing this UX.

## Why
After /recap (PR #103) accumulates conversations, scroll fatigue kicks in fast. A search input is the obvious next move — and shipping it as a pure in-memory predicate over the server-loaded items keeps the slice tight.

## Files
- \`src/lib/recap/search.ts\` — pure \`filterRecapItems(items, query)\`
- \`src/lib/recap/__tests__/search.test.ts\` — 13 UT
- \`src/components/recap/RecapBrowser.{tsx,module.css}\` — client wrapper: input + result count + empty-state + re-grouping
- \`src/app/(app)/recap/page.tsx\` — swap \`<RecapList>\` for \`<RecapBrowser items={items}>\`

## Test plan
- [x] \`pnpm test\` — 13 new UT
- [x] \`pnpm test:coverage\` — branches 81.59% (above gate)
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: /recap → type "SaaS" → expect filtered list, "X 筆" badge updates; clear → all back

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)