### PR TITLE
feat(cards): 👥 RelatedByCompany sidebar — inline list of same-company contacts

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -9,6 +9,7 @@ import { CoachInsightSection } from "@/components/cards/CoachInsightSection";
 import { ContactEventList } from "@/components/cards/ContactEventList";
 import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
 import { PublicProfileToggle } from "@/components/cards/PublicProfileToggle";
+import { RelatedByCompany } from "@/components/cards/RelatedByCompany";
 import { RelatedByEvent } from "@/components/cards/RelatedByEvent";
 import { TagSuggestionsBanner } from "@/components/tags/TagSuggestionsBanner";
 import {
@@ -16,6 +17,7 @@ import {
   getCardsBySharedEvent,
   listCardsForUser,
   listContactEventsForUser,
+  type CardSummary,
 } from "@/db/cards";
 import type { CardCreateInput } from "@/db/schema";
 import { isCoachConfigured } from "@/lib/coach/llm";
@@ -75,21 +77,36 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
   );
   const anniversaryYears = anniversaryEntry?.years ?? null;
 
-  // Count siblings at the same company so we can offer a link to the
-  // /companies/[slug] hub. Wrapped in try/catch — a flaky list query
-  // should not 500 the whole detail page; the link just won't render.
+  // Count + sample siblings at the same company so we can render an
+  // inline mini-list (RelatedByCompany) and a link to /companies/[slug].
+  // Wrapped in try/catch — a flaky list query should not 500 the whole
+  // detail page; the block just won't render.
   let companySiblingCount = 0;
   let companyHrefSlug: string | null = null;
+  let companySiblings: CardSummary[] = [];
   const canonicalCompany = pickCanonicalCompany(card);
   if (canonicalCompany) {
     try {
       const all = await listCardsForUser(user.uid, { limit: 500 });
       const wantedKey = canonicalCompany.toLowerCase().trim();
-      companySiblingCount = all.filter((c) => {
+      const siblings = all.filter((c) => {
         if (c.id === card.id || c.deletedAt) return false;
         const co = pickCanonicalCompany(c).toLowerCase().trim();
         return co === wantedKey;
-      }).length;
+      });
+      companySiblingCount = siblings.length;
+      // lastContactedAt desc, then createdAt desc as tiebreaker — recent
+      // colleagues surface first since those are the most actionable
+      // contacts for "who else have I talked to at $company lately?".
+      siblings.sort((a, b) => {
+        const aLast = a.lastContactedAt?.getTime() ?? 0;
+        const bLast = b.lastContactedAt?.getTime() ?? 0;
+        if (bLast !== aLast) return bLast - aLast;
+        const aCreated = a.createdAt?.getTime() ?? 0;
+        const bCreated = b.createdAt?.getTime() ?? 0;
+        return bCreated - aCreated;
+      });
+      companySiblings = siblings.slice(0, 5);
       if (companySiblingCount > 0) companyHrefSlug = companySlug(canonicalCompany);
     } catch (err) {
       console.error("[card detail] company-sibling count failed:", err);
@@ -330,15 +347,13 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
             <RelatedByEvent eventTag={card.firstMetEventTag} cards={sharedEventCards} />
           )}
 
-          {companyHrefSlug && companySiblingCount > 0 && (
-            <section className={styles.relatedCompany} aria-label="同公司聯絡人">
-              <Link
-                href={`/companies/${encodeURIComponent(companyHrefSlug)}`}
-                className={styles.relatedCompanyLink}
-              >
-                同公司還有 {companySiblingCount} 位 →
-              </Link>
-            </section>
+          {companyHrefSlug && canonicalCompany && companySiblings.length > 0 && (
+            <RelatedByCompany
+              companyName={canonicalCompany}
+              companySlug={companyHrefSlug}
+              cards={companySiblings}
+              totalSiblings={companySiblingCount}
+            />
           )}
 
           <footer className={styles.timestamps}>

--- a/src/components/cards/RelatedByCompany.module.css
+++ b/src/components/cards/RelatedByCompany.module.css
@@ -1,0 +1,109 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border: var(--border-thin) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-raised);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.kicker {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+}
+
+.title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-fg);
+}
+
+.titleLink {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dashed transparent;
+  transition: border-color var(--duration-fast) var(--ease-standard);
+}
+
+.titleLink:hover {
+  border-bottom-color: var(--color-accent-ink);
+}
+
+.count {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+}
+
+.allLink {
+  color: var(--color-accent-ink);
+  text-decoration: none;
+}
+
+.allLink:hover {
+  text-decoration: underline;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.row {
+  border-top: var(--border-hair) solid var(--color-border);
+}
+
+.row:first-child {
+  border-top: none;
+}
+
+.link {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-xs) 0;
+  text-decoration: none;
+  color: inherit;
+  transition: color var(--duration-fast) var(--ease-standard);
+}
+
+.link:hover {
+  color: var(--color-accent-ink);
+}
+
+.name {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-fg);
+}
+
+.sub {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+}
+
+.more {
+  margin: var(--space-xs) 0 0;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+  text-align: right;
+}

--- a/src/components/cards/RelatedByCompany.tsx
+++ b/src/components/cards/RelatedByCompany.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link";
+
+import type { CardSummary } from "@/db/cards";
+
+import styles from "./RelatedByCompany.module.css";
+
+interface RelatedByCompanyProps {
+  /** Display name of the company (canonical, not slugified). */
+  companyName: string;
+  /** URL slug for the company hub page. */
+  companySlug: string;
+  /** Up to N other contacts at the same company (excluding the focal card). */
+  cards: CardSummary[];
+  /** Total siblings at this company (may exceed `cards.length` if truncated). */
+  totalSiblings: number;
+}
+
+/**
+ * Sidebar block on /cards/[id] surfacing other contacts at the same
+ * company. Mirrors the RelatedByEvent shape so the two related-blocks
+ * read consistently. Renders nothing when no siblings.
+ */
+export function RelatedByCompany({
+  companyName,
+  companySlug,
+  cards,
+  totalSiblings,
+}: RelatedByCompanyProps) {
+  if (cards.length === 0) return null;
+  const moreCount = Math.max(0, totalSiblings - cards.length);
+  return (
+    <section className={styles.section} aria-label={`${companyName} 同公司聯絡人`}>
+      <header className={styles.header}>
+        <p className={styles.kicker}>同公司</p>
+        <h3 className={styles.title}>
+          <Link href={`/companies/${encodeURIComponent(companySlug)}`} className={styles.titleLink}>
+            {companyName}
+          </Link>
+        </h3>
+        <p className={styles.count}>
+          {totalSiblings} 位 ·{" "}
+          <Link href={`/companies/${encodeURIComponent(companySlug)}`} className={styles.allLink}>
+            看全部 →
+          </Link>
+        </p>
+      </header>
+      <ul className={styles.list}>
+        {cards.map((c) => {
+          const name = c.nameZh || c.nameEn || "（未命名）";
+          const sub = [c.jobTitleZh || c.jobTitleEn, c.department].filter(Boolean).join(" · ");
+          return (
+            <li key={c.id} className={styles.row}>
+              <Link href={`/cards/${c.id}`} className={styles.link}>
+                <span className={styles.name}>{name}</span>
+                {sub && <span className={styles.sub}>{sub}</span>}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+      {moreCount > 0 && (
+        <p className={styles.more}>
+          還有 {moreCount} 位 ·{" "}
+          <Link href={`/companies/${encodeURIComponent(companySlug)}`} className={styles.allLink}>
+            看全部 →
+          </Link>
+        </p>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Card detail's 「同公司還有 N 位 →」 link expands into an inline list of up to 5 same-company contacts.
- Sorted by \`lastContactedAt\` desc (most-recently-talked-to colleague first — usually the most actionable when prepping for the focal meeting).
- 「還有 N 位 · 看全部 →」 footer preserves the hub link when truncated.

## Why
Three nav clicks to answer "who else from this company do I know?" was friction. Inline list collapses to zero clicks for the top-5 case.

## Files
- \`src/components/cards/RelatedByCompany.{tsx,module.css}\` — new (mirrors RelatedByEvent shape)
- \`src/app/(app)/cards/[id]/page.tsx\` — extends siblings calc to keep top-5; replaces count-only Link with new component

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.56% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open card with ≥1 same-company sibling → expect inline list in sidebar; open card whose company has only that person → expect block hidden; company with >5 siblings → expect 「還有 N 位」 footer

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)