### PR TITLE
feat(stats): ✨ AI weekly digest paragraph at top of /stats

### DIFF
--- a/src/app/(app)/stats/actions.ts
+++ b/src/app/(app)/stats/actions.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { z } from "zod";
+
+import { authedAction } from "@/lib/auth/safe-action";
+import { listCardsForUser, listRecentContactEventsForUser } from "@/db/cards";
+import { isCoachConfigured } from "@/lib/coach/llm";
+import { aggregateStats } from "@/lib/stats/aggregate";
+import { digestCacheMarker } from "@/lib/stats/digest";
+import { callDigestLlm } from "@/lib/stats/digest-llm";
+import { readDigestCache, writeDigestCache } from "@/lib/stats/digest-store";
+
+export type WeeklyDigestResult =
+  | { ok: true; digest: string; cached: boolean }
+  | { ok: false; reason: "no-llm" | "no-data" | "llm-failed" };
+
+/**
+ * ✨ AI 本週摘要 — turns the /stats numbers into a 1-2 sentence prose
+ * summary. Cached at workspaces/{wid}/stats/digest with a fingerprint
+ * marker so a no-op page reload doesn't reburn LLM credits.
+ */
+export const getWeeklyDigestAction = authedAction
+  .inputSchema(z.object({ force: z.boolean().optional().default(false) }))
+  .action(async ({ parsedInput, ctx }): Promise<WeeklyDigestResult> => {
+    if (!isCoachConfigured()) return { ok: false, reason: "no-llm" };
+
+    const now = new Date();
+    const [cards, events] = await Promise.all([
+      listCardsForUser(ctx.user.uid, { limit: 1000 }),
+      listRecentContactEventsForUser(ctx.user.uid, 30),
+    ]);
+    const stats = aggregateStats(cards, events, now);
+
+    // Hide on truly empty data — nothing meaningful to summarize.
+    if (stats.totalCards === 0 && stats.thisMonth.logCount === 0) {
+      return { ok: false, reason: "no-data" };
+    }
+
+    const cacheKey = `v1::${digestCacheMarker(stats)}`;
+
+    if (!parsedInput.force) {
+      const cached = await readDigestCache(ctx.user.uid, cacheKey);
+      if (cached) return { ok: true, digest: cached, cached: true };
+    }
+
+    const digest = await callDigestLlm(stats);
+    if (!digest) return { ok: false, reason: "llm-failed" };
+    await writeDigestCache(ctx.user.uid, cacheKey, digest);
+    return { ok: true, digest, cached: false };
+  });

--- a/src/app/(app)/stats/page.tsx
+++ b/src/app/(app)/stats/page.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
 
 import { StatCard } from "@/components/stats/StatCard";
+import { WeeklyDigestSection } from "@/components/stats/WeeklyDigestSection";
 import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
 import { listCardsForUser, listRecentContactEventsForUser } from "@/db/cards";
 import { computeTemperature } from "@/lib/cards/relationship-temp";
+import { isCoachConfigured } from "@/lib/coach/llm";
 import { readSession } from "@/lib/firebase/session";
 import { aggregateStats } from "@/lib/stats/aggregate";
 
@@ -35,6 +37,10 @@ export default async function StatsPage() {
           本週對話、新人脈、溫度分布、連續 streak。資料來自 /log 累積的對話紀錄。
         </p>
       </header>
+
+      {isCoachConfigured() && (stats.totalCards > 0 || stats.thisMonth.logCount > 0) && (
+        <WeeklyDigestSection />
+      )}
 
       <section aria-label="本週" className={styles.statBlock}>
         <h2 className={styles.blockTitle}>本週</h2>

--- a/src/components/stats/WeeklyDigestSection.module.css
+++ b/src/components/stats/WeeklyDigestSection.module.css
@@ -1,0 +1,38 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-lg);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 35%, var(--color-paper)) 0%,
+    var(--color-paper) 100%
+  );
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-md);
+}
+
+.label {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.body {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-ink);
+  margin: 0;
+  line-height: var(--leading-relaxed);
+}
+
+.placeholder {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-ink-muted);
+  font-size: var(--text-caption);
+  margin: 0;
+}

--- a/src/components/stats/WeeklyDigestSection.tsx
+++ b/src/components/stats/WeeklyDigestSection.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getWeeklyDigestAction } from "@/app/(app)/stats/actions";
+
+import styles from "./WeeklyDigestSection.module.css";
+
+type State =
+  | { kind: "loading" }
+  | { kind: "ready"; digest: string; cached: boolean }
+  | { kind: "hidden" };
+
+/**
+ * Fetches the AI-generated weekly digest paragraph on mount and renders
+ * it at the top of /stats. Hides silently on any failure (no LLM key,
+ * no data, parser empty) so the page never shows a half-broken section.
+ */
+export function WeeklyDigestSection() {
+  const [state, setState] = useState<State>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    void getWeeklyDigestAction({}).then((res) => {
+      if (cancelled) return;
+      if (!res?.data || !res.data.ok) {
+        setState({ kind: "hidden" });
+        return;
+      }
+      setState({ kind: "ready", digest: res.data.digest, cached: res.data.cached });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state.kind === "hidden") return null;
+
+  if (state.kind === "loading") {
+    return (
+      <section className={styles.section} aria-label="本週摘要">
+        <p className={styles.label}>✨ 本週摘要</p>
+        <p className={styles.placeholder}>AI 整理中…</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.section} aria-label="本週摘要">
+      <p className={styles.label}>✨ 本週摘要</p>
+      <p className={styles.body}>{state.digest}</p>
+    </section>
+  );
+}

--- a/src/lib/stats/__tests__/digest.test.ts
+++ b/src/lib/stats/__tests__/digest.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import type { AggregatedStats } from "../aggregate";
+import { buildDigestMessages, digestCacheMarker, parseDigest } from "../digest";
+
+function emptyStats(over: Partial<AggregatedStats> = {}): AggregatedStats {
+  return {
+    thisWeek: { logCount: 0, newCardCount: 0, distinctPeople: 0 },
+    thisMonth: { logCount: 0, newCardCount: 0, distinctPeople: 0 },
+    temperature: { hot: 0, warm: 0, active: 0, quiet: 0, cold: 0 },
+    streak: { current: 0, longest: 0 },
+    topPeople: [],
+    totalCards: 0,
+    ...over,
+  };
+}
+
+describe("buildDigestMessages", () => {
+  it("returns system + user with key numbers", () => {
+    const stats = emptyStats({
+      thisWeek: { logCount: 5, newCardCount: 2, distinctPeople: 4 },
+      streak: { current: 3, longest: 7 },
+    });
+    const msgs = buildDigestMessages(stats);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.role).toBe("system");
+    expect(msgs[1]!.content).toContain("本週 log: 5 次");
+    expect(msgs[1]!.content).toContain("4 位不同");
+    expect(msgs[1]!.content).toContain("連續 streak: 3 天");
+  });
+
+  it("system prompt forbids hallucination of numbers", () => {
+    const msgs = buildDigestMessages(emptyStats());
+    expect(msgs[0]!.content).toContain("不要編造數字");
+  });
+
+  it("includes top person when present", () => {
+    const stats = emptyStats({
+      topPeople: [
+        {
+          card: {
+            id: "k",
+            workspaceId: "w",
+            ownerUid: "u",
+            memberUids: ["u"],
+            nameZh: "Karen",
+            whyRemember: "x",
+            tagIds: [],
+            tagNames: [],
+            phones: [],
+            emails: [],
+            createdAt: null,
+            updatedAt: null,
+            lastContactedAt: null,
+            deletedAt: null,
+          },
+          logCount: 3,
+        },
+      ],
+    });
+    const msgs = buildDigestMessages(stats);
+    expect(msgs[1]!.content).toContain("Karen");
+    expect(msgs[1]!.content).toContain("3 次");
+  });
+
+  it("omits top section when topPeople empty", () => {
+    const msgs = buildDigestMessages(emptyStats());
+    expect(msgs[1]!.content).not.toContain("本月 top");
+  });
+});
+
+describe("parseDigest", () => {
+  it("returns trimmed string for clean input", () => {
+    expect(parseDigest("   本週你 log 5 次   ")).toBe("本週你 log 5 次");
+  });
+
+  it("strips markdown fence", () => {
+    expect(parseDigest("```\nhello\n```")).toBe("hello");
+    expect(parseDigest("```text\nhello\n```")).toBe("hello");
+  });
+
+  it("returns empty for empty / whitespace-only", () => {
+    expect(parseDigest("")).toBe("");
+    expect(parseDigest("   ")).toBe("");
+  });
+
+  it("returns empty for non-string input", () => {
+    // @ts-expect-error testing runtime guard
+    expect(parseDigest(undefined)).toBe("");
+    // @ts-expect-error testing runtime guard
+    expect(parseDigest(null)).toBe("");
+    // @ts-expect-error testing runtime guard
+    expect(parseDigest(42)).toBe("");
+  });
+
+  it("clamps long output at 600 chars", () => {
+    const long = "x".repeat(2000);
+    expect(parseDigest(long).length).toBe(600);
+  });
+});
+
+describe("digestCacheMarker", () => {
+  it("stable for identical stats", () => {
+    const a = emptyStats({ thisWeek: { logCount: 5, newCardCount: 2, distinctPeople: 4 } });
+    const b = emptyStats({ thisWeek: { logCount: 5, newCardCount: 2, distinctPeople: 4 } });
+    expect(digestCacheMarker(a)).toBe(digestCacheMarker(b));
+  });
+
+  it("changes when streak.current changes", () => {
+    const a = emptyStats({ streak: { current: 2, longest: 7 } });
+    const b = emptyStats({ streak: { current: 3, longest: 7 } });
+    expect(digestCacheMarker(a)).not.toBe(digestCacheMarker(b));
+  });
+
+  it("changes when week log count changes", () => {
+    const a = emptyStats({ thisWeek: { logCount: 5, newCardCount: 2, distinctPeople: 4 } });
+    const b = emptyStats({ thisWeek: { logCount: 6, newCardCount: 2, distinctPeople: 4 } });
+    expect(digestCacheMarker(a)).not.toBe(digestCacheMarker(b));
+  });
+
+  it("changes when top person changes", () => {
+    const a = emptyStats({
+      topPeople: [
+        {
+          card: {
+            id: "a",
+            workspaceId: "w",
+            ownerUid: "u",
+            memberUids: ["u"],
+            nameZh: "X",
+            whyRemember: "x",
+            tagIds: [],
+            tagNames: [],
+            phones: [],
+            emails: [],
+            createdAt: null,
+            updatedAt: null,
+            lastContactedAt: null,
+            deletedAt: null,
+          },
+          logCount: 3,
+        },
+      ],
+    });
+    const b = emptyStats({
+      topPeople: [
+        {
+          card: {
+            id: "b",
+            workspaceId: "w",
+            ownerUid: "u",
+            memberUids: ["u"],
+            nameZh: "Y",
+            whyRemember: "x",
+            tagIds: [],
+            tagNames: [],
+            phones: [],
+            emails: [],
+            createdAt: null,
+            updatedAt: null,
+            lastContactedAt: null,
+            deletedAt: null,
+          },
+          logCount: 3,
+        },
+      ],
+    });
+    expect(digestCacheMarker(a)).not.toBe(digestCacheMarker(b));
+  });
+
+  it("changes when temperature distribution changes", () => {
+    const a = emptyStats({
+      temperature: { hot: 1, warm: 0, active: 0, quiet: 0, cold: 0 },
+    });
+    const b = emptyStats({
+      temperature: { hot: 0, warm: 1, active: 0, quiet: 0, cold: 0 },
+    });
+    expect(digestCacheMarker(a)).not.toBe(digestCacheMarker(b));
+  });
+});

--- a/src/lib/stats/digest-llm.ts
+++ b/src/lib/stats/digest-llm.ts
@@ -1,0 +1,54 @@
+import "server-only";
+
+import type { AggregatedStats } from "./aggregate";
+import { buildDigestMessages, parseDigest } from "./digest";
+
+const DEFAULT_BASE_URL = "https://api.minimax.chat/v1";
+const DEFAULT_MODEL = "MiniMax-M2.7";
+const DEFAULT_TIMEOUT_MS = 12_000;
+
+interface MiniMaxChatResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+export async function callDigestLlm(
+  stats: AggregatedStats,
+  options: { timeoutMs?: number } = {},
+): Promise<string | null> {
+  const apiKey = process.env.MINIMAX_API_KEY ?? "";
+  if (!apiKey) return null;
+
+  const baseUrl = process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL;
+  const model = process.env.MINIMAX_MODEL ?? DEFAULT_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const body = {
+    model,
+    temperature: 0.4,
+    max_tokens: 400,
+    messages: buildDigestMessages(stats),
+  };
+
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: abort.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as MiniMaxChatResponse;
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) return null;
+    return parseDigest(raw) || null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/stats/digest-store.ts
+++ b/src/lib/stats/digest-store.ts
@@ -1,0 +1,42 @@
+import "server-only";
+
+import { Timestamp } from "firebase-admin/firestore";
+
+import { getAdminFirestore } from "@/lib/firebase/server";
+import { COLLECTION_WORKSPACES, personalWorkspaceId } from "@/lib/firebase/shared";
+
+const STATS_SUBCOLLECTION = "stats";
+const DIGEST_DOC = "digest";
+
+interface CachedDigestDoc {
+  cacheKey: string;
+  digest: string;
+  generatedAt: Timestamp;
+}
+
+export async function readDigestCache(uid: string, cacheKey: string): Promise<string | null> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${COLLECTION_WORKSPACES}/${wid}/${STATS_SUBCOLLECTION}/${DIGEST_DOC}`);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const data = snap.data() as CachedDigestDoc | undefined;
+  if (!data) return null;
+  if (data.cacheKey !== cacheKey) return null;
+  return data.digest;
+}
+
+export async function writeDigestCache(
+  uid: string,
+  cacheKey: string,
+  digest: string,
+): Promise<void> {
+  const wid = personalWorkspaceId(uid);
+  const db = getAdminFirestore();
+  const ref = db.doc(`${COLLECTION_WORKSPACES}/${wid}/${STATS_SUBCOLLECTION}/${DIGEST_DOC}`);
+  await ref.set({
+    cacheKey,
+    digest,
+    generatedAt: Timestamp.now(),
+  });
+}

--- a/src/lib/stats/digest.ts
+++ b/src/lib/stats/digest.ts
@@ -1,0 +1,79 @@
+import type { AggregatedStats } from "./aggregate";
+
+const SYSTEM_PROMPT =
+  "你是商務人脈週報官。" +
+  "使用者把這週關於人脈關係的數據給你 — 對話次數、新增名片、連續 streak、" +
+  "溫度分布、本月最常聊到的人。" +
+  "用 1-2 句話總結這週的關係動態。\n" +
+  "規則：\n" +
+  "- 用繁體中文，自然口吻，不要 bullet、不要 markdown、不要圍欄。\n" +
+  "- 1-2 句話內，≤120 字。\n" +
+  "- 若 streak ≥ 3 → 主動鼓勵 streak (例：「連續 X 天有 log，繼續保持」)。\n" +
+  "- 若有 topPeople → 提到第一名 (例：「本月最常跟 Karen 聊」)。\n" +
+  "- 若有 cold/quiet 大量 → 提醒 (例：「但有 N 位冷關係該 rekindle」)，但不要每次都講，只在 ≥ 3 個 cold 時才提。\n" +
+  "- 不要編造數字 — 只用提供的數字。";
+
+export function buildDigestMessages(
+  stats: AggregatedStats,
+): Array<{ role: "system" | "user"; content: string }> {
+  const lines: string[] = [];
+  lines.push(
+    `本週 log: ${stats.thisWeek.logCount} 次 (${stats.thisWeek.distinctPeople} 位不同的人)`,
+  );
+  lines.push(`本週新增名片: ${stats.thisWeek.newCardCount}`);
+  lines.push(
+    `本月 log: ${stats.thisMonth.logCount} 次 (${stats.thisMonth.distinctPeople} 位不同的人)`,
+  );
+  lines.push(`本月新增名片: ${stats.thisMonth.newCardCount}`);
+  lines.push(`連續 streak: ${stats.streak.current} 天 (歷史最長 ${stats.streak.longest} 天)`);
+  lines.push(`名片總數: ${stats.totalCards}`);
+  lines.push(
+    `溫度分布: 🔥 ${stats.temperature.hot} / ✨ ${stats.temperature.warm} / 💫 ${stats.temperature.active} / 🌙 ${stats.temperature.quiet} / 💤 ${stats.temperature.cold}`,
+  );
+  if (stats.topPeople.length > 0) {
+    const list = stats.topPeople
+      .map((p) => `${p.card.nameZh || p.card.nameEn || "（未命名）"}（${p.logCount} 次）`)
+      .join("、");
+    lines.push(`本月 top: ${list}`);
+  }
+  return [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: lines.join("\n") },
+  ];
+}
+
+const MAX_DIGEST_LEN = 600;
+
+/**
+ * Permissive parser. Output is prose, not structured. Strip fences,
+ * trim, clamp. Returns "" on empty / non-string so caller can branch.
+ */
+export function parseDigest(raw: string): string {
+  if (typeof raw !== "string") return "";
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  const fenced = trimmed.match(/^```(?:\w*)?\s*([\s\S]*?)\s*```$/);
+  const inner = fenced ? fenced[1]!.trim() : trimmed;
+  return inner.slice(0, MAX_DIGEST_LEN);
+}
+
+/**
+ * Cache marker — flips when any user-visible stat changes. Specifically
+ * tracks the bits the LLM is summarizing, so a no-op page reload doesn't
+ * reburn LLM credits. We do NOT include topPeople log counts (they
+ * change daily) — instead use streak.current + total log count, which
+ * already covers the "user did something today" signal.
+ */
+export function digestCacheMarker(stats: AggregatedStats): string {
+  const topId = stats.topPeople[0]?.card.id ?? "";
+  const tempSig = `${stats.temperature.hot}-${stats.temperature.warm}-${stats.temperature.active}-${stats.temperature.quiet}-${stats.temperature.cold}`;
+  return [
+    `wlc=${stats.thisWeek.logCount}`,
+    `wnp=${stats.thisWeek.distinctPeople}`,
+    `mnc=${stats.thisMonth.newCardCount}`,
+    `s=${stats.streak.current}`,
+    `t=${stats.totalCards}`,
+    `tg=${tempSig}`,
+    `tp=${topId}`,
+  ].join("::");
+}


### PR DESCRIPTION
## Summary
- 1-2 sentence prose summary at the top of /stats. \"本週你 logged 5 對話跟 4 位不同的人，連續 3 天 streak — 最常聊到 Karen.\"
- Pure aggregator → SYSTEM_PROMPT (forbids fabrication, caps length, tactical rules) → MiniMax → defensive parse → render.
- Cached by stats fingerprint so no-op page reload doesn\\'t reburn LLM credits.
- Hides silently on no-llm / no-data / parser-failure.

## Why
/stats showed numbers but didn\\'t synthesize them. A 1-sentence summary turns the dashboard into a glanceable weekly check-in — useful for sharing with manager, self-reflection, or just \"how am I doing\" at a glance.

## Files
- \`src/lib/stats/digest.ts\` — pure: \`buildDigestMessages\`, \`parseDigest\` (defensive: fence-strip, clamp, empty-on-non-string), \`digestCacheMarker\`
- \`src/lib/stats/__tests__/digest.test.ts\` — 14 UT
- \`src/lib/stats/digest-llm.ts\` — MiniMax client (400 max_tokens, 0.4 temp)
- \`src/lib/stats/digest-store.ts\` — Firestore cache at \`workspaces/{wid}/stats/digest\`
- \`src/app/(app)/stats/actions.ts\` — \`getWeeklyDigestAction({force?})\`
- \`src/components/stats/WeeklyDigestSection.{tsx,module.css}\` — client section
- \`src/app/(app)/stats/page.tsx\` — renders above 本週 grid when LLM configured + has data

## Test plan
- [x] \`pnpm test\` — 14 new UT pass
- [x] \`pnpm test:coverage\` — branches 82.52% (above gate)
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open /stats with active /log usage → expect prose paragraph at top citing actual numbers; reload → expect cache hit (no second LLM call); log a new event then reload → expect fresh digest

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)