### PR TITLE
feat(cards): 🔡 form autocomplete from existing companies / titles / events

### DIFF
--- a/src/app/(app)/cards/[id]/edit/page.tsx
+++ b/src/app/(app)/cards/[id]/edit/page.tsx
@@ -2,7 +2,8 @@ import { notFound } from "next/navigation";
 
 import { CardForm } from "@/components/cards/CardForm";
 import { OcrRescanPanel } from "@/components/scan/OcrRescanPanel";
-import { getCardForUser } from "@/db/cards";
+import { getCardForUser, listCardsForUser } from "@/db/cards";
+import { collectFormSuggestions } from "@/lib/cards/form-suggestions";
 import { readSession } from "@/lib/firebase/session";
 
 import styles from "./edit.module.css";
@@ -21,6 +22,16 @@ export default async function EditCardPage({ params }: EditPageProps) {
   if (!user) return null;
   const card = await getCardForUser(user.uid, id);
   if (!card || card.deletedAt) notFound();
+
+  // Hint datalist values from sibling cards. Best-effort; failure just
+  // means no hints.
+  let suggestions: ReturnType<typeof collectFormSuggestions> | undefined;
+  try {
+    const all = await listCardsForUser(user.uid, { limit: 500 });
+    suggestions = collectFormSuggestions(all.filter((c) => c.id !== id));
+  } catch (err) {
+    console.error("[cards/[id]/edit] form suggestions failed:", err);
+  }
 
   const defaults = {
     nameZh: card.nameZh,
@@ -71,7 +82,7 @@ export default async function EditCardPage({ params }: EditPageProps) {
           social: card.social ?? {},
         }}
       />
-      <CardForm mode="edit" cardId={id} defaults={defaults} />
+      <CardForm mode="edit" cardId={id} defaults={defaults} suggestions={suggestions} />
     </article>
   );
 }

--- a/src/app/(app)/cards/new/page.tsx
+++ b/src/app/(app)/cards/new/page.tsx
@@ -1,5 +1,8 @@
 import { CardForm } from "@/components/cards/CardForm";
+import { listCardsForUser } from "@/db/cards";
 import type { CardCreateInput } from "@/db/schema";
+import { collectFormSuggestions } from "@/lib/cards/form-suggestions";
+import { readSession } from "@/lib/firebase/session";
 import { decodePrefill } from "@/lib/voice/extract";
 
 import styles from "./new.module.css";
@@ -18,6 +21,20 @@ export default async function NewCardPage({ searchParams }: NewCardPageProps) {
   const prefill = prefillRaw ? decodePrefill(prefillRaw) : null;
   const defaults: Partial<CardCreateInput> | undefined = prefill ?? undefined;
 
+  // Hydrate the form's autocompletion datalists from the user's existing
+  // workspace cards. Best-effort: a missing session or read failure just
+  // means no hints appear (form still works).
+  let suggestions: ReturnType<typeof collectFormSuggestions> | undefined;
+  try {
+    const user = await readSession();
+    if (user) {
+      const cards = await listCardsForUser(user.uid, { limit: 500 });
+      suggestions = collectFormSuggestions(cards);
+    }
+  } catch (err) {
+    console.error("[cards/new] form suggestions failed:", err);
+  }
+
   return (
     <article className={styles.article}>
       <header className={styles.header}>
@@ -33,7 +50,7 @@ export default async function NewCardPage({ searchParams }: NewCardPageProps) {
           )}
         </p>
       </header>
-      <CardForm mode="create" defaults={defaults} />
+      <CardForm mode="create" defaults={defaults} suggestions={suggestions} />
     </article>
   );
 }

--- a/src/components/cards/CardForm.tsx
+++ b/src/components/cards/CardForm.tsx
@@ -15,10 +15,23 @@ import styles from "./CardForm.module.css";
 /** RHF form values use the Zod INPUT type (fields with .default() can be undefined). */
 type CardFormValues = z.input<typeof cardCreateSchema>;
 
+export interface CardFormSuggestions {
+  /** Existing zh + en company names from the workspace, deduped. */
+  companies?: string[];
+  /** Existing zh + en job titles. */
+  jobTitles?: string[];
+  /** Existing departments. */
+  departments?: string[];
+  /** Existing firstMetEventTag values. */
+  events?: string[];
+}
+
 interface CardFormProps {
   mode: "create" | "edit";
   cardId?: string;
   defaults?: Partial<CardFormValues>;
+  /** Optional prior values shown as <datalist> hints to encourage consistency. */
+  suggestions?: CardFormSuggestions;
 }
 
 const EMPTY_DEFAULTS: CardFormValues = {
@@ -62,7 +75,7 @@ function mergeDefaults(partial?: Partial<CardFormValues>): CardFormValues {
   };
 }
 
-export function CardForm({ mode, cardId, defaults }: CardFormProps) {
+export function CardForm({ mode, cardId, defaults, suggestions }: CardFormProps) {
   const router = useRouter();
   const [submitting, startTransition] = useTransition();
   const [serverError, setServerError] = useState<string | null>(null);
@@ -139,26 +152,26 @@ export function CardForm({ mode, cardId, defaults }: CardFormProps) {
         <div className={styles.row}>
           <label className={styles.field}>
             <span className={styles.label}>職稱 (中)</span>
-            <input className={styles.input} {...register("jobTitleZh")} />
+            <input className={styles.input} {...register("jobTitleZh")} list="cardform-jobtitles" />
           </label>
           <label className={styles.field}>
             <span className={styles.label}>職稱 (英)</span>
-            <input className={styles.input} {...register("jobTitleEn")} />
+            <input className={styles.input} {...register("jobTitleEn")} list="cardform-jobtitles" />
           </label>
         </div>
         <div className={styles.row}>
           <label className={styles.field}>
             <span className={styles.label}>公司 (中)</span>
-            <input className={styles.input} {...register("companyZh")} />
+            <input className={styles.input} {...register("companyZh")} list="cardform-companies" />
           </label>
           <label className={styles.field}>
             <span className={styles.label}>公司 (英)</span>
-            <input className={styles.input} {...register("companyEn")} />
+            <input className={styles.input} {...register("companyEn")} list="cardform-companies" />
           </label>
         </div>
         <label className={styles.field}>
           <span className={styles.label}>部門</span>
-          <input className={styles.input} {...register("department")} />
+          <input className={styles.input} {...register("department")} list="cardform-departments" />
         </label>
       </fieldset>
 
@@ -293,6 +306,7 @@ export function CardForm({ mode, cardId, defaults }: CardFormProps) {
             <input
               className={styles.input}
               placeholder="COMPUTEX 2024"
+              list="cardform-events"
               {...register("firstMetEventTag")}
             />
           </label>
@@ -345,6 +359,38 @@ export function CardForm({ mode, cardId, defaults }: CardFormProps) {
           {submitting ? "儲存中…" : mode === "create" ? "儲存名片" : "更新名片"}
         </button>
       </div>
+
+      {/* Native datalist autocompletion sourced from existing card values.
+          One <datalist> per field type — companyZh + companyEn share the
+          same list to encourage cross-language consistency. */}
+      {suggestions?.companies && suggestions.companies.length > 0 && (
+        <datalist id="cardform-companies">
+          {suggestions.companies.map((c) => (
+            <option key={c} value={c} />
+          ))}
+        </datalist>
+      )}
+      {suggestions?.jobTitles && suggestions.jobTitles.length > 0 && (
+        <datalist id="cardform-jobtitles">
+          {suggestions.jobTitles.map((t) => (
+            <option key={t} value={t} />
+          ))}
+        </datalist>
+      )}
+      {suggestions?.departments && suggestions.departments.length > 0 && (
+        <datalist id="cardform-departments">
+          {suggestions.departments.map((d) => (
+            <option key={d} value={d} />
+          ))}
+        </datalist>
+      )}
+      {suggestions?.events && suggestions.events.length > 0 && (
+        <datalist id="cardform-events">
+          {suggestions.events.map((e) => (
+            <option key={e} value={e} />
+          ))}
+        </datalist>
+      )}
     </form>
   );
 }

--- a/src/lib/cards/__tests__/form-suggestions.test.ts
+++ b/src/lib/cards/__tests__/form-suggestions.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSummary } from "@/db/cards";
+
+import { collectFormSuggestions } from "../form-suggestions";
+
+function aCard(over: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "c-x",
+    workspaceId: "w",
+    ownerUid: "u",
+    memberUids: ["u"],
+    nameZh: "X",
+    whyRemember: "x",
+    tagIds: [],
+    tagNames: [],
+    phones: [],
+    emails: [],
+    createdAt: null,
+    updatedAt: null,
+    lastContactedAt: null,
+    deletedAt: null,
+    ...over,
+  } as CardSummary;
+}
+
+describe("collectFormSuggestions", () => {
+  it("returns empty arrays for empty input", () => {
+    const out = collectFormSuggestions([]);
+    expect(out.companies).toEqual([]);
+    expect(out.jobTitles).toEqual([]);
+    expect(out.departments).toEqual([]);
+    expect(out.events).toEqual([]);
+  });
+
+  it("collects unique company / jobTitle / department / event values across cards", () => {
+    const cards = [
+      aCard({
+        id: "1",
+        companyZh: "智威",
+        companyEn: "Acme",
+        jobTitleZh: "PM",
+        jobTitleEn: "Product Manager",
+        department: "RD",
+        firstMetEventTag: "COMPUTEX 2024",
+      }),
+      aCard({
+        id: "2",
+        companyZh: "智威",
+        companyEn: "Other Corp",
+        jobTitleZh: "BD",
+        firstMetEventTag: "COMPUTEX 2024",
+      }),
+    ];
+    const out = collectFormSuggestions(cards);
+    expect(out.companies?.sort()).toEqual(["Acme", "Other Corp", "智威"]);
+    expect(out.jobTitles?.sort()).toEqual(["BD", "PM", "Product Manager"]);
+    expect(out.departments).toEqual(["RD"]);
+    expect(out.events).toEqual(["COMPUTEX 2024"]);
+  });
+
+  it("trims whitespace and skips empty strings", () => {
+    const cards = [aCard({ companyZh: "  智威  ", companyEn: "" }), aCard({ companyZh: "智威" })];
+    const out = collectFormSuggestions(cards);
+    expect(out.companies).toEqual(["智威"]);
+  });
+
+  it("excludes deleted cards' values", () => {
+    const cards = [
+      aCard({ id: "live", companyZh: "智威" }),
+      aCard({ id: "deleted", companyZh: "Skip", deletedAt: new Date() }),
+    ];
+    const out = collectFormSuggestions(cards);
+    expect(out.companies).toEqual(["智威"]);
+  });
+
+  it("caps each list at 100 entries", () => {
+    const cards = Array.from({ length: 200 }, (_, i) =>
+      aCard({ id: `c-${i}`, companyZh: `Company ${i}` }),
+    );
+    const out = collectFormSuggestions(cards);
+    expect(out.companies?.length).toBe(100);
+  });
+});

--- a/src/lib/cards/form-suggestions.ts
+++ b/src/lib/cards/form-suggestions.ts
@@ -1,0 +1,42 @@
+import type { CardSummary } from "@/db/cards";
+
+import type { CardFormSuggestions } from "@/components/cards/CardForm";
+
+const MAX_PER_LIST = 100;
+
+function pushIf(set: Set<string>, value: string | undefined | null): void {
+  if (!value) return;
+  const trimmed = value.trim();
+  if (trimmed) set.add(trimmed);
+}
+
+/**
+ * Walk the workspace's card list and collect deduped value sets per
+ * suggestion field. Used by /cards/new + /cards/[id]/edit to feed the
+ * <datalist> hints in CardForm so the second card avoids spelling
+ * drift from the first ("智威" vs "智威科技").
+ *
+ * Caps each list at 100 entries — far above what any real workspace
+ * needs to surface, and keeps the inline HTML payload bounded.
+ */
+export function collectFormSuggestions(cards: readonly CardSummary[]): CardFormSuggestions {
+  const companies = new Set<string>();
+  const jobTitles = new Set<string>();
+  const departments = new Set<string>();
+  const events = new Set<string>();
+  for (const c of cards) {
+    if (c.deletedAt) continue;
+    pushIf(companies, c.companyZh);
+    pushIf(companies, c.companyEn);
+    pushIf(jobTitles, c.jobTitleZh);
+    pushIf(jobTitles, c.jobTitleEn);
+    pushIf(departments, c.department);
+    pushIf(events, c.firstMetEventTag);
+  }
+  return {
+    companies: [...companies].slice(0, MAX_PER_LIST),
+    jobTitles: [...jobTitles].slice(0, MAX_PER_LIST),
+    departments: [...departments].slice(0, MAX_PER_LIST),
+    events: [...events].slice(0, MAX_PER_LIST),
+  };
+}


### PR DESCRIPTION
## Summary
- /cards/new and /cards/[id]/edit now show native \`<datalist>\` suggestions on company / jobTitle / department / event-tag inputs, sourced from the user's existing cards.
- Cuts spelling drift ("智威" vs "智威科技" → ghost duplicates at /companies, /events).
- Pure server-side dedup; no client deps; HTML-native, mobile-friendly.

## Why
The system already groups by company and event tag at /companies and /events. But two near-spellings of the same company create two phantom hubs. Datalist suggestions make the consistent value the path of least resistance.

## Files
- \`src/lib/cards/form-suggestions.ts\` — pure \`collectFormSuggestions(cards)\` returning deduped {companies, jobTitles, departments, events}; excludes deleted cards; caps each list at 100
- \`src/lib/cards/__tests__/form-suggestions.test.ts\` — 5 UT
- \`src/components/cards/CardForm.tsx\` — optional \`suggestions\` prop; wires \`list="..."\` attributes; renders one \`<datalist>\` per non-empty field at form tail
- \`src/app/(app)/cards/new/page.tsx\` — fetches user cards server-side, passes suggestions; try/catch on read failure
- \`src/app/(app)/cards/[id]/edit/page.tsx\` — same, excluding focal card from source so it doesn\\'t suggest its own value back

## Test plan
- [x] \`pnpm test\` — 5 new UT pass
- [x] \`pnpm test:coverage\` — branches 82.53% (above gate)
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open /cards/new with existing workspace data → focus 公司 input → expect dropdown of existing company names; pick one → form value matches; create card → /companies hub shows it grouped with the existing entry, no duplicate

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)