### PR TITLE
fix(pwa): manifest must honor NAMECARD_BASE_PATH

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,6 +26,10 @@ const inter = Inter({
   display: "swap",
 });
 
+// Same basePath the manifest itself reads — links here must resolve
+// under the deploy prefix or installed PWAs land on the wrong host.
+const BASE = process.env.NAMECARD_BASE_PATH ?? "";
+
 export const metadata: Metadata = {
   title: {
     default: "Namecard Web",
@@ -34,7 +38,7 @@ export const metadata: Metadata = {
   description: "個人工作名片管理網站 — 以關係脈絡為核心",
   applicationName: "Namecard Web",
   authors: [{ name: "cct08311github" }],
-  manifest: "/manifest.webmanifest",
+  manifest: `${BASE}/manifest.webmanifest`,
   appleWebApp: {
     capable: true,
     title: "Namecard",

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,12 +1,23 @@
 import type { MetadataRoute } from "next";
 
+/**
+ * `start_url`, `scope`, and `icons[].src` must include the deploy
+ * basePath. Otherwise an installed PWA opened from the home screen
+ * navigates to "/" of the host (a different service) instead of the
+ * namecard app at "/namecard-web/".
+ *
+ * Read NAMECARD_BASE_PATH at build time (same env that next.config.ts
+ * uses for `basePath`). Empty in dev, "/namecard-web" in production.
+ */
+const BASE = process.env.NAMECARD_BASE_PATH ?? "";
+
 export default function manifest(): MetadataRoute.Manifest {
   return {
     name: "Namecard Web",
     short_name: "Namecard",
     description: "個人工作名片管理 — 以關係脈絡為核心",
-    start_url: "/",
-    scope: "/",
+    start_url: `${BASE}/`,
+    scope: `${BASE}/`,
     display: "standalone",
     orientation: "portrait",
     background_color: "#fbf9f4",
@@ -14,13 +25,13 @@ export default function manifest(): MetadataRoute.Manifest {
     lang: "zh-Hant",
     icons: [
       {
-        src: "/icon",
+        src: `${BASE}/icon`,
         sizes: "512x512",
         type: "image/png",
         purpose: "any",
       },
       {
-        src: "/apple-icon",
+        src: `${BASE}/apple-icon`,
         sizes: "180x180",
         type: "image/png",
         purpose: "maskable",


### PR DESCRIPTION
## Bug
Prod runs at \`/namecard-web\` but manifest had \`start_url: "/"\` hardcoded → installed PWAs on iPhone home screen opened the wrong host root.

## Fix
- \`src/app/manifest.ts\`: prefix \`start_url\`, \`scope\`, and \`icons[].src\` with \`process.env.NAMECARD_BASE_PATH\`
- \`src/app/layout.tsx\`: same prefix for \`metadata.manifest\` link href (Next.js does not auto-apply basePath to that attribute)

## Verified
Built manifest at \`.next/server/app/manifest.webmanifest.body\` now emits:
\`\`\`json
{"start_url":"/namecard-web/","scope":"/namecard-web/","icons":[{"src":"/namecard-web/icon",...}]}
\`\`\`

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 81.59% (above gate)
- [x] \`pnpm build\` (with NAMECARD_BASE_PATH) — emitted manifest contains the prefix
- [ ] Live smoke after merge: fetch \`https://mac-mini.tailde842d.ts.net/namecard-web/manifest.webmanifest\` → start_url is \`/namecard-web/\`
- [ ] iPhone "Add to Home Screen" → tap icon → loads app (not host root)

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)