### PR TITLE
feat(cards): 🌡️ relationship temperature badges

### DIFF
--- a/src/app/(app)/cards/[id]/detail.module.css
+++ b/src/app/(app)/cards/[id]/detail.module.css
@@ -52,6 +52,14 @@
   margin: 0;
 }
 
+.kickerRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
 .name {
   font-family: var(--font-display);
   font-size: var(--text-h1);

--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -6,6 +6,7 @@ import { CardChatBox } from "@/components/cards/CardChatBox";
 import { CardInlineEdit } from "@/components/cards/CardInlineEdit";
 import { CoachInsightSection } from "@/components/cards/CoachInsightSection";
 import { ContactEventList } from "@/components/cards/ContactEventList";
+import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
 import { PublicProfileToggle } from "@/components/cards/PublicProfileToggle";
 import { RelatedByEvent } from "@/components/cards/RelatedByEvent";
 import { TagSuggestionsBanner } from "@/components/tags/TagSuggestionsBanner";
@@ -18,6 +19,7 @@ import {
 import type { CardCreateInput } from "@/db/schema";
 import { isCoachConfigured } from "@/lib/coach/llm";
 import { companySlug, pickCanonicalCompany } from "@/lib/companies/group";
+import { computeTemperature } from "@/lib/cards/relationship-temp";
 import { findAnniversariesToday } from "@/lib/timeline/anniversaries";
 import { readSession } from "@/lib/firebase/session";
 
@@ -143,7 +145,10 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
       <div className={styles.layout}>
         <main className={styles.main}>
           <header className={styles.header}>
-            <p className={styles.kicker}>名片</p>
+            <div className={styles.kickerRow}>
+              <p className={styles.kicker}>名片</p>
+              <TemperatureBadge temperature={computeTemperature(card, new Date())} />
+            </div>
             <h1 className={styles.name}>
               <CardInlineEdit
                 cardId={card.id}

--- a/src/components/cards/CardGallery.tsx
+++ b/src/components/cards/CardGallery.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
 
 import type { CardSummary } from "@/db/cards";
+import { computeTemperature } from "@/lib/cards/relationship-temp";
 import { daysSinceContact, shouldShowStaleBadge } from "@/lib/timeline/staleness";
 
 import styles from "./CardGallery.module.css";
+import { TemperatureBadge } from "./TemperatureBadge";
 import type { CardSelectionApi } from "./useCardSelection";
 
 interface CardGalleryProps {
@@ -77,6 +79,7 @@ export function CardGallery({ cards, selection }: CardGalleryProps) {
               ) : card.firstMetDate ? (
                 <span className={styles.eventTag}>{card.firstMetDate}</span>
               ) : null}
+              <TemperatureBadge temperature={computeTemperature(card, now)} compact />
               {stale && days !== null && <span className={styles.staleBadge}>{days} 天沒聯絡</span>}
             </footer>
           </article>

--- a/src/components/cards/CardList.tsx
+++ b/src/components/cards/CardList.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
 
 import type { CardSummary } from "@/db/cards";
+import { computeTemperature } from "@/lib/cards/relationship-temp";
 import { daysSinceContact, shouldShowStaleBadge } from "@/lib/timeline/staleness";
 
 import styles from "./CardList.module.css";
+import { TemperatureBadge } from "./TemperatureBadge";
 import type { CardSelectionApi } from "./useCardSelection";
 
 interface CardListProps {
@@ -34,6 +36,7 @@ export function CardList({ cards, selection }: CardListProps) {
         const stale = shouldShowStaleBadge(card, now);
         const days = stale ? daysSinceContact(card, now) : null;
         const checked = selection?.isSelected(card.id) ?? false;
+        const temperature = computeTemperature(card, now);
         const inner = (
           <>
             {selection && (
@@ -53,6 +56,7 @@ export function CardList({ cards, selection }: CardListProps) {
               <span className={styles.name}>{primaryName(card)}</span>
               {role(card) && <span className={styles.role}>{role(card)}</span>}
               {company(card) && <span className={styles.company}>{company(card)}</span>}
+              <TemperatureBadge temperature={temperature} compact />
             </div>
             <p className={styles.why}>{card.whyRemember}</p>
             <div className={styles.meta}>

--- a/src/components/cards/TemperatureBadge.module.css
+++ b/src/components/cards/TemperatureBadge.module.css
@@ -1,0 +1,50 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.15em 0.55em;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-paper);
+  color: var(--color-ink-muted);
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.text {
+  font-weight: 500;
+}
+
+.level_hot {
+  border-color: color-mix(in oklch, oklch(70% 0.18 30) 60%, var(--color-border));
+  background: color-mix(in oklch, oklch(95% 0.04 30) 70%, var(--color-paper));
+  color: oklch(40% 0.12 30);
+}
+
+.level_warm {
+  border-color: color-mix(in oklch, oklch(75% 0.14 70) 60%, var(--color-border));
+  background: color-mix(in oklch, oklch(96% 0.03 70) 70%, var(--color-paper));
+  color: oklch(40% 0.1 50);
+}
+
+.level_active {
+  border-color: color-mix(in oklch, oklch(75% 0.14 250) 50%, var(--color-border));
+  background: color-mix(in oklch, oklch(96% 0.03 250) 70%, var(--color-paper));
+  color: oklch(40% 0.1 250);
+}
+
+.level_quiet {
+  border-color: var(--color-border);
+  background: var(--color-paper);
+  color: var(--color-ink-muted);
+}
+
+.level_cold {
+  border-color: var(--color-border);
+  background: color-mix(in oklch, oklch(95% 0 0) 50%, var(--color-paper));
+  color: var(--color-ink-muted);
+  opacity: 0.85;
+}

--- a/src/components/cards/TemperatureBadge.tsx
+++ b/src/components/cards/TemperatureBadge.tsx
@@ -1,0 +1,39 @@
+import type { Temperature } from "@/lib/cards/relationship-temp";
+
+import styles from "./TemperatureBadge.module.css";
+
+interface TemperatureBadgeProps {
+  temperature: Temperature;
+  /** Compact variant — emoji only with tooltip. Default false. */
+  compact?: boolean;
+}
+
+/**
+ * Visual relationship-temperature pill. Shows emoji + label by default;
+ * compact mode collapses to emoji-only with the label as title attr,
+ * for use in dense lists where horizontal space is tight.
+ *
+ * Uses level-derived class names so CSS can colour each tier subtly.
+ */
+export function TemperatureBadge({ temperature, compact = false }: TemperatureBadgeProps) {
+  const className = `${styles.badge} ${styles[`level_${temperature.level}`] ?? ""}`.trim();
+  const tooltip =
+    temperature.daysSince === null
+      ? temperature.label
+      : `${temperature.label} · ${temperature.daysSince} 天前`;
+
+  if (compact) {
+    return (
+      <span className={className} title={tooltip} aria-label={tooltip}>
+        <span aria-hidden="true">{temperature.emoji}</span>
+      </span>
+    );
+  }
+
+  return (
+    <span className={className} title={tooltip}>
+      <span aria-hidden="true">{temperature.emoji}</span>
+      <span className={styles.text}>{temperature.label}</span>
+    </span>
+  );
+}

--- a/src/lib/cards/__tests__/relationship-temp.test.ts
+++ b/src/lib/cards/__tests__/relationship-temp.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import { computeTemperature } from "../relationship-temp";
+
+const NOW = new Date(2026, 3, 25, 12, 0, 0);
+
+function aCard(over: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "card-x",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "X",
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...over,
+  } as CardSummary;
+}
+
+function dayOffset(base: Date, days: number): Date {
+  return new Date(base.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+describe("computeTemperature", () => {
+  it("hot: contacted within last 7 days", () => {
+    const card = aCard({ lastContactedAt: dayOffset(NOW, -3) });
+    const t = computeTemperature(card, NOW);
+    expect(t.level).toBe("hot");
+    expect(t.emoji).toBe("🔥");
+    expect(t.daysSince).toBe(3);
+  });
+
+  it("warm: 8-30 days", () => {
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -8) }), NOW).level).toBe(
+      "warm",
+    );
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -30) }), NOW).level).toBe(
+      "warm",
+    );
+  });
+
+  it("active: 31-90 days", () => {
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -31) }), NOW).level).toBe(
+      "active",
+    );
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -90) }), NOW).level).toBe(
+      "active",
+    );
+  });
+
+  it("quiet: 91-180 days", () => {
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -91) }), NOW).level).toBe(
+      "quiet",
+    );
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -180) }), NOW).level).toBe(
+      "quiet",
+    );
+  });
+
+  it("cold: > 180 days", () => {
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -181) }), NOW).level).toBe(
+      "cold",
+    );
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -1000) }), NOW).level).toBe(
+      "cold",
+    );
+  });
+
+  it("falls back to createdAt when lastContactedAt is null", () => {
+    const card = aCard({ createdAt: dayOffset(NOW, -5) });
+    expect(computeTemperature(card, NOW).level).toBe("hot");
+  });
+
+  it("never-contacted + never-created → cold (no daysSince)", () => {
+    const t = computeTemperature(aCard(), NOW);
+    expect(t.level).toBe("cold");
+    expect(t.daysSince).toBeNull();
+  });
+
+  it("pinned overrides quiet/cold to warm", () => {
+    const quietPinned = aCard({ isPinned: true, lastContactedAt: dayOffset(NOW, -150) });
+    expect(computeTemperature(quietPinned, NOW).level).toBe("warm");
+
+    const coldPinned = aCard({ isPinned: true, lastContactedAt: dayOffset(NOW, -1000) });
+    expect(computeTemperature(coldPinned, NOW).level).toBe("warm");
+  });
+
+  it("pinned with no signals → warm", () => {
+    const t = computeTemperature(aCard({ isPinned: true }), NOW);
+    expect(t.level).toBe("warm");
+    expect(t.daysSince).toBeNull();
+  });
+
+  it("pinned still keeps hot/active/warm tiers (doesn't downgrade)", () => {
+    const hotPinned = aCard({ isPinned: true, lastContactedAt: dayOffset(NOW, -2) });
+    expect(computeTemperature(hotPinned, NOW).level).toBe("hot");
+
+    const activePinned = aCard({ isPinned: true, lastContactedAt: dayOffset(NOW, -60) });
+    expect(computeTemperature(activePinned, NOW).level).toBe("active");
+  });
+
+  it("future lastContactedAt clamps days to 0 (no negative-days nonsense)", () => {
+    const futureCard = aCard({ lastContactedAt: dayOffset(NOW, 7) });
+    const t = computeTemperature(futureCard, NOW);
+    expect(t.level).toBe("hot");
+    expect(t.daysSince).toBe(0);
+  });
+
+  it("emoji+label match level deterministically", () => {
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -1) }), NOW).emoji).toBe(
+      "🔥",
+    );
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -10) }), NOW).emoji).toBe(
+      "✨",
+    );
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -60) }), NOW).emoji).toBe(
+      "💫",
+    );
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -120) }), NOW).emoji).toBe(
+      "🌙",
+    );
+    expect(computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, -365) }), NOW).emoji).toBe(
+      "💤",
+    );
+  });
+
+  it("label is non-empty for every level", () => {
+    for (const days of [-1, -10, -60, -120, -365]) {
+      const t = computeTemperature(aCard({ lastContactedAt: dayOffset(NOW, days) }), NOW);
+      expect(t.label.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/lib/cards/relationship-temp.ts
+++ b/src/lib/cards/relationship-temp.ts
@@ -1,0 +1,71 @@
+import type { CardSummary } from "@/db/cards";
+
+export type TemperatureLevel = "hot" | "warm" | "active" | "quiet" | "cold";
+
+export interface Temperature {
+  level: TemperatureLevel;
+  emoji: string;
+  /** Short zh-Hant label, suitable for tooltip / aria. */
+  label: string;
+  /** Days since the relationship "warmth source" (lastContactedAt or createdAt). null when both are missing. */
+  daysSince: number | null;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const HOT_THRESHOLD_DAYS = 7;
+const WARM_THRESHOLD_DAYS = 30;
+const ACTIVE_THRESHOLD_DAYS = 90;
+const QUIET_THRESHOLD_DAYS = 180;
+
+function daysBetween(later: Date, earlier: Date): number {
+  return Math.floor((later.getTime() - earlier.getTime()) / MS_PER_DAY);
+}
+
+const LABELS: Record<TemperatureLevel, { emoji: string; label: string }> = {
+  hot: { emoji: "🔥", label: "本週聯絡過" },
+  warm: { emoji: "✨", label: "本月聯絡過" },
+  active: { emoji: "💫", label: "近 3 個月聯絡過" },
+  quiet: { emoji: "🌙", label: "已 6 個月內聯絡" },
+  cold: { emoji: "💤", label: "超過 6 個月未聯絡" },
+};
+
+/**
+ * Pure derivation of relationship "temperature" from a card's signals.
+ *
+ * Rules:
+ *   - Source date = lastContactedAt; falls back to createdAt for cards
+ *     that have never been logged (so brand-new cards aren't misleadingly
+ *     marked cold).
+ *   - Negative days (future date — clock skew, weird import data) clamp
+ *     to 0 so the future-source-card gets the warmest tier rather than
+ *     a nonsensical cold one.
+ *   - isPinned acts as a *floor*: a pinned card never shows quiet/cold,
+ *     because the user explicitly said it's important. Falls back to
+ *     "warm" so it stays visible without overstating recency.
+ *   - When both lastContactedAt and createdAt are null we still surface
+ *     a temperature (cold or warm-via-pin). daysSince is null in that
+ *     case so the UI can suppress the "N days" sub-label cleanly.
+ */
+export function computeTemperature(card: Readonly<CardSummary>, now: Date): Temperature {
+  const sourceDate = card.lastContactedAt ?? card.createdAt;
+  const isPinned = Boolean(card.isPinned);
+
+  if (!sourceDate) {
+    const level: TemperatureLevel = isPinned ? "warm" : "cold";
+    return { level, ...LABELS[level], daysSince: null };
+  }
+
+  const days = Math.max(0, daysBetween(now, sourceDate));
+  let level: TemperatureLevel;
+  if (days <= HOT_THRESHOLD_DAYS) level = "hot";
+  else if (days <= WARM_THRESHOLD_DAYS) level = "warm";
+  else if (days <= ACTIVE_THRESHOLD_DAYS) level = "active";
+  else if (days <= QUIET_THRESHOLD_DAYS) level = "quiet";
+  else level = "cold";
+
+  if (isPinned && (level === "quiet" || level === "cold")) {
+    level = "warm";
+  }
+
+  return { level, ...LABELS[level], daysSince: days };
+}


### PR DESCRIPTION
## Summary
- 5-tier visual badge on every card surface (list, gallery, detail header) so 100+ rolodex stops looking flat.
- Tiers: 🔥 ≤7d / ✨ ≤30d / 💫 ≤90d / 🌙 ≤180d / 💤 >180d (or never).
- Pin acts as a *floor* — pinned cards never drop below ✨ Warm.
- Pure derivation, no LLM, no I/O. Future-date clamps defensively against bad import data.

## Why
The user said \"我希望目前的系統更好用，更貼近商務人士使用\". Once you have 100 cards, lastContactedAt becomes invisible math (\"60 days? 90 days? does it matter?\"). A glanceable badge turns the rolodex from a list-of-names into a heat map of relationships — at-a-glance you see who needs a re-engage.

## Files
- \`src/lib/cards/relationship-temp.ts\` — pure \`computeTemperature(card, now)\` → \`{level, emoji, label, daysSince}\`
- \`src/lib/cards/__tests__/relationship-temp.test.ts\` — 13 UT (all tiers, source fallback, pin floor, future clamp, label/emoji determinism)
- \`src/components/cards/TemperatureBadge.{tsx,module.css}\` — pill with full + compact variants
- \`src/components/cards/CardList.tsx\` — compact badge in row
- \`src/components/cards/CardGallery.tsx\` — compact badge in card footer
- \`src/app/(app)/cards/[id]/page.tsx\` — full badge in header kicker row
- \`src/app/(app)/cards/[id]/detail.module.css\` — \`.kickerRow\` flex layout

## Test plan
- [x] \`pnpm test\` — 13 new UT pass
- [x] \`pnpm test:coverage\` — branches 82.09% (above gate)
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm build\` — green
- [ ] Live smoke: open /cards → expect each row has a temperature emoji; open a card detail → header shows full pill; pin a long-quiet card → expect badge bumps to ✨

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)