### PR TITLE
feat(stats): 📊 /stats relationship dashboard

### DIFF
--- a/src/app/(app)/stats/page.tsx
+++ b/src/app/(app)/stats/page.tsx
@@ -1,0 +1,110 @@
+import Link from "next/link";
+
+import { StatCard } from "@/components/stats/StatCard";
+import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
+import { listCardsForUser, listRecentContactEventsForUser } from "@/db/cards";
+import { computeTemperature } from "@/lib/cards/relationship-temp";
+import { readSession } from "@/lib/firebase/session";
+import { aggregateStats } from "@/lib/stats/aggregate";
+
+import styles from "./stats.module.css";
+
+export const metadata = {
+  title: "儀表板",
+};
+
+export default async function StatsPage() {
+  const user = await readSession();
+  if (!user) return null;
+
+  const now = new Date();
+  const [cards, events] = await Promise.all([
+    listCardsForUser(user.uid, { limit: 1000 }),
+    listRecentContactEventsForUser(user.uid, 30),
+  ]);
+  const stats = aggregateStats(cards, events, now);
+
+  return (
+    <article className={styles.article}>
+      <header className={styles.header}>
+        <p className={styles.kicker}>📊 儀表板</p>
+        <h1 className={styles.title}>
+          你的<em>關係健康</em>本週概況
+        </h1>
+        <p className={styles.lead}>
+          本週對話、新人脈、溫度分布、連續 streak。資料來自 /log 累積的對話紀錄。
+        </p>
+      </header>
+
+      <section aria-label="本週" className={styles.statBlock}>
+        <h2 className={styles.blockTitle}>本週</h2>
+        <div className={styles.grid}>
+          <StatCard
+            label="對話次數"
+            value={stats.thisWeek.logCount}
+            hint={`${stats.thisWeek.distinctPeople} 位不同的人`}
+            emphasis="accent"
+          />
+          <StatCard label="新增名片" value={stats.thisWeek.newCardCount} hint="last 7 days" />
+          <StatCard
+            label="連續 streak"
+            value={`${stats.streak.current} 天`}
+            hint={`歷史最長 ${stats.streak.longest} 天`}
+            emphasis={stats.streak.current > 0 ? "accent" : "default"}
+          />
+        </div>
+      </section>
+
+      <section aria-label="本月" className={styles.statBlock}>
+        <h2 className={styles.blockTitle}>本月</h2>
+        <div className={styles.grid}>
+          <StatCard
+            label="對話次數"
+            value={stats.thisMonth.logCount}
+            hint={`${stats.thisMonth.distinctPeople} 位不同的人`}
+          />
+          <StatCard label="新增名片" value={stats.thisMonth.newCardCount} hint="last 30 days" />
+          <StatCard label="名片總數" value={stats.totalCards} hint="非刪除" />
+        </div>
+      </section>
+
+      <section aria-label="溫度分布" className={styles.statBlock}>
+        <h2 className={styles.blockTitle}>關係溫度分布</h2>
+        <div className={styles.tempGrid}>
+          <StatCard label="🔥 本週" value={stats.temperature.hot} />
+          <StatCard label="✨ 本月" value={stats.temperature.warm} />
+          <StatCard label="💫 近 3 月" value={stats.temperature.active} />
+          <StatCard label="🌙 半年內" value={stats.temperature.quiet} />
+          <StatCard label="💤 冷" value={stats.temperature.cold} />
+        </div>
+      </section>
+
+      {stats.topPeople.length > 0 && (
+        <section aria-label="本月最常聊到" className={styles.statBlock}>
+          <h2 className={styles.blockTitle}>本月最常聊到</h2>
+          <ol className={styles.topList}>
+            {stats.topPeople.map((p) => (
+              <li key={p.card.id} className={styles.topItem}>
+                <Link href={`/cards/${p.card.id}`} className={styles.topName}>
+                  {p.card.nameZh || p.card.nameEn || "（未命名）"}
+                </Link>
+                <span className={styles.topMeta}>
+                  <TemperatureBadge temperature={computeTemperature(p.card, now)} compact />
+                  <span className={styles.topCount}>{p.logCount} 次對話</span>
+                </span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
+
+      {stats.thisMonth.logCount === 0 && (
+        <section className={styles.empty}>
+          <p>
+            本月還沒有任何 /log 紀錄。去 <Link href="/log">/log 對話速記</Link> 留第一筆吧。
+          </p>
+        </section>
+      )}
+    </article>
+  );
+}

--- a/src/app/(app)/stats/stats.module.css
+++ b/src/app/(app)/stats/stats.module.css
@@ -1,0 +1,138 @@
+.article {
+  max-width: var(--content-max);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding-bottom: var(--space-md);
+  border-bottom: var(--border-hair) solid var(--color-border);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h2);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+}
+
+.title em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-accent);
+}
+
+.lead {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  line-height: var(--leading-relaxed);
+  margin: var(--space-xs) 0 0;
+  max-width: 60ch;
+}
+
+.statBlock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.blockTitle {
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  font-weight: 500;
+  margin: 0;
+  color: var(--color-ink);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: var(--space-md);
+}
+
+.tempGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: var(--space-sm);
+}
+
+.topList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.topItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.topName {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-ink);
+  text-decoration: none;
+  letter-spacing: var(--tracking-tight);
+}
+
+.topName:hover {
+  color: var(--color-accent-ink);
+  text-decoration: underline;
+}
+
+.topMeta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.topCount {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+}
+
+.empty {
+  padding: var(--space-xl) var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) dashed var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-ink-muted);
+  text-align: center;
+}
+
+.empty a {
+  color: var(--color-accent-ink);
+  margin: 0 0.25em;
+}

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -25,6 +25,7 @@ const PRIMARY: NavItem[] = [
   { href: "/log", label: "🗣️ 對話速記", description: "講一句 log 進對方的卡" },
   { href: "/recap", label: "📓 對話日誌", description: "最近 14 天 log 過的對話" },
   { href: "/prep", label: "📅 會議準備", description: "貼上出席者，10 秒拿到 context" },
+  { href: "/stats", label: "📊 儀表板", description: "本週對話、新人脈、溫度、streak" },
   { href: "/companies", label: "公司", description: "同公司聯絡人聚合" },
   { href: "/events", label: "場合", description: "同場合認識的人" },
   { href: "/tags", label: "標籤", description: "分類 · 重新命名" },

--- a/src/components/stats/StatCard.module.css
+++ b/src/components/stats/StatCard.module.css
@@ -1,0 +1,46 @@
+.card,
+.cardAccent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25em;
+  padding: var(--space-md) var(--space-lg);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  min-height: 6rem;
+  justify-content: space-between;
+}
+
+.cardAccent {
+  border-color: var(--color-accent-ink);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 35%, var(--color-paper)) 0%,
+    var(--color-paper) 100%
+  );
+}
+
+.label {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.value {
+  font-family: var(--font-display);
+  font-size: var(--text-h2);
+  font-weight: 500;
+  color: var(--color-ink);
+  margin: 0;
+  line-height: 1;
+}
+
+.hint {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0;
+}

--- a/src/components/stats/StatCard.tsx
+++ b/src/components/stats/StatCard.tsx
@@ -1,0 +1,18 @@
+import styles from "./StatCard.module.css";
+
+interface StatCardProps {
+  label: string;
+  value: number | string;
+  hint?: string;
+  emphasis?: "default" | "accent";
+}
+
+export function StatCard({ label, value, hint, emphasis = "default" }: StatCardProps) {
+  return (
+    <div className={emphasis === "accent" ? styles.cardAccent : styles.card}>
+      <p className={styles.label}>{label}</p>
+      <p className={styles.value}>{value}</p>
+      {hint && <p className={styles.hint}>{hint}</p>}
+    </div>
+  );
+}

--- a/src/lib/stats/__tests__/aggregate.test.ts
+++ b/src/lib/stats/__tests__/aggregate.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary, ContactEvent } from "@/db/cards";
+import type { RecapItem } from "@/lib/recap/group";
+
+import { aggregateStats } from "../aggregate";
+
+const NOW = new Date(2026, 3, 26, 12, 0, 0);
+
+function aCard(over: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "card-x",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "X",
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...over,
+  } as CardSummary;
+}
+
+function dayOffset(base: Date, days: number): Date {
+  return new Date(base.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+function evItem(cardId: string, daysAgo: number, name = cardId): RecapItem {
+  const event: ContactEvent = {
+    id: `e-${cardId}-${daysAgo}`,
+    at: dayOffset(NOW, daysAgo),
+    note: "n",
+    authorUid: "u",
+    authorDisplay: null,
+  };
+  return {
+    card: aCard({ id: cardId, nameZh: name, lastContactedAt: dayOffset(NOW, daysAgo) }),
+    event,
+  };
+}
+
+describe("aggregateStats", () => {
+  it("empty cards + empty events → zeros across the board", () => {
+    const out = aggregateStats([], [], NOW);
+    expect(out.thisWeek).toEqual({ logCount: 0, newCardCount: 0, distinctPeople: 0 });
+    expect(out.thisMonth).toEqual({ logCount: 0, newCardCount: 0, distinctPeople: 0 });
+    expect(out.streak).toEqual({ current: 0, longest: 0 });
+    expect(out.topPeople).toEqual([]);
+    expect(out.totalCards).toBe(0);
+  });
+
+  it("counts logs in this week vs this month windows correctly", () => {
+    const events = [
+      evItem("a", 1),
+      evItem("a", 2),
+      evItem("b", 5),
+      evItem("c", 10), // outside week, inside month
+      evItem("d", 60), // outside both
+    ];
+    const out = aggregateStats([], events, NOW);
+    expect(out.thisWeek.logCount).toBe(3);
+    expect(out.thisMonth.logCount).toBe(4);
+    expect(out.thisWeek.distinctPeople).toBe(2); // a, b
+    expect(out.thisMonth.distinctPeople).toBe(3); // a, b, c
+  });
+
+  it("counts new cards by createdAt cutoff", () => {
+    const cards = [
+      aCard({ id: "x", createdAt: dayOffset(NOW, 2) }),
+      aCard({ id: "y", createdAt: dayOffset(NOW, 14) }),
+      aCard({ id: "z", createdAt: dayOffset(NOW, 60) }),
+    ];
+    const out = aggregateStats(cards, [], NOW);
+    expect(out.thisWeek.newCardCount).toBe(1);
+    expect(out.thisMonth.newCardCount).toBe(2);
+  });
+
+  it("computes temperature distribution over live cards only", () => {
+    const cards = [
+      aCard({ id: "hot", lastContactedAt: dayOffset(NOW, 3) }),
+      aCard({ id: "cold", lastContactedAt: dayOffset(NOW, 365) }),
+      aCard({ id: "deleted", deletedAt: NOW, lastContactedAt: dayOffset(NOW, 1) }),
+    ];
+    const out = aggregateStats(cards, [], NOW);
+    expect(out.temperature.hot).toBe(1);
+    expect(out.temperature.cold).toBe(1);
+    expect(out.totalCards).toBe(2); // deleted excluded
+  });
+
+  it("streak.current counts back-to-back days from today", () => {
+    const events = [evItem("a", 0), evItem("b", 1), evItem("c", 2)];
+    const out = aggregateStats([], events, NOW);
+    expect(out.streak.current).toBe(3);
+    expect(out.streak.longest).toBeGreaterThanOrEqual(3);
+  });
+
+  it("streak.current = 0 when neither today nor yesterday has logs", () => {
+    const events = [evItem("a", 5)];
+    const out = aggregateStats([], events, NOW);
+    expect(out.streak.current).toBe(0);
+  });
+
+  it("streak.current still active if yesterday is logged but today isn't", () => {
+    const events = [evItem("a", 1), evItem("b", 2)];
+    const out = aggregateStats([], events, NOW);
+    expect(out.streak.current).toBe(2);
+  });
+
+  it("streak.longest finds the largest consecutive run in the window", () => {
+    const events = [
+      evItem("a", 0),
+      evItem("b", 1),
+      evItem("c", 2),
+      // gap of 3 days
+      evItem("d", 7),
+      evItem("e", 8),
+    ];
+    const out = aggregateStats([], events, NOW);
+    expect(out.streak.longest).toBe(3);
+  });
+
+  it("topPeople sorts by log count desc then by recency", () => {
+    const events = [
+      evItem("a", 1),
+      evItem("a", 2),
+      evItem("a", 3),
+      evItem("b", 1),
+      evItem("b", 2),
+      evItem("c", 1),
+    ];
+    const out = aggregateStats([], events, NOW);
+    expect(out.topPeople.map((p) => p.card.id)).toEqual(["a", "b", "c"]);
+    expect(out.topPeople[0]!.logCount).toBe(3);
+  });
+
+  it("topPeople caps at 3", () => {
+    const events = ["a", "b", "c", "d", "e"].map((id) => evItem(id, 1));
+    const out = aggregateStats([], events, NOW);
+    expect(out.topPeople).toHaveLength(3);
+  });
+
+  it("topPeople excludes events outside the 30-day window", () => {
+    const events = [evItem("recent", 1), evItem("old", 60), evItem("old", 90)];
+    const out = aggregateStats([], events, NOW);
+    expect(out.topPeople.map((p) => p.card.id)).toEqual(["recent"]);
+  });
+
+  it("excludes deleted cards from temperature totals", () => {
+    const cards = [
+      aCard({ id: "live", lastContactedAt: dayOffset(NOW, 1) }),
+      aCard({ id: "deleted", deletedAt: NOW, lastContactedAt: dayOffset(NOW, 1) }),
+    ];
+    const out = aggregateStats(cards, [], NOW);
+    expect(out.temperature.hot).toBe(1);
+  });
+
+  it("ignores events with epoch / invalid at", () => {
+    const epochEvent: RecapItem = {
+      card: aCard({ id: "bad" }),
+      event: {
+        id: "epoch",
+        at: new Date(0),
+        note: "x",
+        authorUid: "u",
+        authorDisplay: null,
+      },
+    };
+    const out = aggregateStats([], [epochEvent], NOW);
+    expect(out.thisWeek.logCount).toBe(0);
+    expect(out.streak).toEqual({ current: 0, longest: 0 });
+  });
+});

--- a/src/lib/stats/aggregate.ts
+++ b/src/lib/stats/aggregate.ts
@@ -1,0 +1,201 @@
+import type { CardSummary } from "@/db/cards";
+import { computeTemperature, type TemperatureLevel } from "@/lib/cards/relationship-temp";
+import type { RecapItem } from "@/lib/recap/group";
+
+export interface PeriodStats {
+  /** Total contact-event log count in the window. */
+  logCount: number;
+  /** New cards created in the window. */
+  newCardCount: number;
+  /** Distinct people the user logged with. */
+  distinctPeople: number;
+}
+
+export interface TopPerson {
+  card: CardSummary;
+  logCount: number;
+}
+
+export interface Streak {
+  /** Consecutive days back-to-back from today with ≥1 log. */
+  current: number;
+  /** Longest run within the supplied event window. */
+  longest: number;
+}
+
+export interface AggregatedStats {
+  thisWeek: PeriodStats;
+  thisMonth: PeriodStats;
+  temperature: Record<TemperatureLevel, number>;
+  streak: Streak;
+  /** Top 3 most-logged-with people in last 30 days. */
+  topPeople: TopPerson[];
+  /** Total live (non-deleted) cards in the workspace. */
+  totalCards: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function startOfLocalDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+function diffDays(later: Date, earlier: Date): number {
+  return Math.floor(
+    (startOfLocalDay(later).getTime() - startOfLocalDay(earlier).getTime()) / MS_PER_DAY,
+  );
+}
+
+function isoDay(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const da = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${da}`;
+}
+
+function periodFor(
+  items: readonly RecapItem[],
+  cards: readonly CardSummary[],
+  cutoff: Date,
+): PeriodStats {
+  let logCount = 0;
+  const distinctPeople = new Set<string>();
+  for (const item of items) {
+    if (!item.event.at || item.event.at.getTime() < cutoff.getTime()) continue;
+    logCount++;
+    distinctPeople.add(item.card.id);
+  }
+  let newCardCount = 0;
+  for (const card of cards) {
+    if (!card.createdAt) continue;
+    if (card.createdAt.getTime() >= cutoff.getTime()) newCardCount++;
+  }
+  return {
+    logCount,
+    newCardCount,
+    distinctPeople: distinctPeople.size,
+  };
+}
+
+function temperatureCounts(
+  cards: readonly CardSummary[],
+  now: Date,
+): Record<TemperatureLevel, number> {
+  const counts: Record<TemperatureLevel, number> = {
+    hot: 0,
+    warm: 0,
+    active: 0,
+    quiet: 0,
+    cold: 0,
+  };
+  for (const c of cards) {
+    counts[computeTemperature(c, now).level]++;
+  }
+  return counts;
+}
+
+/**
+ * Streak = number of consecutive days back-to-back from today (inclusive
+ * if there's at least 1 log today, otherwise from yesterday) where the
+ * user logged ≥1 contact event.
+ *
+ * Longest = max consecutive-day run found in the supplied event window.
+ * (Bounded by however much data the caller passed in — typically the
+ * /recap 14-day window. Showing "longest streak in last 14 days" is a
+ * reasonable scope; longer history can be added later.)
+ */
+function computeStreak(items: readonly RecapItem[], now: Date): Streak {
+  // Build set of unique day-keys with at least one event.
+  const days = new Set<string>();
+  for (const it of items) {
+    if (!it.event.at || it.event.at.getTime() <= 0) continue;
+    days.add(isoDay(it.event.at));
+  }
+  if (days.size === 0) return { current: 0, longest: 0 };
+
+  // Walk back from today (or yesterday) day-by-day until a gap.
+  const todayKey = isoDay(now);
+  const yesterdayKey = isoDay(new Date(now.getTime() - MS_PER_DAY));
+  let current = 0;
+  let cursor = days.has(todayKey)
+    ? new Date(now)
+    : days.has(yesterdayKey)
+      ? new Date(now.getTime() - MS_PER_DAY)
+      : null;
+  while (cursor) {
+    const key = isoDay(cursor);
+    if (!days.has(key)) break;
+    current++;
+    cursor = new Date(cursor.getTime() - MS_PER_DAY);
+  }
+
+  // Longest: scan sorted unique day list.
+  const sorted = [...days].sort();
+  let longest = 0;
+  let run = 0;
+  let prev: Date | null = null;
+  for (const key of sorted) {
+    const [y, m, d] = key.split("-").map(Number) as [number, number, number];
+    const day = new Date(y, m - 1, d);
+    if (prev && diffDays(day, prev) === 1) {
+      run++;
+    } else {
+      run = 1;
+    }
+    longest = Math.max(longest, run);
+    prev = day;
+  }
+
+  return { current, longest };
+}
+
+function computeTopPeople(items: readonly RecapItem[], cutoff: Date, limit = 3): TopPerson[] {
+  const counts = new Map<string, { card: CardSummary; logCount: number; lastAt: number }>();
+  for (const item of items) {
+    if (!item.event.at || item.event.at.getTime() < cutoff.getTime()) continue;
+    const cur = counts.get(item.card.id);
+    if (cur) {
+      cur.logCount++;
+      cur.lastAt = Math.max(cur.lastAt, item.event.at.getTime());
+    } else {
+      counts.set(item.card.id, {
+        card: item.card,
+        logCount: 1,
+        lastAt: item.event.at.getTime(),
+      });
+    }
+  }
+  const list = [...counts.values()];
+  list.sort((a, b) => {
+    if (b.logCount !== a.logCount) return b.logCount - a.logCount;
+    if (b.lastAt !== a.lastAt) return b.lastAt - a.lastAt;
+    return a.card.id < b.card.id ? -1 : 1;
+  });
+  return list.slice(0, limit).map((x) => ({ card: x.card, logCount: x.logCount }));
+}
+
+/**
+ * One-shot aggregator. Caller supplies live cards + recent recap items
+ * (already filtered to ≤ N days by listRecentContactEventsForUser) +
+ * a deterministic `now`. No I/O, no LLM — just bucket sums.
+ */
+export function aggregateStats(
+  cards: readonly CardSummary[],
+  events: readonly RecapItem[],
+  now: Date,
+): AggregatedStats {
+  const live = cards.filter((c) => !c.deletedAt);
+  const weekCutoff = new Date(now.getTime() - 7 * MS_PER_DAY);
+  const monthCutoff = new Date(now.getTime() - 30 * MS_PER_DAY);
+
+  return {
+    thisWeek: periodFor(events, live, weekCutoff),
+    thisMonth: periodFor(events, live, monthCutoff),
+    temperature: temperatureCounts(live, now),
+    streak: computeStreak(events, now),
+    topPeople: computeTopPeople(events, monthCutoff, 3),
+    totalCards: live.length,
+  };
+}


### PR DESCRIPTION
## Summary
- Fitness-tracker-style dashboard for relationships. Pure aggregator over existing data; no LLM, no extra I/O cost.
- Sections: 本週 / 本月 stats, temperature distribution, top 3 people this month.
- Streak (current + longest in window) so users can see consecutive-day momentum.

## Why
After shipping 9 AI/conversation slices, users have rich data — but no place that says "you're doing well this week." A motivational dashboard turns the abstract \"關係累積\" into a number they can move.

## Files
- \`src/lib/stats/aggregate.ts\` — pure \`aggregateStats(cards, events, now)\`
- \`src/lib/stats/__tests__/aggregate.test.ts\` — 13 UT (empty, windows, new-card cutoff, temperature deleted-exclusion, streak today/yesterday/no-recent, streak.longest run detection, topPeople ordering + cap + window, epoch-event drop)
- \`src/components/stats/StatCard.{tsx,module.css}\` — reusable card with accent variant
- \`src/app/(app)/stats/{page.tsx,stats.module.css}\` — RSC dashboard
- \`src/components/shell/AppShell.tsx\` — adds 「📊 儀表板」 nav link

## Test plan
- [x] \`pnpm test\` — 13 new UT pass
- [x] \`pnpm test:coverage\` — branches 82.56% (above gate)
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm build\` — green; route table includes /stats
- [ ] Live smoke after merge: open /stats with active /log usage → expect populated week/month, streak counter accurate, topPeople sorted by log count

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)