### PR TITLE
feat(cards): 📷 upload / replace card photo from card detail

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { CardActions } from "@/components/cards/CardActions";
 import { CardChatBox } from "@/components/cards/CardChatBox";
 import { CardImagePreview } from "@/components/cards/CardImagePreview";
+import { CardImageUploader } from "@/components/cards/CardImageUploader";
 import { CardInlineEdit } from "@/components/cards/CardInlineEdit";
 import { CoachInsightSection } from "@/components/cards/CoachInsightSection";
 import { ContactEventList } from "@/components/cards/ContactEventList";
@@ -275,6 +276,7 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
             frontImagePath={card.frontImagePath}
             backImagePath={card.backImagePath}
           />
+          <CardImageUploader cardId={card.id} hasFrontImage={Boolean(card.frontImagePath)} />
           <section className={styles.contactBlock}>
             <h2 className={styles.sidebarTitle}>聯絡</h2>
             <ul className={styles.contactList}>

--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -786,3 +786,60 @@ export const bulkLogContactAction = authedAction
       return { ok: true, logged, total: parsedInput.ids.length };
     },
   );
+
+/**
+ * 📷 Attach (or replace) a photo on an existing card. Lets users who
+ * created a card manually or via voice add a real card photo later —
+ * the OCR-only frontImagePath path was a one-shot at create time.
+ * Reuses the same uploadCardImage pipeline (Sharp → WebP → Storage).
+ */
+export const attachCardImageAction = authedAction
+  .inputSchema(
+    z.object({
+      cardId: z.string().min(1),
+      fileBase64: z.string().min(1),
+      mimeType: z.string().refine((v) => v.startsWith("image/"), "must be image/*"),
+      side: z.enum(["front", "back"]).default("front"),
+      originalName: z.string().max(200).optional(),
+    }),
+  )
+  .action(
+    async ({
+      parsedInput,
+      ctx,
+    }): Promise<{ ok: true; path: string } | { ok: false; reason: string }> => {
+      const buffer = Buffer.from(parsedInput.fileBase64, "base64");
+      if (buffer.byteLength === 0) return { ok: false, reason: "empty image payload" };
+      if (buffer.byteLength > 10 * 1024 * 1024) return { ok: false, reason: "image exceeds 10MB" };
+
+      // Lazy-import keeps the storage helper (Sharp, Firebase Admin)
+      // out of any cold-import budget that doesn't need it.
+      const { uploadCardImage } = await import("@/lib/storage/card-images");
+      let upload;
+      try {
+        upload = await uploadCardImage({
+          uid: ctx.user.uid,
+          fileBuffer: buffer,
+          originalName: parsedInput.originalName,
+          mimeType: parsedInput.mimeType,
+        });
+      } catch (err) {
+        return { ok: false, reason: err instanceof Error ? err.message : "upload failed" };
+      }
+
+      try {
+        const patch =
+          parsedInput.side === "back"
+            ? { backImagePath: upload.path }
+            : { frontImagePath: upload.path };
+        await updateCardForUser(parsedInput.cardId, patch, { uid: ctx.user.uid });
+      } catch (err) {
+        return { ok: false, reason: err instanceof Error ? err.message : "card update failed" };
+      }
+
+      revalidatePath("/");
+      revalidatePath("/cards");
+      revalidatePath(`/cards/${parsedInput.cardId}`);
+      return { ok: true, path: upload.path };
+    },
+  );

--- a/src/components/cards/CardImageUploader.module.css
+++ b/src/components/cards/CardImageUploader.module.css
@@ -1,0 +1,46 @@
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  align-items: stretch;
+}
+
+.input {
+  display: none;
+}
+
+.button {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: var(--border-hair) dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.button:hover:not(:disabled) {
+  border-color: var(--color-accent-ink);
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 30%,
+    var(--color-paper)
+  );
+}
+
+.button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.error {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-error, #b00020);
+  margin: 0;
+}

--- a/src/components/cards/CardImageUploader.tsx
+++ b/src/components/cards/CardImageUploader.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useRef, useState, useTransition } from "react";
+
+import { attachCardImageAction } from "@/app/(app)/cards/actions";
+
+import styles from "./CardImageUploader.module.css";
+
+interface CardImageUploaderProps {
+  cardId: string;
+  /** True when the card already has frontImagePath — the button label changes from "上傳" to "換一張". */
+  hasFrontImage: boolean;
+}
+
+const MAX_BYTES = 10 * 1024 * 1024;
+
+async function fileToBase64(file: File): Promise<string> {
+  const buffer = await file.arrayBuffer();
+  let binary = "";
+  const bytes = new Uint8Array(buffer);
+  // Process in chunks to avoid call-stack overflow on large files.
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
+/**
+ * Tiny client component that lets a user attach (or replace) the
+ * front photo of an existing card. Hides the native file picker
+ * behind a styled button. After upload, calls router.refresh() so
+ * the sibling <CardImagePreview> server component re-fetches a
+ * fresh signed URL and renders the new image.
+ */
+export function CardImageUploader({ cardId, hasFrontImage }: CardImageUploaderProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const onFile = (file: File) => {
+    setError(null);
+    if (file.size > MAX_BYTES) {
+      setError("檔案超過 10MB");
+      return;
+    }
+    if (!file.type.startsWith("image/")) {
+      setError("請選圖片檔");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        const fileBase64 = await fileToBase64(file);
+        const res = await attachCardImageAction({
+          cardId,
+          fileBase64,
+          mimeType: file.type || "image/jpeg",
+          side: "front",
+          originalName: file.name,
+        });
+        if (!res?.data) {
+          setError("送出失敗（網路）");
+          return;
+        }
+        if (!res.data.ok) {
+          setError(res.data.reason);
+          return;
+        }
+        router.refresh();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "上傳失敗");
+      }
+    });
+  };
+
+  return (
+    <div className={styles.row}>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        className={styles.input}
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) onFile(f);
+          // Reset so picking the same file twice still triggers onChange.
+          e.target.value = "";
+        }}
+        disabled={pending}
+      />
+      <button
+        type="button"
+        className={styles.button}
+        onClick={() => inputRef.current?.click()}
+        disabled={pending}
+      >
+        {pending ? "上傳中…" : hasFrontImage ? "📷 換一張照片" : "📷 上傳名片照片"}
+      </button>
+      {error && (
+        <p role="alert" className={styles.error}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New \`attachCardImageAction\` reuses the existing \`uploadCardImage\` (Sharp → WebP → Storage) pipeline, patches \`frontImagePath\` (or \`backImagePath\`) on the card.
- New \`<CardImageUploader>\` client component renders a styled "📷 上傳照片" / "📷 換一張" button below the existing photo preview in the card-detail sidebar.
- After upload, calls \`router.refresh()\` so the server-rendered \`<CardImagePreview>\` re-fetches a fresh signed URL and the new image appears in place.

## Why
\`frontImagePath\` was a one-shot at create time — only the OCR-scan flow populated it. Cards created manually or via voice could never get a photo back even if the user wanted to add one later. This closes that gap with a small inline uploader.

## Files
- \`src/app/(app)/cards/actions.ts\` — \`attachCardImageAction({cardId, fileBase64, mimeType, side, originalName})\` returns \`{ok, path}\` or \`{ok:false, reason}\`. Lazy-imports the storage helper so non-image actions don\\'t pay the Sharp cold-start cost.
- \`src/components/cards/CardImageUploader.{tsx,module.css}\` — chunked-base64 read (0x8000 chunks), 10MB client-side guard, hidden file input behind styled button.
- \`src/app/(app)/cards/[id]/page.tsx\` — renders the uploader immediately after \`<CardImagePreview>\` in the sidebar so users see "this is the current photo / change it" together.

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.53% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open a manually-created card with no image → expect "📷 上傳名片照片" button → pick file → upload → image appears, button label changes to "📷 換一張"; pick another file → expect image swaps in place

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)