### PR TITLE
feat(cards): 🌡️ tempHot / tempCold sort options on /cards

### DIFF
--- a/src/components/cards/ViewToggle.tsx
+++ b/src/components/cards/ViewToggle.tsx
@@ -13,6 +13,8 @@ const SORT_OPTIONS: Array<{ key: SortKey; label: string; title: string }> = [
   { key: "newest", label: "最新建立", title: "最近新增的名片在前" },
   { key: "contacted", label: "最近聯絡", title: "最近互動過的在前；從未聯絡的排最後" },
   { key: "name", label: "姓名", title: "依中文筆畫 / 字母排序" },
+  { key: "tempHot", label: "🔥 熱→冷", title: "最 active 關係在前" },
+  { key: "tempCold", label: "💤 冷→熱", title: "最 stale 在前 — 該 rekindle 誰一目了然" },
 ];
 
 export function ViewToggle({ current, sort }: ViewToggleProps) {

--- a/src/lib/cards/__tests__/sort.test.ts
+++ b/src/lib/cards/__tests__/sort.test.ts
@@ -32,9 +32,56 @@ describe("parseSortKey", () => {
   });
 
   it("passes known keys through", () => {
-    for (const k of ["newest", "oldest", "contacted", "name"] as const) {
+    for (const k of ["newest", "oldest", "contacted", "name", "tempHot", "tempCold"] as const) {
       expect(parseSortKey(k)).toBe(k);
     }
+  });
+});
+
+describe("sortCards: temperature sorts", () => {
+  function dayOffset(days: number): Date {
+    return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  }
+  // Build cards spanning all 5 tiers via lastContactedAt:
+  //   3d → hot, 20d → warm, 60d → active, 120d → quiet, 365d → cold, null → cold
+  const hot = mk({ id: "h", lastContactedAt: dayOffset(3) });
+  const warm = mk({ id: "w", lastContactedAt: dayOffset(20) });
+  const active = mk({ id: "a", lastContactedAt: dayOffset(60) });
+  const quiet = mk({ id: "q", lastContactedAt: dayOffset(120) });
+  const cold = mk({ id: "c", lastContactedAt: dayOffset(365) });
+  const never = mk({ id: "n" });
+
+  it("tempHot orders hot → cold", () => {
+    const out = sortCards([cold, never, active, hot, warm, quiet], "tempHot").map((c) => c.id);
+    expect(out.slice(0, 4)).toEqual(["h", "w", "a", "q"]);
+    expect(out.slice(4).sort()).toEqual(["c", "n"]);
+  });
+
+  it("tempCold orders cold → hot", () => {
+    const out = sortCards([cold, never, active, hot, warm, quiet], "tempCold").map((c) => c.id);
+    // cold tier first (cold + never both rank 0); then quiet, active, warm, hot
+    expect(out.slice(2)).toEqual(["q", "a", "w", "h"]);
+  });
+
+  it("within the same tier, recency wins as tiebreaker", () => {
+    const recent = mk({ id: "recent", lastContactedAt: dayOffset(2) });
+    const older = mk({ id: "older", lastContactedAt: dayOffset(5) });
+    const out = sortCards([older, recent], "tempHot").map((c) => c.id);
+    expect(out).toEqual(["recent", "older"]);
+  });
+
+  it("pinned card with stale contact still ranks as warm (not quiet/cold)", () => {
+    const pinnedStale = mk({ id: "pin", lastContactedAt: dayOffset(200), isPinned: true });
+    const unpinnedActive = mk({ id: "act", lastContactedAt: dayOffset(60) });
+    // tempHot: pinned-stale (warm=3) > active (rank 2)
+    const out = sortCards([unpinnedActive, pinnedStale], "tempHot").map((c) => c.id);
+    expect(out).toEqual(["pin", "act"]);
+  });
+
+  it("returns a new array (doesn't mutate)", () => {
+    const input = [hot, cold];
+    const out = sortCards(input, "tempHot");
+    expect(out).not.toBe(input);
   });
 });
 

--- a/src/lib/cards/sort.ts
+++ b/src/lib/cards/sort.ts
@@ -1,13 +1,31 @@
 import type { CardSummary } from "@/db/cards";
 
-export type SortKey = "newest" | "oldest" | "contacted" | "name";
+import { computeTemperature, type TemperatureLevel } from "./relationship-temp";
 
-export const SORT_KEYS: readonly SortKey[] = ["newest", "oldest", "contacted", "name"];
+export type SortKey = "newest" | "oldest" | "contacted" | "name" | "tempHot" | "tempCold";
+
+export const SORT_KEYS: readonly SortKey[] = [
+  "newest",
+  "oldest",
+  "contacted",
+  "name",
+  "tempHot",
+  "tempCold",
+];
 
 export function parseSortKey(raw: unknown): SortKey {
   if (typeof raw !== "string") return "newest";
   return (SORT_KEYS as readonly string[]).includes(raw) ? (raw as SortKey) : "newest";
 }
+
+// Level ordering used by tempHot / tempCold sorts. Higher number = warmer.
+const LEVEL_RANK: Record<TemperatureLevel, number> = {
+  hot: 4,
+  warm: 3,
+  active: 2,
+  quiet: 1,
+  cold: 0,
+};
 
 function primaryName(c: CardSummary): string {
   return c.nameZh || c.nameEn || "";
@@ -43,6 +61,27 @@ export function sortCards(cards: CardSummary[], key: SortKey): CardSummary[] {
         if (!na && nb) return 1;
         const cmp = collator.compare(na, nb);
         return cmp !== 0 ? cmp : stableFallback(a, b);
+      });
+      break;
+    }
+    case "tempHot":
+    case "tempCold": {
+      // Compute temperature once per card before sort to keep the
+      // comparator O(1) per call. Pinned cards' "warm floor" is honored
+      // because computeTemperature already does that bump.
+      const now = new Date();
+      const ranks = new Map<string, number>();
+      for (const c of out) {
+        ranks.set(c.id, LEVEL_RANK[computeTemperature(c, now).level]);
+      }
+      out.sort((a, b) => {
+        const ra = ranks.get(a.id) ?? 0;
+        const rb = ranks.get(b.id) ?? 0;
+        if (ra !== rb) return key === "tempHot" ? rb - ra : ra - rb;
+        // Within the same tier, fall back to recency so the secondary
+        // ordering still feels intuitive (most-recent-contact within
+        // the tier surfaces first).
+        return tsDesc(a.lastContactedAt, b.lastContactedAt) || stableFallback(a, b);
       });
       break;
     }


### PR DESCRIPTION
## Summary
- Adds 「🔥 熱→冷」 and 「💤 冷→熱」 sort options. URL: \`?sort=tempHot\` / \`?sort=tempCold\`.
- Composable with existing tag filter, temp filter, and search.
- Pinned-stale cards still rank as warm because \`computeTemperature\` applies the floor before scoring.

## Why
Filter chips show "only this tier"; sort shows "ordered by tier". Together they cover the two queries every business user has on /cards: \"who's hot right now?\" and \"who should I rekindle?\".

## Files
- \`src/lib/cards/sort.ts\` — \`SortKey\` adds \`tempHot\`/\`tempCold\`; \`LEVEL_RANK\` table; precomputes ranks once per sort
- \`src/components/cards/ViewToggle.tsx\` — two new SORT_OPTIONS
- \`src/lib/cards/__tests__/sort.test.ts\` — 5 new UT (tier order both directions, within-tier recency tiebreaker, pinned-floor preserved, immutability, parseSortKey accepts new keys)

## Test plan
- [x] \`pnpm test\` — 5 new UT pass
- [x] \`pnpm test:coverage\` — branches 82.51% (above gate)
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm build\` — green
- [ ] Live smoke: open /cards → tap 「🔥 熱→冷」 → expect hot cards on top; switch to 「💤 冷→熱」 → cold cards on top; combine with temp filter chip → still ordered correctly inside the filtered subset

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)