### PR TITLE
feat(shortcuts): ⌨️ extra g-prefix nav + 'n' for /log

### DIFF
--- a/src/components/shell/GlobalShortcuts.tsx
+++ b/src/components/shell/GlobalShortcuts.tsx
@@ -132,6 +132,12 @@ function HelpOverlay({ onClose }: { onClose: () => void }) {
           </div>
           <div className={styles.row}>
             <dt>
+              <kbd>n</kbd>
+            </dt>
+            <dd>對話速記（最快速 capture）</dd>
+          </div>
+          <div className={styles.row}>
+            <dt>
               <kbd>g</kbd> <kbd>h</kbd>
             </dt>
             <dd>回首頁（時間軸）</dd>
@@ -141,6 +147,36 @@ function HelpOverlay({ onClose }: { onClose: () => void }) {
               <kbd>g</kbd> <kbd>c</kbd>
             </dt>
             <dd>名片冊</dd>
+          </div>
+          <div className={styles.row}>
+            <dt>
+              <kbd>g</kbd> <kbd>l</kbd>
+            </dt>
+            <dd>對話速記 /log</dd>
+          </div>
+          <div className={styles.row}>
+            <dt>
+              <kbd>g</kbd> <kbd>p</kbd>
+            </dt>
+            <dd>會議準備 /prep</dd>
+          </div>
+          <div className={styles.row}>
+            <dt>
+              <kbd>g</kbd> <kbd>r</kbd>
+            </dt>
+            <dd>對話日誌 /recap</dd>
+          </div>
+          <div className={styles.row}>
+            <dt>
+              <kbd>g</kbd> <kbd>f</kbd>
+            </dt>
+            <dd>追蹤 /followups</dd>
+          </div>
+          <div className={styles.row}>
+            <dt>
+              <kbd>g</kbd> <kbd>s</kbd>
+            </dt>
+            <dd>儀表板 /stats</dd>
           </div>
           <div className={styles.row}>
             <dt>

--- a/src/lib/shortcuts/__tests__/match.test.ts
+++ b/src/lib/shortcuts/__tests__/match.test.ts
@@ -130,3 +130,27 @@ describe("matchKeyEvent — help overlay", () => {
     expect(ignored.nextPrefix).toBe(helpOpen.prefix);
   });
 });
+
+describe("matchKeyEvent — extended g-prefix nav", () => {
+  it("g l → /log", () => {
+    expect(matchKeyEvent(gPrefix, key("l")).action).toEqual({ kind: "go", href: "/log" });
+  });
+  it("g p → /prep", () => {
+    expect(matchKeyEvent(gPrefix, key("p")).action).toEqual({ kind: "go", href: "/prep" });
+  });
+  it("g r → /recap", () => {
+    expect(matchKeyEvent(gPrefix, key("r")).action).toEqual({ kind: "go", href: "/recap" });
+  });
+  it("g f → /followups", () => {
+    expect(matchKeyEvent(gPrefix, key("f")).action).toEqual({ kind: "go", href: "/followups" });
+  });
+  it("g s → /stats", () => {
+    expect(matchKeyEvent(gPrefix, key("s")).action).toEqual({ kind: "go", href: "/stats" });
+  });
+});
+
+describe("matchKeyEvent — leaf 'n' shortcut", () => {
+  it("'n' alone → /log (fastest conversation-capture path)", () => {
+    expect(matchKeyEvent(noPrefix, key("n")).action).toEqual({ kind: "go", href: "/log" });
+  });
+});

--- a/src/lib/shortcuts/match.ts
+++ b/src/lib/shortcuts/match.ts
@@ -88,6 +88,16 @@ export function matchKeyEvent(ctx: ShortcutContext, e: KeyEventLike): MatchResul
         return { action: { kind: "go", href: "/cards" }, nextPrefix: null };
       case "t":
         return { action: { kind: "go", href: "/tags" }, nextPrefix: null };
+      case "l":
+        return { action: { kind: "go", href: "/log" }, nextPrefix: null };
+      case "p":
+        return { action: { kind: "go", href: "/prep" }, nextPrefix: null };
+      case "r":
+        return { action: { kind: "go", href: "/recap" }, nextPrefix: null };
+      case "f":
+        return { action: { kind: "go", href: "/followups" }, nextPrefix: null };
+      case "s":
+        return { action: { kind: "go", href: "/stats" }, nextPrefix: null };
       case "Escape":
         return { action: null, nextPrefix: null };
       default:
@@ -102,6 +112,9 @@ export function matchKeyEvent(ctx: ShortcutContext, e: KeyEventLike): MatchResul
       return { action: null, nextPrefix: "g" };
     case "c":
       return { action: { kind: "go", href: "/cards/new" }, nextPrefix: null };
+    case "n":
+      // 「n」 = 「new conversation log」 — most common quick-capture.
+      return { action: { kind: "go", href: "/log" }, nextPrefix: null };
     case "?":
       return { action: { kind: "show-help" }, nextPrefix: null };
     case "Escape":


### PR DESCRIPTION
## Summary
- Adds 5 new g-prefix shortcuts: g l/p/r/f/s → /log, /prep, /recap, /followups, /stats.
- Adds single-key \`n\` → /log (most-common capture shouldn\\'t need a two-stroke).
- HelpOverlay (\`?\`) lists them all in capture-then-nav order.

## Why
Power users on desktop already use g h / g c / g t. But /log, /prep, /recap, /followups, /stats had no shortcuts at all — every visit required hamburger / rail nav. These 6 keys cover every primary daily-flow page in 1-2 keystrokes.

## Files
- \`src/lib/shortcuts/match.ts\` — new cases under g-prefix branch + leaf branch
- \`src/lib/shortcuts/__tests__/match.test.ts\` — 6 new UT (one per shortcut)
- \`src/components/shell/GlobalShortcuts.tsx\` — HelpOverlay reflects the additions

## Test plan
- [x] \`pnpm test\` — 6 new UT pass
- [x] \`pnpm test:coverage\` — branches 82.59% (above gate)
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: press \`?\` to see updated cheat sheet; tap \`g l\` from anywhere → land on /log; tap \`n\` from anywhere → /log; tap \`g s\` → /stats

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)