### PR TITLE
feat(voice): 🎙️ mic on /prep + CardChatBox textareas

### DIFF
--- a/src/components/cards/CardChatBox.tsx
+++ b/src/components/cards/CardChatBox.tsx
@@ -5,6 +5,7 @@ import { useState, useTransition } from "react";
 import { askCardQuestionAction } from "@/app/(app)/cards/actions";
 
 import styles from "./CardChatBox.module.css";
+import { VoiceMicButton } from "./VoiceMicButton";
 
 interface CardChatBoxProps {
   cardId: string;
@@ -85,6 +86,12 @@ export function CardChatBox({ cardId, displayName }: CardChatBoxProps) {
           rows={2}
           placeholder={placeholder}
           maxLength={500}
+          disabled={pending}
+        />
+        <VoiceMicButton
+          onFinalTranscript={(t) =>
+            setQuestion((prev) => (prev ? `${prev} ${t}` : t).slice(0, 500))
+          }
           disabled={pending}
         />
         <div className={styles.actions}>

--- a/src/components/prep/PrepBoard.tsx
+++ b/src/components/prep/PrepBoard.tsx
@@ -8,6 +8,7 @@ import { encodePrefill } from "@/lib/voice/extract";
 import { computeTemperature } from "@/lib/cards/relationship-temp";
 
 import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
+import { VoiceMicButton } from "@/components/cards/VoiceMicButton";
 
 import styles from "./PrepBoard.module.css";
 
@@ -76,6 +77,10 @@ export function PrepBoard() {
           onChange={(e) => setText(e.target.value)}
           rows={3}
           placeholder="例：明天 3pm 跟 Karen Chen, Tom Lee 開會"
+          disabled={loading}
+        />
+        <VoiceMicButton
+          onFinalTranscript={(t) => setText((prev) => (prev ? `${prev} ${t}` : t))}
           disabled={loading}
         />
         <div className={styles.actions}>


### PR DESCRIPTION
## Summary
- Wires the existing \`VoiceMicButton\` into the two remaining textarea-input surfaces: /prep attendees field and the CardChatBox question field.
- Same append-to-current-input pattern as /log and the in-card 「記錄」 textarea.
- 12 lines total. No new tests (component is already covered).

## Why
Mobile users walking to a meeting want to speak attendee names. Users prepping for a meeting want to speak their question to AI. After this PR, voice input is reachable from every text capture surface in the app.

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.51% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open /prep on phone → see mic → speak names → text appends; open card detail → CardChatBox → mic → speak question → appends

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)