### PR TITLE
feat(voice): 📋 surface email-signature paste as first-class on /cards/voice

### DIFF
--- a/src/app/(app)/cards/voice/page.tsx
+++ b/src/app/(app)/cards/voice/page.tsx
@@ -14,14 +14,18 @@ export default function VoiceCardPage() {
   return (
     <article className={styles.article}>
       <header className={styles.header}>
-        <p className={styles.kicker}>🎙️ 語音建卡</p>
+        <p className={styles.kicker}>🎙️ 語音建卡 · 📋 貼上文字</p>
         <h1 className={styles.title}>
           剛 networking 結束？<em>講 30 秒</em>讓 AI 幫你建檔
         </h1>
         <p className={styles.lead}>
           不用手動填欄位 — 把剛剛遇到的人講出來：「陳玉涵 PM 智威科技 在 2024 Computex 攤位上聊邊緣
-          AI 推論很投緣」。AI 會解析出姓名、職稱、公司、認識場合、為什麼記得，預填到建立表單，你檢查
-          後一鍵送出。
+          AI 推論很投緣」。 AI
+          會解析出姓名、職稱、公司、認識場合、為什麼記得，預填到建立表單，你檢查 後一鍵送出。
+        </p>
+        <p className={styles.lead}>
+          桌機 user：直接<em>貼上 email signature</em>、LinkedIn 介紹、或任何含人名 + 職稱 + 公司的
+          文字段，AI 同樣幫你拆成欄位 — 不用打字。
         </p>
       </header>
 

--- a/src/components/cards/VoiceCardCapture.tsx
+++ b/src/components/cards/VoiceCardCapture.tsx
@@ -14,6 +14,10 @@ const EXAMPLES = [
   "陳玉涵 PM 智威科技 在 2024 Computex 攤位上聊邊緣 AI 推論很投緣，提到他們公司在做 ML 加速器",
   "李大同 沛理科技業務 BD 上週 Web Summit Lisbon 認識，欠他一個 referral 給 NVIDIA 的 contact",
   "今天 Demo Day 認識三個人：A 是 GreenLeaf 共同創辦人 Sarah Wang 在做永續供應鏈，B 是 Pixel 的 PM Tom Chen 在開發 AR 眼鏡，C 是創投 Mike 在找早期 hardware 案",
+  // Email signature paste — typical desktop use case. Same prompt
+  // handles it because the LLM extracts structured fields from any
+  // freeform text containing name + role + company.
+  "Karen Chen\nProduct Manager | GreenLeaf Tech\n+1-555-1234 · karen@greenleaf.com\nlinkedin.com/in/karenchen — 上週 SaaStr 認識的，她們在做 climate analytics",
 ];
 
 type Phase =


### PR DESCRIPTION
## Summary
- Two-line copy change on /cards/voice + one new EXAMPLE in VoiceCardCapture.
- The pipeline already handled freeform text — only discoverability was missing.
- Desktop users now see "📋 貼上文字" in the header and an email-signature sample in 「看範例」.

## Why
Best-kept secret: the voice flow has always been input-method-agnostic. Pasting an email signature (or LinkedIn intro, or any name+role+company snippet) into the textarea triggers the same AI extraction → preview → save flow. But desktop users seeing only 「🎙️ 語音建卡」 wouldn\\'t realize. This is one of those highest-leverage fixes — zero engineering, doubles the addressable workflow.

## Files
- \`src/app/(app)/cards/voice/page.tsx\` — kicker now reads 「🎙️ 語音建卡 · 📋 貼上文字」, added a second \`<p>\` explaining the paste use case
- \`src/components/cards/VoiceCardCapture.tsx\` — EXAMPLES array gains an email-signature pattern

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.53% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open /cards/voice on desktop → expect new copy + new example; click the email-signature example → expect text in textarea → submit → AI extracts Karen Chen's card

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)