### PR TITLE
feat(home): 📱 PWA install hint banner — mobile-only, dismissible

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { DailyBriefingSection } from "@/components/coach/DailyBriefingSection";
 import { OnboardingHero } from "@/components/home/OnboardingHero";
+import { PwaInstallHint } from "@/components/home/PwaInstallHint";
 import { TimelineSection } from "@/components/timeline/TimelineSection";
 import { listCardsForUser } from "@/db/cards";
 import { isCoachConfigured } from "@/lib/coach/llm";
@@ -69,6 +70,8 @@ export default async function HomePage() {
           </div>
         </>
       )}
+
+      <PwaInstallHint />
     </article>
   );
 }

--- a/src/components/home/PwaInstallHint.module.css
+++ b/src/components/home/PwaInstallHint.module.css
@@ -1,0 +1,92 @@
+.banner {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .banner {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    padding: var(--space-md);
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklch, var(--color-accent-soft, var(--color-paper)) 35%, var(--color-paper)) 0%,
+      var(--color-paper) 100%
+    );
+    border: var(--border-hair) solid var(--color-accent-ink);
+    border-radius: var(--radius-md);
+    margin-top: var(--space-xl);
+  }
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.title {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--color-ink);
+  margin: 0;
+  letter-spacing: var(--tracking-tight);
+}
+
+.subtitle {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0;
+  line-height: var(--leading-relaxed);
+}
+
+.iosTip {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink);
+  background: var(--color-paper);
+  border-left: 3px solid var(--color-accent-ink);
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  margin: 0;
+  line-height: var(--leading-relaxed);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  justify-content: flex-end;
+}
+
+.primary {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.primary:hover {
+  background: var(--color-accent-ink);
+}
+
+.secondary {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  padding: var(--space-xs) var(--space-md);
+  background: transparent;
+  color: var(--color-ink-muted);
+  border: var(--border-hair) solid transparent;
+  cursor: pointer;
+}
+
+.secondary:hover {
+  color: var(--color-accent-ink);
+}

--- a/src/components/home/PwaInstallHint.tsx
+++ b/src/components/home/PwaInstallHint.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import styles from "./PwaInstallHint.module.css";
+
+const STORAGE_KEY = "namecard:pwa-hint-dismissed";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+}
+
+type State = "hidden" | "show";
+
+function detectIOS(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent;
+  // iPad on iOS 13+ identifies as Macintosh; check touch support too.
+  const isIPad = /iPad|Macintosh/i.test(ua) && navigator.maxTouchPoints > 1;
+  return /iPhone|iPod/i.test(ua) || isIPad;
+}
+
+/**
+ * Pure synchronous detect — runs in lazy useState init so we never
+ * trigger setState-in-effect (cascading-render rule). SSR returns
+ * "hidden"; browser checks viewport / standalone / localStorage.
+ */
+function detectShouldShow(): State {
+  if (typeof window === "undefined") return "hidden";
+  if (window.matchMedia?.("(display-mode: standalone)").matches) return "hidden";
+  try {
+    if (window.localStorage?.getItem(STORAGE_KEY)) return "hidden";
+  } catch {
+    // Storage blocked (Safari private mode etc.) — proceed and show.
+  }
+  const isMobile = window.matchMedia?.("(max-width: 768px)").matches ?? false;
+  return isMobile ? "show" : "hidden";
+}
+
+/**
+ * One-time mobile install hint. Hidden on desktop, hidden once installed
+ * (display-mode: standalone), hidden once user dismisses (persisted).
+ *
+ * Android Chrome may emit a `beforeinstallprompt` event before render —
+ * we capture it via useEffect listener and use it to trigger the native
+ * picker when the user opts in. iOS has no programmatic prompt; we
+ * surface a plain-text instruction "Share → Add to Home Screen".
+ */
+export function PwaInstallHint() {
+  const [state, setState] = useState<State>(() => detectShouldShow());
+  const [installEvent, setInstallEvent] = useState<BeforeInstallPromptEvent | null>(null);
+  const [showIosTip, setShowIosTip] = useState(false);
+
+  useEffect(() => {
+    if (state !== "show") return;
+    const onPrompt = (e: Event) => {
+      e.preventDefault();
+      setInstallEvent(e as BeforeInstallPromptEvent);
+    };
+    window.addEventListener("beforeinstallprompt", onPrompt);
+    return () => window.removeEventListener("beforeinstallprompt", onPrompt);
+  }, [state]);
+
+  const dismiss = () => {
+    try {
+      window.localStorage?.setItem(STORAGE_KEY, "1");
+    } catch {
+      // ignore
+    }
+    setState("hidden");
+  };
+
+  const triggerInstall = async () => {
+    if (installEvent) {
+      await installEvent.prompt();
+      await installEvent.userChoice;
+      dismiss();
+      return;
+    }
+    if (detectIOS()) {
+      setShowIosTip(true);
+      return;
+    }
+    // Other browsers without beforeinstallprompt — show iOS-style tip
+    // text as a generic fallback.
+    setShowIosTip(true);
+  };
+
+  if (state !== "show") return null;
+
+  return (
+    <aside className={styles.banner} role="region" aria-label="安裝到手機桌面">
+      <div className={styles.body}>
+        <p className={styles.title}>📱 把 namecard 加到手機桌面</p>
+        <p className={styles.subtitle}>
+          像 native app 一樣全螢幕開啟，桌面有圖示直接點 — 不用每次找 browser bookmark。
+        </p>
+        {showIosTip && (
+          <p className={styles.iosTip}>
+            iOS Safari 步驟：點下方「分享」⤴︎ → 「加入主畫面」 → 完成。
+          </p>
+        )}
+      </div>
+      <div className={styles.actions}>
+        <button type="button" className={styles.primary} onClick={triggerInstall}>
+          {showIosTip ? "了解" : "怎麼裝？"}
+        </button>
+        <button type="button" className={styles.secondary} onClick={dismiss}>
+          稍後再說
+        </button>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- One-time banner at the bottom of the home page on mobile suggesting "Add to Home Screen".
- Hidden on desktop, hidden once installed (\`display-mode: standalone\`), hidden after dismiss (localStorage-persisted).
- Android Chrome: triggers the native install prompt via captured \`beforeinstallprompt\`. iOS: surfaces inline instructions ("點分享 → 加入主畫面").

## Why
PR #115 fixed the PWA manifest basePath so install actually works. But users have no signal that the app *can* be installed on their home screen. A tiny one-time banner closes that loop.

## Files
- \`src/components/home/PwaInstallHint.{tsx,module.css}\` — lazy useState init avoids set-state-in-effect; CSS \`@media\` baseline keeps desktop strictly hidden
- \`src/app/(app)/page.tsx\` — renders \`<PwaInstallHint />\` at the bottom of the home article

## Defensive choices
- Lazy useState (not useEffect setState) — sidesteps React Compiler rule + no flash-of-banner before effect hides it
- \`window.matchMedia?\` optional chaining — works in environments without matchMedia (test runners)
- localStorage failure caught — Safari private mode throws; we still show the banner, just dismiss won\\'t persist
- CSS \`.banner { display: none }\` baseline + \`@media max-width:768px\` override → desktop never sees the banner even if JS misdetects

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.59% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke: open on iPhone Safari → expect banner at bottom of home with "怎麼裝？" / "稍後再說"; tap "怎麼裝？" → see iOS Share-button instructions; tap "稍後再說" → banner disappears + reload → still gone
- [ ] Open on desktop → banner never appears
- [ ] After Add to Home Screen → re-open via icon → banner never appears (display-mode: standalone)

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)