### PR TITLE
feat(cards): ✅ bulk log interaction from /cards selection toolbar

### DIFF
--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -734,3 +734,55 @@ export const getActionItemsAction = authedAction
       return { ok: true, items, cached: false };
     },
   );
+
+/**
+ * Bulk-log a single contact-event note across N cards. Designed for the
+ * "I just met 5 people at one event" workflow — write the shared
+ * context once, attach it to every card.
+ *
+ * Sequential per-card (not parallel) so partial failures still surface
+ * a meaningful count: we write to as many cards as possible, then
+ * report how many succeeded vs. the first error.
+ */
+export const bulkLogContactAction = authedAction
+  .inputSchema(
+    z.object({
+      ids: z.array(z.string().min(1)).min(1).max(50),
+      note: z.string().max(500).default(""),
+    }),
+  )
+  .action(
+    async ({
+      parsedInput,
+      ctx,
+    }): Promise<
+      { ok: true; logged: number; total: number } | { ok: false; reason: string; logged: number }
+    > => {
+      let logged = 0;
+      for (const id of parsedInput.ids) {
+        try {
+          await logContactEvent(id, {
+            uid: ctx.user.uid,
+            note: parsedInput.note,
+            authorDisplay: ctx.user.displayName ?? null,
+          });
+          logged++;
+        } catch (err) {
+          if (logged > 0) {
+            revalidatePath("/");
+            revalidatePath("/cards");
+            revalidatePath("/followups");
+          }
+          return {
+            ok: false,
+            reason: err instanceof Error ? err.message : "記錄失敗",
+            logged,
+          };
+        }
+      }
+      revalidatePath("/");
+      revalidatePath("/cards");
+      revalidatePath("/followups");
+      return { ok: true, logged, total: parsedInput.ids.length };
+    },
+  );

--- a/src/components/cards/CardsSelectionShell.tsx
+++ b/src/components/cards/CardsSelectionShell.tsx
@@ -5,7 +5,11 @@ import { useState, useTransition } from "react";
 
 import { CardGallery } from "@/components/cards/CardGallery";
 import { CardList } from "@/components/cards/CardList";
-import { bulkSoftDeleteCardsAction, bulkUpdateCardsAction } from "@/app/(app)/cards/actions";
+import {
+  bulkLogContactAction,
+  bulkSoftDeleteCardsAction,
+  bulkUpdateCardsAction,
+} from "@/app/(app)/cards/actions";
 import type { CardSummary } from "@/db/cards";
 import type { TagSummary } from "@/db/tags";
 
@@ -38,6 +42,8 @@ export function CardsSelectionShell({ cards, view, tags }: CardsSelectionShellPr
   const [tagDraft, setTagDraft] = useState("");
   const [showSetEvent, setShowSetEvent] = useState(false);
   const [eventDraft, setEventDraft] = useState("");
+  const [showBulkLog, setShowBulkLog] = useState(false);
+  const [bulkLogDraft, setBulkLogDraft] = useState("");
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const selection = useCardSelection();
@@ -49,6 +55,8 @@ export function CardsSelectionShell({ cards, view, tags }: CardsSelectionShellPr
     selection.clear();
     setShowAddTag(false);
     setShowSetEvent(false);
+    setShowBulkLog(false);
+    setBulkLogDraft("");
     setConfirmDelete(false);
     setError(null);
   }
@@ -91,6 +99,32 @@ export function CardsSelectionShell({ cards, view, tags }: CardsSelectionShellPr
 
   function handleSetPin(pinned: boolean) {
     applyBulk({ ids: selection.selectedIds, patch: { setPinned: pinned } });
+  }
+
+  function handleBulkLog() {
+    setError(null);
+    startTransition(async () => {
+      const res = await bulkLogContactAction({
+        ids: selection.selectedIds,
+        note: bulkLogDraft.trim(),
+      });
+      if (res?.serverError) {
+        setError(res.serverError);
+        return;
+      }
+      const data = res?.data;
+      if (!data) {
+        setError("送出失敗");
+        return;
+      }
+      if (data.ok) {
+        flashToast(`已記錄到 ${data.logged} 張`);
+        exitSelectMode();
+        router.refresh();
+      } else {
+        setError(`部分失敗：${data.reason}（已記錄 ${data.logged} 張）`);
+      }
+    });
   }
 
   function handleBulkDelete() {
@@ -179,6 +213,36 @@ export function CardsSelectionShell({ cards, view, tags }: CardsSelectionShellPr
                 取消
               </button>
             </div>
+          ) : showBulkLog ? (
+            <div className={styles.actionRow}>
+              <input
+                type="text"
+                className={styles.input}
+                placeholder="一筆 note，套用到 N 張卡（可留空只 mark 為已聯絡）"
+                value={bulkLogDraft}
+                onChange={(e) => setBulkLogDraft(e.target.value.slice(0, 500))}
+                maxLength={500}
+                autoFocus
+              />
+              <button
+                type="button"
+                className={styles.primary}
+                onClick={handleBulkLog}
+                disabled={pending}
+              >
+                記錄到 {selection.count} 張
+              </button>
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={() => {
+                  setShowBulkLog(false);
+                  setBulkLogDraft("");
+                }}
+              >
+                取消
+              </button>
+            </div>
           ) : showSetEvent ? (
             <div className={styles.actionRow}>
               <input
@@ -210,6 +274,15 @@ export function CardsSelectionShell({ cards, view, tags }: CardsSelectionShellPr
             </div>
           ) : (
             <div className={styles.actionRow}>
+              <button
+                type="button"
+                className={styles.secondary}
+                onClick={() => setShowBulkLog(true)}
+                disabled={pending}
+                title="把同一筆 note 記錄到所有選中的卡（適合「剛開完同場 event」）"
+              >
+                ✅ 記錄互動
+              </button>
               <button
                 type="button"
                 className={styles.secondary}


### PR DESCRIPTION
## Summary
- Selection toolbar gains 「✅ 記錄互動」 as the new leftmost action.
- One textarea → \`bulkLogContactAction\` writes the same note to N selected cards (sequential loop).
- 5-card use case drops from ~20 actions to 4.

## Why
After voice-multi (PR #97) creates 5 cards from one event, users still want to attach the *same* context (\"demo day, talked about edge AI\") to all of them. Forcing 5 separate disclosures kills the workflow. This is the natural bulk surface that's been missing.

## Files
- \`src/app/(app)/cards/actions.ts\` — \`bulkLogContactAction\`. Sequential loop so a partial failure still reports a useful 「已記錄 N 張」 count + revalidates paths.
- \`src/components/cards/CardsSelectionShell.tsx\` — new disclosure + button + handler with proper discriminated-union narrowing on the result.

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.56% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: select 3 cards → 「✅ 記錄互動」 → type note → submit → expect toast 「已記錄到 3 張」, all 3 cards' lastContactedAt = now (TemperatureBadge → 🔥), the note appears in each card's ContactEventList

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)