### PR TITLE
feat(prep): 📅 card detail → /prep with this person pre-populated

### DIFF
--- a/src/app/(app)/cards/[id]/detail.module.css
+++ b/src/app/(app)/cards/[id]/detail.module.css
@@ -289,6 +289,28 @@
   border-bottom-style: solid;
 }
 
+.prepLink {
+  display: inline-block;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-accent-ink);
+  text-decoration: none;
+  padding: var(--space-xs) var(--space-md);
+  border: var(--border-hair) dashed var(--color-accent-ink);
+  border-radius: var(--radius-sm);
+  align-self: flex-start;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.prepLink:hover {
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 40%,
+    var(--color-paper)
+  );
+}
+
 .timestamps {
   display: flex;
   flex-direction: column;

--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -356,6 +356,10 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
             />
           )}
 
+          <Link href={`/prep?attendees=${encodeURIComponent(primary)}`} className={styles.prepLink}>
+            📅 用這人準備下次見面 →
+          </Link>
+
           <footer className={styles.timestamps}>
             {card.createdAt && (
               <p>

--- a/src/app/(app)/prep/page.tsx
+++ b/src/app/(app)/prep/page.tsx
@@ -6,7 +6,20 @@ export const metadata = {
   title: "會議準備",
 };
 
-export default function PrepPage() {
+interface PrepPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function PrepPage({ searchParams }: PrepPageProps) {
+  const raw = await searchParams;
+  const attendeesParam = raw.attendees;
+  const initialText =
+    typeof attendeesParam === "string"
+      ? attendeesParam.slice(0, 2000)
+      : Array.isArray(attendeesParam)
+        ? attendeesParam.join(", ").slice(0, 2000)
+        : "";
+
   return (
     <article className={styles.article}>
       <header className={styles.header}>
@@ -20,7 +33,7 @@ export default function PrepPage() {
         </p>
       </header>
 
-      <PrepBoard />
+      <PrepBoard initialText={initialText} />
     </article>
   );
 }

--- a/src/components/prep/PrepBoard.tsx
+++ b/src/components/prep/PrepBoard.tsx
@@ -18,6 +18,11 @@ const EXAMPLES = [
   "tomorrow 4pm: Alice, Bob, Charlie",
 ];
 
+interface PrepBoardProps {
+  /** Optional initial textarea content (e.g. seeded by ?attendees= URL param). */
+  initialText?: string;
+}
+
 type Phase =
   | { kind: "input" }
   | { kind: "loading" }
@@ -39,8 +44,8 @@ function pickRoleCompany(card: {
   return [role, company].filter(Boolean).join(" @ ");
 }
 
-export function PrepBoard() {
-  const [text, setText] = useState("");
+export function PrepBoard({ initialText = "" }: PrepBoardProps = {}) {
+  const [text, setText] = useState(initialText);
   const [phase, setPhase] = useState<Phase>({ kind: "input" });
   const [pending, startTransition] = useTransition();
   const now = new Date();


### PR DESCRIPTION
## Summary
- Card detail sidebar gains 「📅 用這人準備下次見面 →」 link → \`/prep?attendees=<name>\`.
- /prep server-side reads the search param, threads as \`initialText\` prop into PrepBoard.
- Empty-prep workflow unchanged (no param = empty textarea).

## Why
Workflow today: looking at a card → realize "I'm meeting them tomorrow" → nav to /prep → retype the name → submit. New: one link from the sidebar lands you on /prep with the name already in the textarea, ready to add others or just hit 「找人」.

## Files
- \`src/app/(app)/prep/page.tsx\` — accepts \`?attendees=\`, handles string and string[] union, clamps to 2000 chars
- \`src/components/prep/PrepBoard.tsx\` — accepts \`initialText\` prop with default ""
- \`src/app/(app)/cards/[id]/page.tsx\` — renders the link below related-by-company, above timestamps
- \`src/app/(app)/cards/[id]/detail.module.css\` — \`.prepLink\` dashed-accent pill

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.51% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open card → click link → expect /prep with the name in textarea; open /prep directly → still empty

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)