### PR TITLE
feat(shell): 📱 mobile FAB + quick action sheet

### DIFF
--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -6,6 +6,7 @@ import type { SessionUser } from "@/lib/firebase/session";
 
 import styles from "./AppShell.module.css";
 import { GlobalShortcuts } from "./GlobalShortcuts";
+import { MobileFab } from "./MobileFab";
 import { MobileNavWrapper } from "./MobileNavWrapper";
 
 interface NavItem {
@@ -88,6 +89,7 @@ export function AppShell({ user, children }: AppShellProps) {
         </aside>
       </MobileNavWrapper>
       <main className={styles.main}>{children}</main>
+      <MobileFab />
       <GlobalShortcuts />
     </div>
   );

--- a/src/components/shell/GlobalShortcuts.tsx
+++ b/src/components/shell/GlobalShortcuts.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { matchKeyEvent } from "@/lib/shortcuts/match";
 
 import styles from "./GlobalShortcuts.module.css";
+import { OPEN_SEARCH_EVENT } from "./MobileFab";
 import { QuickSearchPalette } from "./QuickSearchPalette";
 
 /**
@@ -87,8 +88,13 @@ export function GlobalShortcuts() {
     };
 
     window.addEventListener("keydown", handler);
+    // Bridge for the MobileFab "🔍 找人" action — lets the FAB open the
+    // palette without lifting palette state into AppShell.
+    const openSearch = () => setPaletteOpen(true);
+    window.addEventListener(OPEN_SEARCH_EVENT, openSearch);
     return () => {
       window.removeEventListener("keydown", handler);
+      window.removeEventListener(OPEN_SEARCH_EVENT, openSearch);
       if (timerRef.current) clearTimeout(timerRef.current);
     };
   }, [helpOpen, paletteOpen, router]);

--- a/src/components/shell/MobileFab.module.css
+++ b/src/components/shell/MobileFab.module.css
@@ -1,0 +1,99 @@
+.root {
+  /* Mobile-only — desktop already has the rail. */
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .root {
+    display: block;
+  }
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  background: color-mix(in oklch, var(--color-ink) 25%, transparent);
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.sheet {
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom, 0) + 5.5rem);
+  right: calc(env(safe-area-inset-right, 0) + 1rem);
+  z-index: 80;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-sm);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  min-width: 12rem;
+}
+
+.action {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-decoration: none;
+  text-align: left;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.action:hover,
+.action:focus-visible {
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 35%,
+    var(--color-paper)
+  );
+  outline: none;
+}
+
+.fab,
+.fabOpen {
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom, 0) + 1rem);
+  right: calc(env(safe-area-inset-right, 0) + 1rem);
+  z-index: 80;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border: none;
+  font-size: 1.6rem;
+  font-weight: 400;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    transform var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.fab:hover,
+.fab:focus-visible,
+.fabOpen:hover,
+.fabOpen:focus-visible {
+  background: var(--color-accent-ink);
+  transform: scale(1.04);
+  outline: none;
+}
+
+.fabOpen {
+  background: var(--color-accent-ink);
+}

--- a/src/components/shell/MobileFab.tsx
+++ b/src/components/shell/MobileFab.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+
+import styles from "./MobileFab.module.css";
+
+/**
+ * Custom event used by the FAB's "🔍 找人" action to ask `GlobalShortcuts`
+ * to open the QuickSearchPalette without lifting state into AppShell.
+ * Listener registered in GlobalShortcuts.
+ */
+export const OPEN_SEARCH_EVENT = "namecard:openSearch";
+
+/**
+ * Mobile-only floating action button. Defaults to a single ⊕ glyph in
+ * the bottom-right; tap toggles a small action sheet with the three
+ * highest-frequency captures (對話速記, 語音建卡, 找人). Backdrop click
+ * + Esc both close. Hidden on ≥769px via media query in the .css module.
+ */
+export function MobileFab() {
+  const [open, setOpen] = useState(false);
+  const sheetRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const handleSearch = () => {
+    setOpen(false);
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent(OPEN_SEARCH_EVENT));
+    }
+  };
+
+  return (
+    <div className={styles.root}>
+      {open && (
+        <button
+          type="button"
+          className={styles.backdrop}
+          onClick={() => setOpen(false)}
+          aria-label="關閉快速動作"
+        />
+      )}
+      {open && (
+        <div ref={sheetRef} className={styles.sheet} role="menu" aria-label="快速動作">
+          <Link
+            href="/log"
+            className={styles.action}
+            role="menuitem"
+            onClick={() => setOpen(false)}
+          >
+            🗣️ 對話速記
+          </Link>
+          <Link
+            href="/cards/voice"
+            className={styles.action}
+            role="menuitem"
+            onClick={() => setOpen(false)}
+          >
+            🎙️ 語音建卡
+          </Link>
+          <button type="button" className={styles.action} role="menuitem" onClick={handleSearch}>
+            🔍 找人
+          </button>
+        </div>
+      )}
+      <button
+        type="button"
+        className={open ? styles.fabOpen : styles.fab}
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-label={open ? "關閉快速動作" : "打開快速動作"}
+      >
+        {open ? "×" : "⊕"}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Mobile-only floating ⊕ button bottom-right (hidden ≥769px). Tap → mini action sheet with the 3 highest-frequency captures: 🗣️ 對話速記, 🎙️ 語音建卡, 🔍 找人.
- 🔍 trigger uses a \`CustomEvent("namecard:openSearch")\` bridge to GlobalShortcuts — no need to lift palette state into AppShell or thread props through MobileNavWrapper.
- safe-area insets handled (iOS notch / home-indicator).

## Why
Desktop users have the rail. Mobile users had to: hamburger → scroll 13 nav items → tap target → land on the page → start the action. For the fastest capture story (\"剛離開會議走在路上\") this is too many taps. Twitter/Notion/WhatsApp all use this pattern for the same reason.

## Files
- \`src/components/shell/MobileFab.{tsx,module.css}\` — new
- \`src/components/shell/AppShell.tsx\` — renders \`<MobileFab/>\` next to GlobalShortcuts
- \`src/components/shell/GlobalShortcuts.tsx\` — addEventListener bridge

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 81.59% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open on phone → see ⊕ bottom-right → tap → sheet appears with 3 actions; tap each → expect navigate-or-palette-open and sheet closes; on desktop → no ⊕ visible

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)