### PR TITLE
feat(cards): 🖼️ thumbnail images on /cards list + gallery

### DIFF
--- a/src/app/(app)/cards/page.tsx
+++ b/src/app/(app)/cards/page.tsx
@@ -8,6 +8,7 @@ import { ViewToggle } from "@/components/cards/ViewToggle";
 import { listCardsForUser, type CardSummary } from "@/db/cards";
 import { listTagsForUser } from "@/db/tags";
 import { readSession } from "@/lib/firebase/session";
+import { signedUrlsForBatch } from "@/lib/storage/card-images";
 import { findDuplicateGroups } from "@/lib/cards/duplicates";
 import { applyTagFilter, countByTemperature, filterByTemperature } from "@/lib/cards/filter";
 import type { TemperatureLevel } from "@/lib/cards/relationship-temp";
@@ -138,6 +139,19 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
   // its own independent scan, so this is just a notification.
   const duplicateGroupCount = hasSearchState ? 0 : findDuplicateGroups(allCards).length;
 
+  // Mint signed URLs only for the visible cards' frontImagePath. Batched
+  // via Promise.allSettled so a stale/missing storage object doesn't
+  // bring down the whole list. Backed by the storage CDN behind a 15-min
+  // signed URL — adequate caching for the normal browse loop.
+  const imagePaths = cards.map((c) => c.frontImagePath).filter((p): p is string => Boolean(p));
+  const pathToUrl = await signedUrlsForBatch(imagePaths);
+  const imageUrls: Record<string, string> = {};
+  for (const c of cards) {
+    if (c.frontImagePath && pathToUrl[c.frontImagePath]) {
+      imageUrls[c.id] = pathToUrl[c.frontImagePath]!;
+    }
+  }
+
   return (
     <article className={styles.article}>
       <header className={styles.header}>
@@ -197,7 +211,12 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
           </Link>
         </div>
       ) : (
-        <CardsSelectionShell cards={cards} view={isGallery ? "gallery" : "list"} tags={allTags} />
+        <CardsSelectionShell
+          cards={cards}
+          view={isGallery ? "gallery" : "list"}
+          tags={allTags}
+          imageUrls={imageUrls}
+        />
       )}
     </article>
   );

--- a/src/components/cards/CardGallery.module.css
+++ b/src/components/cards/CardGallery.module.css
@@ -58,6 +58,16 @@
   aspect-ratio: 3 / 1.3;
 }
 
+.banner {
+  width: calc(100% + 2 * var(--space-lg));
+  margin: calc(-1 * var(--space-lg)) calc(-1 * var(--space-lg)) 0;
+  height: 5rem;
+  object-fit: cover;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  background: color-mix(in oklch, var(--color-ink) 5%, var(--color-paper));
+  display: block;
+}
+
 .cardHeader {
   display: flex;
   flex-direction: column;

--- a/src/components/cards/CardGallery.tsx
+++ b/src/components/cards/CardGallery.tsx
@@ -12,6 +12,8 @@ interface CardGalleryProps {
   cards: CardSummary[];
   /** When provided, tiles toggle selection instead of navigating. */
   selection?: CardSelectionApi;
+  /** Optional cardId → signed-URL map for thumbnail rendering. */
+  imageUrls?: Record<string, string>;
 }
 
 function primaryName(card: CardSummary): string {
@@ -39,7 +41,7 @@ function tiltFor(id: string): number {
   return magnitude * 0.5;
 }
 
-export function CardGallery({ cards, selection }: CardGalleryProps) {
+export function CardGallery({ cards, selection, imageUrls }: CardGalleryProps) {
   const now = new Date();
   return (
     <ul className={styles.grid}>
@@ -49,6 +51,7 @@ export function CardGallery({ cards, selection }: CardGalleryProps) {
         const stale = shouldShowStaleBadge(card, now);
         const days = stale ? daysSinceContact(card, now) : null;
         const checked = selection?.isSelected(card.id) ?? false;
+        const thumbUrl = imageUrls?.[card.id];
         const inner = (
           <article className={styles.card}>
             {selection && (
@@ -58,6 +61,17 @@ export function CardGallery({ cards, selection }: CardGalleryProps) {
               >
                 {checked ? "✓" : ""}
               </span>
+            )}
+            {thumbUrl && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={thumbUrl}
+                alt=""
+                className={styles.banner}
+                loading="lazy"
+                decoding="async"
+                aria-hidden="true"
+              />
             )}
             <header className={styles.cardHeader}>
               <h2 className={styles.name}>

--- a/src/components/cards/CardList.module.css
+++ b/src/components/cards/CardList.module.css
@@ -32,6 +32,22 @@
   }
 }
 
+.thumb {
+  width: 4rem;
+  height: 2.5rem;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--color-ink) 5%, var(--color-paper));
+  flex-shrink: 0;
+}
+
+.primaryRow {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: flex-start;
+  min-width: 0;
+}
+
 .link:hover {
   background: var(--color-accent-soft);
 }

--- a/src/components/cards/CardList.tsx
+++ b/src/components/cards/CardList.tsx
@@ -12,6 +12,8 @@ interface CardListProps {
   cards: CardSummary[];
   /** When provided, rows render as toggles instead of navigation links. */
   selection?: CardSelectionApi;
+  /** Optional cardId → signed-URL map for thumbnail rendering. */
+  imageUrls?: Record<string, string>;
 }
 
 function primaryName(card: CardSummary): string {
@@ -26,7 +28,7 @@ function role(card: CardSummary): string | null {
   return card.jobTitleZh || card.jobTitleEn || null;
 }
 
-export function CardList({ cards, selection }: CardListProps) {
+export function CardList({ cards, selection, imageUrls }: CardListProps) {
   // Compute now once per render so staleness is stable across the list and
   // doesn't diverge between items rendered a few ms apart.
   const now = new Date();
@@ -37,6 +39,7 @@ export function CardList({ cards, selection }: CardListProps) {
         const days = stale ? daysSinceContact(card, now) : null;
         const checked = selection?.isSelected(card.id) ?? false;
         const temperature = computeTemperature(card, now);
+        const thumbUrl = imageUrls?.[card.id];
         const inner = (
           <>
             {selection && (
@@ -47,16 +50,29 @@ export function CardList({ cards, selection }: CardListProps) {
                 {checked ? "✓" : ""}
               </span>
             )}
-            <div className={styles.primary}>
-              {card.isPinned && (
-                <span className={styles.pinBadge} aria-label="重要聯絡人" title="重要聯絡人">
-                  📍
-                </span>
+            <div className={styles.primaryRow}>
+              {thumbUrl && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={thumbUrl}
+                  alt=""
+                  className={styles.thumb}
+                  loading="lazy"
+                  decoding="async"
+                  aria-hidden="true"
+                />
               )}
-              <span className={styles.name}>{primaryName(card)}</span>
-              {role(card) && <span className={styles.role}>{role(card)}</span>}
-              {company(card) && <span className={styles.company}>{company(card)}</span>}
-              <TemperatureBadge temperature={temperature} compact />
+              <div className={styles.primary}>
+                {card.isPinned && (
+                  <span className={styles.pinBadge} aria-label="重要聯絡人" title="重要聯絡人">
+                    📍
+                  </span>
+                )}
+                <span className={styles.name}>{primaryName(card)}</span>
+                {role(card) && <span className={styles.role}>{role(card)}</span>}
+                {company(card) && <span className={styles.company}>{company(card)}</span>}
+                <TemperatureBadge temperature={temperature} compact />
+              </div>
             </div>
             <p className={styles.why}>{card.whyRemember}</p>
             <div className={styles.meta}>

--- a/src/components/cards/CardsSelectionShell.tsx
+++ b/src/components/cards/CardsSelectionShell.tsx
@@ -22,6 +22,8 @@ interface CardsSelectionShellProps {
   cards: CardSummary[];
   view: View;
   tags: TagSummary[];
+  /** Optional cardId → signed-URL map for thumbnail rendering. */
+  imageUrls?: Record<string, string>;
 }
 
 /**
@@ -32,7 +34,7 @@ interface CardsSelectionShellProps {
  * (sort change / pagination) clears selection. Cross-page persistence
  * was deliberately scoped out; users have only one page of cards.
  */
-export function CardsSelectionShell({ cards, view, tags }: CardsSelectionShellProps) {
+export function CardsSelectionShell({ cards, view, tags, imageUrls }: CardsSelectionShellProps) {
   const router = useRouter();
   const [selectMode, setSelectMode] = useState(false);
   const [pending, startTransition] = useTransition();
@@ -171,9 +173,17 @@ export function CardsSelectionShell({ cards, view, tags }: CardsSelectionShellPr
       </div>
 
       {view === "gallery" ? (
-        <CardGallery cards={cards} selection={selectMode ? selection : undefined} />
+        <CardGallery
+          cards={cards}
+          selection={selectMode ? selection : undefined}
+          imageUrls={imageUrls}
+        />
       ) : (
-        <CardList cards={cards} selection={selectMode ? selection : undefined} />
+        <CardList
+          cards={cards}
+          selection={selectMode ? selection : undefined}
+          imageUrls={imageUrls}
+        />
       )}
 
       {selectMode && selection.count > 0 && (

--- a/src/lib/storage/card-images.ts
+++ b/src/lib/storage/card-images.ts
@@ -94,6 +94,27 @@ export async function signedUrlFor(path: string): Promise<string> {
   return url;
 }
 
+/**
+ * Batch-mint signed URLs in parallel. Returns a path → url map; failed
+ * lookups are silently omitted so a stale or missing storage object
+ * doesn't bring down the whole list view.
+ *
+ * Used by /cards page to render thumbnails — all storage round-trips
+ * happen concurrently while the page already awaits its other data.
+ */
+export async function signedUrlsForBatch(
+  paths: readonly string[],
+): Promise<Record<string, string>> {
+  const unique = [...new Set(paths.filter(Boolean))];
+  if (unique.length === 0) return {};
+  const settled = await Promise.allSettled(unique.map((p) => signedUrlFor(p)));
+  const out: Record<string, string> = {};
+  settled.forEach((res, i) => {
+    if (res.status === "fulfilled") out[unique[i]!] = res.value;
+  });
+  return out;
+}
+
 /** Delete an uploaded image. Safe to call for missing paths. */
 export async function deleteCardImage(path: string): Promise<void> {
   const bucket = getAdminStorage().bucket();


### PR DESCRIPTION
## Summary
- /cards list shows a 64×40px thumbnail to the left of each row.
- /cards gallery shows a 5rem-tall banner at the top of each tile.
- Pulls signed URLs in parallel via new \`signedUrlsForBatch\` helper. Stale/missing storage objects silently omit instead of breaking the list.

## Why
After PR #131 made card photos visible on /cards/[id], the list/gallery views stayed text-only. Once you have 100+ cards, every row looks the same. Thumbnails add visual identity — the rolodex becomes a card *book*, not a names list. Lets users recognize cards by sight before they read.

## Files
- \`src/lib/storage/card-images.ts\` — \`signedUrlsForBatch(paths)\` parallel mint via \`Promise.allSettled\`, dedups paths
- \`src/app/(app)/cards/page.tsx\` — builds \`imageUrls: Record<cardId, url>\` for visible cards, threads to shell
- \`src/components/cards/CardsSelectionShell.tsx\` — accepts \`imageUrls\` prop, forwards to list + gallery
- \`src/components/cards/CardList.{tsx,module.css}\` — wraps \`.primary\` in \`.primaryRow\` flex, adds thumb left
- \`src/components/cards/CardGallery.{tsx,module.css}\` — adds full-bleed banner at top via negative margin trick

## Defensive choices
- \`signedUrlsForBatch\` uses \`Promise.allSettled\` so one bad path doesn't break the whole batch
- Cards without \`frontImagePath\` render no thumbnail (no placeholder, no reserved space)
- All images \`loading="lazy" decoding="async"\` + aspect-ratio fixed → zero layout shift
- 15-min signed URL TTL covers the normal browse loop with plenty of margin

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.56% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke: open /cards (list view) → expect rows with frontImagePath show thumb on left, others show no extra space; switch to gallery → expect banner at top of tile; both views work with 100+ cards without dramatic load delay

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)