### PR TITLE
feat(home): 🎯 onboarding hero — 4 paths to first card

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { DailyBriefingSection } from "@/components/coach/DailyBriefingSection";
+import { OnboardingHero } from "@/components/home/OnboardingHero";
 import { TimelineSection } from "@/components/timeline/TimelineSection";
 import { listCardsForUser } from "@/db/cards";
 import { isCoachConfigured } from "@/lib/coach/llm";
@@ -50,14 +51,7 @@ export default async function HomePage() {
       </header>
 
       {cards.length === 0 ? (
-        <div className={styles.empty}>
-          <p className={styles.emptyLead}>
-            還沒有任何名片。從手動建立第一張開始—— 就算不用 OCR，這個工具也已經準備好陪你記錄關係。
-          </p>
-          <Link href="/cards/new" className={styles.emptyBtn}>
-            建立第一張名片
-          </Link>
-        </div>
+        <OnboardingHero />
       ) : totalInSections === 0 ? (
         <div className={styles.empty}>
           <p className={styles.emptyLead}>

--- a/src/components/home/OnboardingHero.module.css
+++ b/src/components/home/OnboardingHero.module.css
@@ -1,0 +1,121 @@
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.heroHeader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.kicker {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--color-accent-ink);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--text-h2);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+}
+
+.title em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-accent);
+}
+
+.lead {
+  font-family: var(--font-serif);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+  line-height: var(--leading-relaxed);
+  margin: var(--space-xs) 0 0;
+  max-width: 60ch;
+}
+
+.lead em {
+  font-style: italic;
+  color: var(--color-ink);
+}
+
+.grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--space-md);
+}
+
+.card,
+.cardEmphasis {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-lg);
+  background: var(--color-paper);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  color: inherit;
+  min-height: 11rem;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    transform var(--duration-fast) var(--ease-standard),
+    box-shadow var(--duration-fast) var(--ease-standard);
+}
+
+.cardEmphasis {
+  border-color: var(--color-accent-ink);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 35%, var(--color-paper)) 0%,
+    var(--color-paper) 100%
+  );
+}
+
+.card:hover,
+.cardEmphasis:hover {
+  border-color: var(--color-accent-ink);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+}
+
+.emoji {
+  font-size: 2.4rem;
+  line-height: 1;
+}
+
+.cardTitle {
+  font-family: var(--font-display);
+  font-size: var(--text-h4);
+  font-weight: 500;
+  color: var(--color-ink);
+  letter-spacing: var(--tracking-tight);
+}
+
+.description {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  line-height: var(--leading-relaxed);
+  flex: 1;
+}
+
+.cta {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-accent-ink);
+  margin-top: auto;
+}

--- a/src/components/home/OnboardingHero.tsx
+++ b/src/components/home/OnboardingHero.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+
+import styles from "./OnboardingHero.module.css";
+
+interface PathCardData {
+  href: string;
+  emoji: string;
+  title: string;
+  description: string;
+  cta: string;
+  emphasis?: boolean;
+}
+
+const PATHS: PathCardData[] = [
+  {
+    href: "/cards/voice",
+    emoji: "🎙️",
+    title: "語音建卡",
+    description: "30 秒講出剛遇到的人，AI 幫你抽出姓名、職稱、公司",
+    cta: "開始說話",
+    emphasis: true,
+  },
+  {
+    href: "/cards/scan",
+    emoji: "📷",
+    title: "拍實體名片",
+    description: "OCR 掃描，自動填欄位 — 適合剛從 networking event 回來",
+    cta: "上傳照片",
+  },
+  {
+    href: "/cards/new",
+    emoji: "✏️",
+    title: "手動建立",
+    description: "一字一字打 — 最簡單、最熟悉",
+    cta: "新增表單",
+  },
+  {
+    href: "/import",
+    emoji: "📥",
+    title: "vCard / CSV / LinkedIn 匯入",
+    description: "已經在別處有名單？一次匯入幾百筆",
+    cta: "匯入聯絡人",
+  },
+];
+
+/**
+ * First-run hero on the home page when the user has zero cards. Surfaces
+ * the four capture paths side-by-side instead of forcing them through a
+ * single CTA — different users prefer different on-ramps and we want to
+ * show that choice immediately rather than buried in nav.
+ */
+export function OnboardingHero() {
+  return (
+    <section className={styles.hero} aria-labelledby="onboarding-hero-title">
+      <header className={styles.heroHeader}>
+        <p className={styles.kicker}>第一張名片</p>
+        <h2 id="onboarding-hero-title" className={styles.title}>
+          選你<em>最快</em>的方式開始
+        </h2>
+        <p className={styles.lead}>
+          這個工具的核心不是名片儲存，是<em>關係的脈絡</em> ——
+          每張卡都會記下「為什麼記得這個人」、之後的對話、AI 推薦下一步。 從一張卡開始就好。
+        </p>
+      </header>
+      <ul className={styles.grid}>
+        {PATHS.map((p) => (
+          <li key={p.href}>
+            <Link href={p.href} className={p.emphasis ? styles.cardEmphasis : styles.card}>
+              <span className={styles.emoji} aria-hidden="true">
+                {p.emoji}
+              </span>
+              <span className={styles.cardTitle}>{p.title}</span>
+              <span className={styles.description}>{p.description}</span>
+              <span className={styles.cta}>{p.cta} →</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces the single-CTA 0-cards empty state with a 4-card hero grid: voice / scan / manual / import.
- Voice path is visually emphasized (accent border + gradient) — it's the fastest on-ramp and we want new users to try it first.
- Hero header explains the relationship-context philosophy in 2 sentences (the *why* before the *how*).

## Why
The existing empty state had one CTA → users didn\\'t know that voice/OCR/import were even options. First impression matters; showing all 4 paths up front lets users pick the one that matches their on-ramp preference.

## Files
- \`src/components/home/OnboardingHero.{tsx,module.css}\` — server component, responsive grid (220px min, stacks 2x2 on narrow), emphasis variant for voice
- \`src/app/(app)/page.tsx\` — replaces the single-CTA empty branch with \`<OnboardingHero />\`; the "all caught up" branch (cards exist but timeline empty) is untouched

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.52% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: log in as a brand-new user (or temporarily soft-delete all cards) → expect 4-card hero on home with voice emphasized; restore cards → existing timeline view returns

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)