### PR TITLE
feat(cards): 🌡️ filter chips on /cards

### DIFF
--- a/src/app/(app)/cards/page.tsx
+++ b/src/app/(app)/cards/page.tsx
@@ -3,12 +3,14 @@ import Link from "next/link";
 import { CardsSelectionShell } from "@/components/cards/CardsSelectionShell";
 import { ExportButton } from "@/components/cards/ExportButton";
 import { TagFilterBar } from "@/components/cards/TagFilterBar";
+import { TemperatureFilterBar } from "@/components/cards/TemperatureFilterBar";
 import { ViewToggle } from "@/components/cards/ViewToggle";
 import { listCardsForUser, type CardSummary } from "@/db/cards";
 import { listTagsForUser } from "@/db/tags";
 import { readSession } from "@/lib/firebase/session";
 import { findDuplicateGroups } from "@/lib/cards/duplicates";
-import { applyTagFilter } from "@/lib/cards/filter";
+import { applyTagFilter, countByTemperature, filterByTemperature } from "@/lib/cards/filter";
+import type { TemperatureLevel } from "@/lib/cards/relationship-temp";
 import { parseSortKey, sortCards } from "@/lib/cards/sort";
 import { getTypesenseClient } from "@/lib/search/client";
 import { buildSearchParams } from "@/lib/search/query";
@@ -22,6 +24,28 @@ export const metadata = {
 };
 
 const MAX_CARDS = 500;
+
+const TEMP_LEVELS: ReadonlySet<TemperatureLevel> = new Set([
+  "hot",
+  "warm",
+  "active",
+  "quiet",
+  "cold",
+]);
+
+function parseTempParam(raw: string | string[] | undefined): TemperatureLevel[] {
+  if (!raw) return [];
+  const tokens = (Array.isArray(raw) ? raw.join(",") : raw).split(",").map((s) => s.trim());
+  const out: TemperatureLevel[] = [];
+  const seen = new Set<TemperatureLevel>();
+  for (const t of tokens) {
+    if (TEMP_LEVELS.has(t as TemperatureLevel) && !seen.has(t as TemperatureLevel)) {
+      seen.add(t as TemperatureLevel);
+      out.push(t as TemperatureLevel);
+    }
+  }
+  return out;
+}
 
 interface CardsPageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -98,6 +122,16 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
   // (or a tag-filtered list) we respect the segment control.
   if (!q) cards = sortCards(cards, sort);
 
+  // Temperature filter applies last (after sort) so the URL state stays
+  // composable with all other filters and the chip counts reflect the
+  // tag-filtered universe, not the temperature-filtered one.
+  const now = new Date();
+  const selectedTempLevels = parseTempParam(raw.temp);
+  const tempCounts = countByTemperature(cards, now);
+  if (selectedTempLevels.length > 0) {
+    cards = filterByTemperature(cards, selectedTempLevels, now);
+  }
+
   // Surface a duplicate-count nudge in the header. Computed over the
   // unfiltered list so the link is visible regardless of the current
   // search/tag state — the actual /cards/duplicates page also runs
@@ -151,6 +185,7 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
       </header>
 
       <TagFilterBar tags={allTags} selectedIds={tag} tagMode={tagMode} />
+      <TemperatureFilterBar counts={tempCounts} selected={selectedTempLevels} />
 
       {cards.length === 0 ? (
         <div className={styles.empty}>

--- a/src/components/cards/TemperatureFilterBar.module.css
+++ b/src/components/cards/TemperatureFilterBar.module.css
@@ -1,0 +1,75 @@
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.chipList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: 999px;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.chip:hover:not(:disabled) {
+  border-color: var(--color-accent-ink);
+}
+
+.chip:disabled {
+  cursor: not-allowed;
+}
+
+.chipEmpty {
+  opacity: 0.4;
+}
+
+.chipActive {
+  border-color: var(--color-ink);
+  background: var(--color-ink);
+  color: var(--color-paper);
+}
+
+.chipShort {
+  font-weight: 500;
+}
+
+.chipCount {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  opacity: 0.85;
+}
+
+.clearBtn {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-md);
+  background: transparent;
+  color: var(--color-ink-muted);
+  border: var(--border-hair) solid transparent;
+  cursor: pointer;
+}
+
+.clearBtn:hover {
+  color: var(--color-accent-ink);
+}

--- a/src/components/cards/TemperatureFilterBar.tsx
+++ b/src/components/cards/TemperatureFilterBar.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+
+import type { TemperatureLevel } from "@/lib/cards/relationship-temp";
+
+import styles from "./TemperatureFilterBar.module.css";
+
+interface TemperatureFilterBarProps {
+  /** Pre-computed counts per level (over the current tag-filtered list). */
+  counts: Record<TemperatureLevel, number>;
+  /** Currently selected levels (empty = no filter). */
+  selected: readonly TemperatureLevel[];
+}
+
+const ORDER: ReadonlyArray<{ level: TemperatureLevel; emoji: string; short: string }> = [
+  { level: "hot", emoji: "🔥", short: "本週" },
+  { level: "warm", emoji: "✨", short: "本月" },
+  { level: "active", emoji: "💫", short: "近 3 月" },
+  { level: "quiet", emoji: "🌙", short: "半年內" },
+  { level: "cold", emoji: "💤", short: "冷" },
+];
+
+const LEVEL_LABELS: Record<TemperatureLevel, string> = {
+  hot: "本週聯絡過",
+  warm: "本月聯絡過",
+  active: "近 3 個月聯絡過",
+  quiet: "近半年聯絡過",
+  cold: "超過半年未聯絡或從未聯絡",
+};
+
+/**
+ * Filter chips alongside the existing tag bar. Reads/writes URL state
+ * (`?temp=cold,quiet`) so a filtered view is shareable + survives a
+ * page reload. OR semantics: any chip selected = show that tier.
+ */
+export function TemperatureFilterBar({ counts, selected }: TemperatureFilterBarProps) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [pending, startTransition] = useTransition();
+
+  const selectedSet = new Set<TemperatureLevel>(selected);
+
+  const setLevels = (next: TemperatureLevel[]) => {
+    const sp = new URLSearchParams(params.toString());
+    if (next.length === 0) sp.delete("temp");
+    else sp.set("temp", next.join(","));
+    const qs = sp.toString();
+    startTransition(() => {
+      router.replace(qs ? `/cards?${qs}` : "/cards", { scroll: false });
+    });
+  };
+
+  const toggle = (level: TemperatureLevel) => {
+    const next = selectedSet.has(level)
+      ? selected.filter((l) => l !== level)
+      : [...selected, level];
+    setLevels(next);
+  };
+
+  const clear = () => setLevels([]);
+
+  const totalSelected = selected.length;
+
+  return (
+    <div className={styles.bar} aria-label="關係溫度篩選">
+      <ul className={styles.chipList}>
+        {ORDER.map(({ level, emoji, short }) => {
+          const count = counts[level] ?? 0;
+          const active = selectedSet.has(level);
+          const tooltip = `${LEVEL_LABELS[level]} · ${count} 張`;
+          const className = `${styles.chip} ${active ? styles.chipActive : ""} ${
+            count === 0 ? styles.chipEmpty : ""
+          }`.trim();
+          return (
+            <li key={level}>
+              <button
+                type="button"
+                className={className}
+                onClick={() => toggle(level)}
+                disabled={pending || count === 0}
+                aria-pressed={active}
+                title={tooltip}
+              >
+                <span aria-hidden="true">{emoji}</span>
+                <span className={styles.chipShort}>{short}</span>
+                <span className={styles.chipCount}>{count}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {totalSelected > 0 && (
+        <button
+          type="button"
+          className={styles.clearBtn}
+          onClick={clear}
+          disabled={pending}
+          title="清除溫度篩選"
+        >
+          清除
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/lib/cards/__tests__/filter.test.ts
+++ b/src/lib/cards/__tests__/filter.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { CardSummary } from "@/db/cards";
 
-import { applyTagFilter } from "../filter";
+import { applyTagFilter, countByTemperature, filterByTemperature } from "../filter";
 
 function card(id: string, tagIds: string[]): CardSummary {
   return {
@@ -20,6 +20,19 @@ function card(id: string, tagIds: string[]): CardSummary {
     updatedAt: null,
     lastContactedAt: null,
     deletedAt: null,
+  };
+}
+
+function tempCard(id: string, daysAgoLastContact: number | null, isPinned = false): CardSummary {
+  const now = new Date(2026, 3, 26, 12, 0, 0);
+  const lastContactedAt =
+    daysAgoLastContact === null
+      ? null
+      : new Date(now.getTime() - daysAgoLastContact * 24 * 60 * 60 * 1000);
+  return {
+    ...card(id, []),
+    isPinned,
+    lastContactedAt,
   };
 }
 
@@ -78,5 +91,83 @@ describe("applyTagFilter", () => {
     const cardsWithManyTags = [card("x", ["tag-0", "tag-5", "tag-14"]), card("y", ["tag-99"])];
     const result = applyTagFilter(cardsWithManyTags, manyTags, "or");
     expect(result.map((c) => c.id)).toEqual(["x"]);
+  });
+});
+
+describe("filterByTemperature", () => {
+  const NOW = new Date(2026, 3, 26, 12, 0, 0);
+  const cards = [
+    tempCard("hot", 3), // 3 days
+    tempCard("warm", 20), // 20 days
+    tempCard("active", 60), // 60 days
+    tempCard("quiet", 120), // 120 days
+    tempCard("cold", 365), // 1 year
+    tempCard("never", null),
+  ];
+
+  it("empty levels → pass-through (returns all cards)", () => {
+    expect(filterByTemperature(cards, [], NOW)).toHaveLength(cards.length);
+  });
+
+  it("single level filters to just matching cards", () => {
+    expect(filterByTemperature(cards, ["hot"], NOW).map((c) => c.id)).toEqual(["hot"]);
+    expect(
+      filterByTemperature(cards, ["cold"], NOW)
+        .map((c) => c.id)
+        .sort(),
+    ).toEqual(["cold", "never"]);
+  });
+
+  it("multiple levels OR together", () => {
+    const result = filterByTemperature(cards, ["quiet", "cold"], NOW);
+    expect(result.map((c) => c.id).sort()).toEqual(["cold", "never", "quiet"]);
+  });
+
+  it("returns [] when no cards match", () => {
+    const onlyCold = [tempCard("a", 365), tempCard("b", 400)];
+    expect(filterByTemperature(onlyCold, ["hot"], NOW)).toEqual([]);
+  });
+
+  it("returns a new array (does not mutate input)", () => {
+    const result = filterByTemperature(cards, [], NOW);
+    expect(result).not.toBe(cards);
+  });
+});
+
+describe("countByTemperature", () => {
+  const NOW = new Date(2026, 3, 26, 12, 0, 0);
+
+  it("counts cards across all 5 levels", () => {
+    const cards = [
+      tempCard("a", 3),
+      tempCard("b", 20),
+      tempCard("c", 60),
+      tempCard("d", 120),
+      tempCard("e", 365),
+      tempCard("f", null),
+    ];
+    expect(countByTemperature(cards, NOW)).toEqual({
+      hot: 1,
+      warm: 1,
+      active: 1,
+      quiet: 1,
+      cold: 2,
+    });
+  });
+
+  it("returns zeros for empty list", () => {
+    expect(countByTemperature([], NOW)).toEqual({
+      hot: 0,
+      warm: 0,
+      active: 0,
+      quiet: 0,
+      cold: 0,
+    });
+  });
+
+  it("respects pinned floor (pinned long-quiet is warm not quiet)", () => {
+    const cards = [tempCard("p", 200, true)];
+    expect(countByTemperature(cards, NOW).warm).toBe(1);
+    expect(countByTemperature(cards, NOW).quiet).toBe(0);
   });
 });

--- a/src/lib/cards/filter.ts
+++ b/src/lib/cards/filter.ts
@@ -1,5 +1,7 @@
 import type { CardSummary } from "@/db/cards";
 
+import { computeTemperature, type TemperatureLevel } from "./relationship-temp";
+
 /**
  * Client-side fallback tag filter. Used when Typesense is unavailable
  * or for tiny workspaces where a round-trip is wasted. Mirrors the
@@ -28,4 +30,43 @@ export function applyTagFilter(
     const ownedSet = new Set(owned);
     return tagIds.every((id) => ownedSet.has(id));
   });
+}
+
+/**
+ * Filter cards whose computed temperature is in the requested levels
+ * (OR semantics). Empty levels = pass-through (no filter applied).
+ *
+ * `now` is passed in so tests can fix a reference time and the page
+ * renders deterministically across the request lifecycle.
+ */
+export function filterByTemperature(
+  cards: readonly CardSummary[],
+  levels: readonly TemperatureLevel[],
+  now: Date,
+): CardSummary[] {
+  if (levels.length === 0) return [...cards];
+  const wanted = new Set<TemperatureLevel>(levels);
+  return cards.filter((card) => wanted.has(computeTemperature(card, now).level));
+}
+
+/**
+ * Counts of cards by temperature level. Used by the filter bar to show
+ * "🔥 12 / ✨ 34 / ..." per chip alongside the tag filter.
+ */
+export function countByTemperature(
+  cards: readonly CardSummary[],
+  now: Date,
+): Record<TemperatureLevel, number> {
+  const counts: Record<TemperatureLevel, number> = {
+    hot: 0,
+    warm: 0,
+    active: 0,
+    quiet: 0,
+    cold: 0,
+  };
+  for (const card of cards) {
+    const { level } = computeTemperature(card, now);
+    counts[level]++;
+  }
+  return counts;
 }


### PR DESCRIPTION
## Summary
- Adds 5 toggle chips (🔥 ✨ 💫 🌙 💤) above the card list. Click any to filter by relationship temperature.
- URL state: \`?temp=cold,quiet\`. Empty = pass-through. OR semantics across selected chips.
- Chip counts reflect the tag-filtered universe (so the chip badges still respond when tags change).
- Pure filter + count helpers in \`lib/cards/filter.ts\` reuse the existing \`computeTemperature\` from PR #121.

## Why
Now that every card has a temperature badge, the obvious next step is to *act* on it. \"Show me 💤 冷關係 I should rekindle\" becomes a 1-click view. Composable with existing tag filter, sort, and search params.

## Files
- \`src/lib/cards/filter.ts\` — pure \`filterByTemperature\` + \`countByTemperature\`
- \`src/lib/cards/__tests__/filter.test.ts\` — 8 new UT
- \`src/components/cards/TemperatureFilterBar.{tsx,module.css}\`
- \`src/app/(app)/cards/page.tsx\` — \`parseTempParam\` (level-enum gated), filter applied after sort, render \`<TemperatureFilterBar>\` next to \`<TagFilterBar>\`

## Test plan
- [x] \`pnpm test\` — 8 new UT pass
- [x] \`pnpm test:coverage\` — branches 82.24% (above gate)
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open /cards → see 5 chips with counts → tap 💤 → list shrinks to cold cards, URL has \`?temp=cold\`; tap 「清除」 → list restores

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)