### PR TITLE
feat(coach): ✨ AI action items — extract promises from /log notes

### DIFF
--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -12,6 +12,7 @@ import {
   getCardsBySharedEvent,
   listCardsForUser,
   listContactEventsForUser,
+  listRecentContactEventsForUser,
   logContactEvent,
   mergeCardsForUser,
   setCardPinned,
@@ -42,6 +43,9 @@ import { callCoachLlm, isCoachConfigured } from "@/lib/coach/llm";
 import { selectTodayPriorityCards, type PriorityCandidate } from "@/lib/coach/priority";
 import { suggestNextFollowupDate, type FollowupSuggestion } from "@/lib/coach/followup-suggest";
 import { callCardChatLlm } from "@/lib/coach/chat-llm";
+import { actionItemsCacheMarker, type ActionItem } from "@/lib/coach/action-items";
+import { callActionItemsLlm } from "@/lib/coach/action-items-llm";
+import { readActionItemsCache, writeActionItemsCache } from "@/lib/coach/action-items-store";
 import { reengageCacheKey, type ReengageContext, type ReengageDrafts } from "@/lib/coach/reengage";
 import { callReengageLlm } from "@/lib/coach/reengage-llm";
 import { readReengageCache, writeReengageCache } from "@/lib/coach/reengage-store";
@@ -686,5 +690,47 @@ export const askCardQuestionAction = authedAction
       const answer = await callCardChatLlm({ card, events }, parsedInput.question);
       if (!answer) return { ok: false, reason: "llm-failed" };
       return { ok: true, answer };
+    },
+  );
+
+/**
+ * ✨ AI Action Items — scan recent /log entries, return things the user
+ * promised to do but hasn't followed up on. Uses the same /recap-style
+ * input range (default 14 days) and caches per item-fingerprint marker
+ * so a no-op page reload doesn't re-burn LLM credits.
+ */
+export const getActionItemsAction = authedAction
+  .inputSchema(
+    z.object({
+      sinceDays: z.number().int().min(1).max(60).default(14),
+      force: z.boolean().optional().default(false),
+    }),
+  )
+  .action(
+    async ({
+      parsedInput,
+      ctx,
+    }): Promise<
+      | { ok: true; items: ActionItem[]; cached: boolean }
+      | { ok: false; reason: "no-llm" | "no-events" | "llm-failed" }
+    > => {
+      if (!isCoachConfigured()) return { ok: false, reason: "no-llm" };
+      const recap = await listRecentContactEventsForUser(ctx.user.uid, parsedInput.sinceDays);
+      if (recap.length === 0) return { ok: false, reason: "no-events" };
+
+      const marker = actionItemsCacheMarker(recap);
+      const cacheKey = `v1::since=${parsedInput.sinceDays}::${marker}`;
+
+      if (!parsedInput.force) {
+        const cached = await readActionItemsCache(ctx.user.uid, cacheKey);
+        if (cached) {
+          return { ok: true, items: cached, cached: true };
+        }
+      }
+
+      const items = await callActionItemsLlm(recap);
+      if (items === null) return { ok: false, reason: "llm-failed" };
+      await writeActionItemsCache(ctx.user.uid, cacheKey, items);
+      return { ok: true, items, cached: false };
     },
   );

--- a/src/app/(app)/followups/page.tsx
+++ b/src/app/(app)/followups/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { ActionItemsSection } from "@/components/coach/ActionItemsSection";
 import { FollowupCardRow } from "@/components/followups/FollowupCardRow";
 import { listCardsForUser } from "@/db/cards";
 import { isCoachConfigured } from "@/lib/coach/llm";
@@ -43,6 +44,8 @@ export default async function FollowupsPage() {
           按急迫度排序。點 <em>✅ 已聯絡</em> 會把這個人從清單裡拿掉。
         </p>
       </header>
+
+      {showAiDrafts && <ActionItemsSection />}
 
       {total === 0 ? (
         <section className={styles.empty}>

--- a/src/components/coach/ActionItemsSection.module.css
+++ b/src/components/coach/ActionItemsSection.module.css
@@ -1,0 +1,135 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 30%, var(--color-paper)) 0%,
+    var(--color-paper) 100%
+  );
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-md);
+}
+
+.label {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.placeholder {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-ink-muted);
+  font-size: var(--text-caption);
+  margin: 0;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.body {
+  flex: 1;
+  min-width: 12rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+}
+
+.action {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  margin: 0;
+  line-height: var(--leading-relaxed);
+}
+
+.dueHint {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  margin-left: 0.25em;
+  letter-spacing: var(--tracking-wide);
+}
+
+.cardLink {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  text-decoration: none;
+  letter-spacing: var(--tracking-wide);
+}
+
+.cardLink:hover {
+  text-decoration: underline;
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.setBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.setBtn:hover:not(:disabled) {
+  background: var(--color-accent-ink);
+}
+
+.setBtn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.dismissBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-paper);
+  color: var(--color-ink-muted);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.dismissBtn:hover {
+  border-color: var(--color-accent-ink);
+}
+
+.done {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+}

--- a/src/components/coach/ActionItemsSection.tsx
+++ b/src/components/coach/ActionItemsSection.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState, useTransition } from "react";
+
+import { getActionItemsAction, setFollowUpAction } from "@/app/(app)/cards/actions";
+import type { ActionItem } from "@/lib/coach/action-items";
+
+import styles from "./ActionItemsSection.module.css";
+
+type State =
+  | { kind: "loading" }
+  | { kind: "ready"; items: ActionItem[]; cached: boolean }
+  | { kind: "hidden" };
+
+function tomorrowIso(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const da = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${da}`;
+}
+
+/**
+ * Surfaces AI-extracted promises ("I said I'd send the deck", "I owe him
+ * an intro") at the top of /followups. Hides on any failure (LLM not
+ * configured, no events, parser dropped everything) — no scary banner
+ * when the inferred list is empty.
+ *
+ * Per-item: ✓ button calls setFollowUpAction(cardId, tomorrow). The card
+ * is the source of truth for the reminder; we don't persist the action
+ * text itself (intentional simplicity — user can rewrite during set).
+ */
+export function ActionItemsSection() {
+  const [state, setState] = useState<State>({ kind: "loading" });
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  const [pending, startTransition] = useTransition();
+  const [done, setDone] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    void getActionItemsAction({ sinceDays: 14 }).then((res) => {
+      if (cancelled) return;
+      if (!res?.data || !res.data.ok || res.data.items.length === 0) {
+        setState({ kind: "hidden" });
+        return;
+      }
+      setState({ kind: "ready", items: res.data.items, cached: res.data.cached });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSetFollowup = (cardId: string) => {
+    startTransition(async () => {
+      const res = await setFollowUpAction({ id: cardId, followUpAt: tomorrowIso() });
+      if (res?.data?.ok) {
+        setDone((prev) => new Set(prev).add(cardId));
+      }
+    });
+  };
+
+  const handleDismiss = (key: string) => {
+    setDismissed((prev) => new Set(prev).add(key));
+  };
+
+  if (state.kind === "hidden") return null;
+
+  if (state.kind === "loading") {
+    return (
+      <section className={styles.section} aria-label="AI 觀察到的 action items">
+        <p className={styles.label}>✨ AI 觀察到的 action items</p>
+        <p className={styles.placeholder}>掃描中…</p>
+      </section>
+    );
+  }
+
+  const visible = state.items.filter((it) => !dismissed.has(`${it.cardId}::${it.action}`));
+  if (visible.length === 0) return null;
+
+  return (
+    <section className={styles.section} aria-label="AI 觀察到的 action items">
+      <p className={styles.label}>✨ AI 觀察到的 action items</p>
+      <ul className={styles.list}>
+        {visible.map((item) => {
+          const key = `${item.cardId}::${item.action}`;
+          const isDone = done.has(item.cardId);
+          return (
+            <li key={key} className={styles.item}>
+              <div className={styles.body}>
+                <p className={styles.action}>
+                  {item.action}
+                  {item.dueHint && <span className={styles.dueHint}>（{item.dueHint}）</span>}
+                </p>
+                <Link href={`/cards/${item.cardId}`} className={styles.cardLink}>
+                  → 看卡片
+                </Link>
+              </div>
+              <div className={styles.actions}>
+                {isDone ? (
+                  <span className={styles.done}>✓ 已排提醒</span>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      className={styles.setBtn}
+                      onClick={() => handleSetFollowup(item.cardId)}
+                      disabled={pending}
+                      title="把這個 action item 排到明天提醒"
+                    >
+                      ✓ 排提醒
+                    </button>
+                    <button
+                      type="button"
+                      className={styles.dismissBtn}
+                      onClick={() => handleDismiss(key)}
+                    >
+                      略過
+                    </button>
+                  </>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/lib/coach/__tests__/action-items.test.ts
+++ b/src/lib/coach/__tests__/action-items.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary, ContactEvent } from "@/db/cards";
+import type { RecapItem } from "@/lib/recap/group";
+
+import {
+  actionItemsCacheMarker,
+  buildActionItemsMessages,
+  parseActionItems,
+} from "../action-items";
+
+function aCard(over: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "card-x",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "陳玉涵",
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...over,
+  } as CardSummary;
+}
+
+function mkItem(cardId: string, name: string, note: string, at = new Date(2026, 3, 25)): RecapItem {
+  const event: ContactEvent = {
+    id: `e-${cardId}`,
+    at,
+    note,
+    authorUid: "u",
+    authorDisplay: null,
+  };
+  return { card: aCard({ id: cardId, nameZh: name }), event };
+}
+
+describe("buildActionItemsMessages", () => {
+  it("returns system + user messages with each item enumerated and cardId prefixed", () => {
+    const items = [
+      mkItem("c1", "陳玉涵", "她要 pitch deck，我答應週五前寄"),
+      mkItem("c2", "Karen", "她要我介紹 NVIDIA contact"),
+    ];
+    const msgs = buildActionItemsMessages(items);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.role).toBe("system");
+    expect(msgs[0]!.content).toContain("使用者本人");
+    expect(msgs[1]!.role).toBe("user");
+    expect(msgs[1]!.content).toContain("cardId=c1");
+    expect(msgs[1]!.content).toContain("cardId=c2");
+    expect(msgs[1]!.content).toContain("陳玉涵");
+    expect(msgs[1]!.content).toContain("pitch deck");
+  });
+
+  it("renders epoch event.at as empty date prefix (no 1970 leak)", () => {
+    const items = [mkItem("c1", "X", "...", new Date(0))];
+    const msgs = buildActionItemsMessages(items);
+    expect(msgs[1]!.content).not.toContain("1970");
+  });
+
+  it("falls back to （未命名） when both names missing", () => {
+    const item: RecapItem = {
+      card: aCard({ id: "anon", nameZh: undefined, nameEn: undefined }),
+      event: {
+        id: "e",
+        at: new Date(2026, 3, 25),
+        note: "X",
+        authorUid: "u",
+        authorDisplay: null,
+      },
+    };
+    const msgs = buildActionItemsMessages([item]);
+    expect(msgs[1]!.content).toContain("（未命名）");
+  });
+});
+
+describe("parseActionItems", () => {
+  const validIds = new Set(["c1", "c2", "c3"]);
+
+  it("parses a clean response", () => {
+    const raw = JSON.stringify({
+      items: [
+        { cardId: "c1", action: "週五前寄 pitch deck", dueHint: "週五前" },
+        { cardId: "c2", action: "介紹 NVIDIA contact" },
+      ],
+    });
+    const result = parseActionItems(raw, validIds);
+    expect(result).toEqual([
+      { cardId: "c1", action: "週五前寄 pitch deck", dueHint: "週五前" },
+      { cardId: "c2", action: "介紹 NVIDIA contact" },
+    ]);
+  });
+
+  it("strips markdown json fence", () => {
+    const raw = "```json\n" + JSON.stringify({ items: [{ cardId: "c1", action: "x" }] }) + "\n```";
+    expect(parseActionItems(raw, validIds)).toHaveLength(1);
+  });
+
+  it("returns [] on malformed JSON", () => {
+    expect(parseActionItems("not json", validIds)).toEqual([]);
+  });
+
+  it("returns [] when items field missing", () => {
+    expect(parseActionItems(JSON.stringify({ other: 1 }), validIds)).toEqual([]);
+  });
+
+  it("returns [] when root is array", () => {
+    expect(parseActionItems("[1,2]", validIds)).toEqual([]);
+  });
+
+  it("drops items with hallucinated cardId", () => {
+    const raw = JSON.stringify({
+      items: [
+        { cardId: "c1", action: "x" },
+        { cardId: "MADE-UP", action: "y" },
+        { cardId: "c2", action: "z" },
+      ],
+    });
+    const result = parseActionItems(raw, validIds);
+    expect(result.map((i) => i.cardId)).toEqual(["c1", "c2"]);
+  });
+
+  it("drops items missing action", () => {
+    const raw = JSON.stringify({
+      items: [{ cardId: "c1" }, { cardId: "c2", action: "" }, { cardId: "c3", action: "good" }],
+    });
+    const result = parseActionItems(raw, validIds);
+    expect(result.map((i) => i.cardId)).toEqual(["c3"]);
+  });
+
+  it("clamps action to 120 chars", () => {
+    const long = "x".repeat(500);
+    const raw = JSON.stringify({ items: [{ cardId: "c1", action: long }] });
+    expect(parseActionItems(raw, validIds)[0]!.action.length).toBe(120);
+  });
+
+  it("clamps dueHint to 30 chars", () => {
+    const long = "x".repeat(100);
+    const raw = JSON.stringify({ items: [{ cardId: "c1", action: "x", dueHint: long }] });
+    expect(parseActionItems(raw, validIds)[0]!.dueHint!.length).toBe(30);
+  });
+
+  it("omits dueHint when empty / non-string", () => {
+    const raw = JSON.stringify({
+      items: [
+        { cardId: "c1", action: "a", dueHint: "" },
+        { cardId: "c2", action: "b", dueHint: 42 },
+      ],
+    });
+    const result = parseActionItems(raw, validIds);
+    expect(result[0]!.dueHint).toBeUndefined();
+    expect(result[1]!.dueHint).toBeUndefined();
+  });
+
+  it("caps at 5 items even if LLM returns more", () => {
+    const raw = JSON.stringify({
+      items: Array.from({ length: 10 }, (_, i) => ({
+        cardId: i % 3 === 0 ? "c1" : i % 3 === 1 ? "c2" : "c3",
+        action: `act-${i}`,
+      })),
+    });
+    expect(parseActionItems(raw, validIds).length).toBe(5);
+  });
+
+  it("trims whitespace from action and dueHint", () => {
+    const raw = JSON.stringify({
+      items: [{ cardId: "c1", action: "  寄 deck  ", dueHint: "  週五  " }],
+    });
+    const result = parseActionItems(raw, validIds)[0]!;
+    expect(result.action).toBe("寄 deck");
+    expect(result.dueHint).toBe("週五");
+  });
+
+  it("ignores non-object entries in items array", () => {
+    const raw = JSON.stringify({
+      items: [null, "string", 42, { cardId: "c1", action: "good" }, [1, 2]],
+    });
+    const result = parseActionItems(raw, validIds);
+    expect(result).toEqual([{ cardId: "c1", action: "good" }]);
+  });
+});
+
+describe("actionItemsCacheMarker", () => {
+  const ev = (at: Date): ContactEvent => ({
+    id: `e-${at.getTime()}`,
+    at,
+    note: "n",
+    authorUid: "u",
+    authorDisplay: null,
+  });
+
+  it("returns 'empty' for no items", () => {
+    expect(actionItemsCacheMarker([])).toBe("empty");
+  });
+
+  it("includes count and max timestamp", () => {
+    const a = { card: aCard({ id: "a" }), event: ev(new Date(2026, 3, 25)) };
+    const b = { card: aCard({ id: "b" }), event: ev(new Date(2026, 3, 26)) };
+    const marker = actionItemsCacheMarker([a, b]);
+    expect(marker).toContain("n=2");
+    expect(marker).toContain(`max=${b.event.at.getTime()}`);
+  });
+
+  it("changes when a new event arrives", () => {
+    const a = { card: aCard({ id: "a" }), event: ev(new Date(2026, 3, 25)) };
+    const before = actionItemsCacheMarker([a]);
+    const b = { card: aCard({ id: "b" }), event: ev(new Date(2026, 3, 26)) };
+    const after = actionItemsCacheMarker([a, b]);
+    expect(before).not.toBe(after);
+  });
+});

--- a/src/lib/coach/action-items-llm.ts
+++ b/src/lib/coach/action-items-llm.ts
@@ -1,0 +1,57 @@
+import "server-only";
+
+import type { RecapItem } from "@/lib/recap/group";
+
+import { buildActionItemsMessages, parseActionItems, type ActionItem } from "./action-items";
+
+const DEFAULT_BASE_URL = "https://api.minimax.chat/v1";
+const DEFAULT_MODEL = "MiniMax-M2.7";
+const DEFAULT_TIMEOUT_MS = 12_000;
+
+interface MiniMaxChatResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+export async function callActionItemsLlm(
+  items: readonly RecapItem[],
+  options: { timeoutMs?: number } = {},
+): Promise<ActionItem[] | null> {
+  const apiKey = process.env.MINIMAX_API_KEY ?? "";
+  if (!apiKey) return null;
+  if (items.length === 0) return [];
+
+  const baseUrl = process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = process.env.MINIMAX_MODEL ?? DEFAULT_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const body = {
+    model,
+    temperature: 0.3,
+    max_tokens: 800,
+    messages: buildActionItemsMessages(items),
+  };
+
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: abort.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as MiniMaxChatResponse;
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) return null;
+    const validIds = new Set(items.map((it) => it.card.id));
+    return parseActionItems(raw, validIds);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/coach/action-items-store.ts
+++ b/src/lib/coach/action-items-store.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+import { Timestamp } from "firebase-admin/firestore";
+
+import { getAdminFirestore } from "@/lib/firebase/server";
+import { COLLECTION_WORKSPACES, personalWorkspaceId } from "@/lib/firebase/shared";
+
+import type { ActionItem } from "./action-items";
+
+const COACH_SUBCOLLECTION = "coach";
+const ACTION_ITEMS_DOC = "action-items";
+
+interface CachedActionItemsDoc {
+  cacheKey: string;
+  items: ActionItem[];
+  generatedAt: Timestamp;
+}
+
+export async function readActionItemsCache(
+  uid: string,
+  cacheKey: string,
+): Promise<ActionItem[] | null> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${COLLECTION_WORKSPACES}/${wid}/${COACH_SUBCOLLECTION}/${ACTION_ITEMS_DOC}`);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const data = snap.data() as CachedActionItemsDoc | undefined;
+  if (!data) return null;
+  if (data.cacheKey !== cacheKey) return null;
+  return data.items;
+}
+
+export async function writeActionItemsCache(
+  uid: string,
+  cacheKey: string,
+  items: ActionItem[],
+): Promise<void> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${COLLECTION_WORKSPACES}/${wid}/${COACH_SUBCOLLECTION}/${ACTION_ITEMS_DOC}`);
+  await ref.set({
+    cacheKey,
+    items,
+    generatedAt: Timestamp.now(),
+  });
+}

--- a/src/lib/coach/action-items.ts
+++ b/src/lib/coach/action-items.ts
@@ -1,0 +1,112 @@
+import type { RecapItem } from "@/lib/recap/group";
+
+export interface ActionItem {
+  /** ID of the card the action refers to. Validated against the input set. */
+  cardId: string;
+  /** Short verb-led description of what the user promised. zh-Hant. ≤120 chars. */
+  action: string;
+  /** Optional time hint extracted from the original note ("週五前"、"下週"). */
+  dueHint?: string;
+}
+
+const MAX_ITEMS = 5;
+const MAX_ACTION_LEN = 120;
+const MAX_DUE_HINT_LEN = 30;
+
+const SYSTEM_PROMPT =
+  "你是商務 action item 抽取器。" +
+  "使用者最近的對話紀錄如下，每筆是「跟某人聊」的內容。" +
+  "從中抽出 *使用者本人* 答應要做、但還沒做的事情（promise / commitment / TODO）。" +
+  "例如「答應寄 pitch deck」、「他要我介紹 X」、「下週給報價」。\n" +
+  "回答必須是合法 JSON：\n" +
+  "{\n" +
+  '  "items": [\n' +
+  '    { "cardId": string, "action": string, "dueHint"?: string }\n' +
+  "  ]\n" +
+  "}\n" +
+  "規則：\n" +
+  "- 只回傳 JSON，不要 markdown 圍欄、不要任何說明文字。\n" +
+  "- cardId 必須完全對應使用者提供的卡片 ID（每筆 RecapItem 開頭會給）。\n" +
+  "- action 用繁體中文，動詞開頭，1 句話 ≤120 字（不含 dueHint）。\n" +
+  "- 只抽 *使用者本人答應的事*；對方答應你的事不算。\n" +
+  "- 沒有承諾性語句的對話 → 不要硬擠 action item。\n" +
+  "- 最多 5 筆，挑最具體 / 最緊迫的。\n" +
+  "- dueHint 是時間提示（「週五前」「下週」「月底」），原文沒寫就 omit。";
+
+function pickName(card: RecapItem["card"]): string {
+  return card.nameZh || card.nameEn || "（未命名）";
+}
+
+export function buildActionItemsMessages(
+  items: readonly RecapItem[],
+): Array<{ role: "system" | "user"; content: string }> {
+  const lines: string[] = [];
+  lines.push("最近對話紀錄（每筆開頭是 cardId，務必完全對應使用）：");
+  lines.push("");
+  for (const it of items) {
+    const date = it.event.at && it.event.at.getTime() > 0 ? formatLocalDate(it.event.at) : "";
+    const name = pickName(it.card);
+    const note = it.event.note?.trim() || "（無內容）";
+    lines.push(`cardId=${it.card.id} | ${date} | 跟 ${name} 聊：${note}`);
+  }
+  return [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: lines.join("\n") },
+  ];
+}
+
+function formatLocalDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const da = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${da}`;
+}
+
+function sanitizeStr(value: unknown, max: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, max);
+}
+
+/**
+ * Parse the LLM's JSON. Defensive: drops items whose cardId is not in
+ * the validIds set (anti-hallucination), drops items missing action,
+ * caps at MAX_ITEMS, clamps action/dueHint lengths.
+ */
+export function parseActionItems(raw: string, validCardIds: ReadonlySet<string>): ActionItem[] {
+  if (!raw) return [];
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const inner = fenced ? fenced[1]! : trimmed;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(inner);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+  const itemsRaw = (parsed as { items?: unknown }).items;
+  if (!Array.isArray(itemsRaw)) return [];
+
+  const out: ActionItem[] = [];
+  for (const entry of itemsRaw) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const obj = entry as Record<string, unknown>;
+    const cardId = sanitizeStr(obj.cardId, 200);
+    if (!cardId || !validCardIds.has(cardId)) continue;
+    const action = sanitizeStr(obj.action, MAX_ACTION_LEN);
+    if (!action) continue;
+    const dueHint = sanitizeStr(obj.dueHint, MAX_DUE_HINT_LEN);
+    out.push(dueHint ? { cardId, action, dueHint } : { cardId, action });
+    if (out.length >= MAX_ITEMS) break;
+  }
+  return out;
+}
+
+/** Cache marker — flips when item set or freshest event timestamp changes. */
+export function actionItemsCacheMarker(items: readonly RecapItem[]): string {
+  if (items.length === 0) return "empty";
+  const maxAt = items.reduce((acc, it) => Math.max(acc, it.event.at?.getTime() ?? 0), 0);
+  return `n=${items.length}::max=${maxAt}`;
+}


### PR DESCRIPTION
## Summary
- **Surfaces forgotten promises.** Scans the last 14 days of /log notes, asks the LLM to extract what *the user* promised but hasn\\'t done. Surfaces them at the top of /followups with one-tap "✓ 排提醒" that sets a followup reminder for tomorrow.
- **Anti-hallucination by design.** Every prompt line is prefixed with the source cardId; parser validates against the Set of valid IDs and drops any the LLM invented.
- **Cost-controlled.** Same fingerprint-marker pattern as /recap themes: same items count + same max event timestamp = cache hit, no LLM call.
- **Hides silently on failure.** No LLM key, no events, parser dropped everything → no scary banner.

## Why
The full conversation loop (/log → briefing → recap → themes) lets users *write* and *see* their conversation history. But the most actionable bit — "things I said I\\'d do" — was buried in the free-form note text. This extracts the verb-led commitments and shoves them in the user's face on the page they already check for follow-ups.

## Files
- \`src/lib/coach/action-items.ts\` — pure: \`buildActionItemsMessages\` (cardId-prefixed lines), \`parseActionItems\` (defensive, validIds-gated), \`actionItemsCacheMarker\`
- \`src/lib/coach/__tests__/action-items.test.ts\` — 19 UT
- \`src/lib/coach/action-items-llm.ts\` — MiniMax client (800 max_tokens, 0.3 temp)
- \`src/lib/coach/action-items-store.ts\` — Firestore cache at \`workspaces/{wid}/coach/action-items\`
- \`src/app/(app)/cards/actions.ts\` — \`getActionItemsAction({sinceDays, force?})\` with cache hit/miss
- \`src/components/coach/ActionItemsSection.{tsx,module.css}\` — client section with ✓ 排提醒 + 略過 per-item
- \`src/app/(app)/followups/page.tsx\` — renders the section when LLM configured

## Test plan
- [x] \`pnpm test\` — 19 new UT pass
- [x] \`pnpm test:coverage\` — branches 81.88% (above gate)
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: log a note with a promise ("我答應寄 X") via /log → reload /followups → expect AI-extracted action item appears with ✓ button; tap ✓ → that card gets followUpAt=tomorrow

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)