### PR TITLE
feat(cards): 🖼️ render scanned card image on detail page

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { CardActions } from "@/components/cards/CardActions";
 import { CardChatBox } from "@/components/cards/CardChatBox";
+import { CardImagePreview } from "@/components/cards/CardImagePreview";
 import { CardInlineEdit } from "@/components/cards/CardInlineEdit";
 import { CoachInsightSection } from "@/components/cards/CoachInsightSection";
 import { ContactEventList } from "@/components/cards/ContactEventList";
@@ -253,6 +254,10 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
         </main>
 
         <aside className={styles.sidebar} aria-label="Contact details">
+          <CardImagePreview
+            frontImagePath={card.frontImagePath}
+            backImagePath={card.backImagePath}
+          />
           <section className={styles.contactBlock}>
             <h2 className={styles.sidebarTitle}>聯絡</h2>
             <ul className={styles.contactList}>

--- a/src/components/cards/CardImagePreview.module.css
+++ b/src/components/cards/CardImagePreview.module.css
@@ -1,0 +1,48 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.title {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.imageLink {
+  display: block;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  outline: none;
+  transition:
+    transform var(--duration-fast) var(--ease-standard),
+    box-shadow var(--duration-fast) var(--ease-standard);
+}
+
+.imageLink:hover,
+.imageLink:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
+}
+
+.image {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  display: block;
+  background: color-mix(in oklch, var(--color-ink) 5%, var(--color-paper));
+}

--- a/src/components/cards/CardImagePreview.tsx
+++ b/src/components/cards/CardImagePreview.tsx
@@ -1,0 +1,86 @@
+import "server-only";
+
+import { signedUrlFor } from "@/lib/storage/card-images";
+
+import styles from "./CardImagePreview.module.css";
+
+interface CardImagePreviewProps {
+  /** Storage path written by the OCR scan flow. */
+  frontImagePath?: string;
+  backImagePath?: string;
+}
+
+/**
+ * Server component — mints a fresh signed URL per image at render time
+ * and renders it inline in the card detail sidebar. Returns null when
+ * no images so we don't reserve UI space for a missing card photo.
+ *
+ * Click-through opens the image in a new tab — sufficient for "I want
+ * to see the original" without adding a lightbox dependency.
+ */
+export async function CardImagePreview({ frontImagePath, backImagePath }: CardImagePreviewProps) {
+  if (!frontImagePath && !backImagePath) return null;
+
+  const [frontUrl, backUrl] = await Promise.all([
+    frontImagePath ? safeSign(frontImagePath) : Promise.resolve(null),
+    backImagePath ? safeSign(backImagePath) : Promise.resolve(null),
+  ]);
+
+  if (!frontUrl && !backUrl) return null;
+
+  return (
+    <section className={styles.section} aria-label="名片照片">
+      <h2 className={styles.title}>名片照片</h2>
+      <div className={styles.stack}>
+        {frontUrl && (
+          <a
+            href={frontUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.imageLink}
+            aria-label="名片正面（點擊放大）"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={frontUrl}
+              alt="名片正面"
+              className={styles.image}
+              loading="lazy"
+              decoding="async"
+            />
+          </a>
+        )}
+        {backUrl && (
+          <a
+            href={backUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.imageLink}
+            aria-label="名片背面（點擊放大）"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={backUrl}
+              alt="名片背面"
+              className={styles.image}
+              loading="lazy"
+              decoding="async"
+            />
+          </a>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Wrap signedUrlFor so a missing/inaccessible storage object doesn't
+ * break the whole card detail render — the image just won't appear.
+ */
+async function safeSign(path: string): Promise<string | null> {
+  try {
+    return await signedUrlFor(path);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Renders the actual scanned business card image in the card detail sidebar — closing a long-standing gap where \`frontImagePath\` / \`backImagePath\` was captured by OCR but never displayed.
- Server component mints a fresh signed URL via existing \`signedUrlFor\` helper. No new infra.
- Click opens the image in a new tab (no lightbox dep).

## Why
The actual business card carries logo, color, layout — *visual* memory hooks that text fields can't replicate. After OCR scan parses the text, the user has no way to see the original. This restores that.

## Files
- \`src/components/cards/CardImagePreview.{tsx,module.css}\` — new
- \`src/app/(app)/cards/[id]/page.tsx\` — render at sidebar top, above 「聯絡」

## Defensive choices
- Returns null when neither image path is set (no UI space reserved)
- \`safeSign\` wraps signedUrlFor in try/catch so a missing/expired Storage object doesn't 500 the whole detail page
- \`aspect-ratio: 16/10\` fixed (standard business card) so layout doesn't jump while loading
- \`lazy + decoding="async"\` so it never blocks above-the-fold render

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.56% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open card detail for an OCR-scanned card → expect photo in sidebar; open one without OCR scan → expect no image block (no empty space)

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)