### PR TITLE
feat(cards): 🤖 OCR auto-extract on photo upload

### DIFF
--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -807,7 +807,9 @@ export const attachCardImageAction = authedAction
     async ({
       parsedInput,
       ctx,
-    }): Promise<{ ok: true; path: string } | { ok: false; reason: string }> => {
+    }): Promise<
+      { ok: true; path: string; fieldsExtracted: number } | { ok: false; reason: string }
+    > => {
       const buffer = Buffer.from(parsedInput.fileBase64, "base64");
       if (buffer.byteLength === 0) return { ok: false, reason: "empty image payload" };
       if (buffer.byteLength > 10 * 1024 * 1024) return { ok: false, reason: "image exceeds 10MB" };
@@ -827,12 +829,56 @@ export const attachCardImageAction = authedAction
         return { ok: false, reason: err instanceof Error ? err.message : "upload failed" };
       }
 
+      // Best-effort: run OCR against the new front image so blank
+      // fields on a manually-created card auto-populate. fill-empty
+      // strategy never overwrites the user's typing. OCR failure is
+      // non-fatal — the photo is still saved.
+      let fieldsExtracted = 0;
+      let ocrPatch: Record<string, unknown> = {};
+      if (parsedInput.side === "front") {
+        try {
+          const card = await getCardForUser(ctx.user.uid, parsedInput.cardId);
+          if (card && !card.deletedAt) {
+            const { getOcrProvider } = await import("@/lib/ocr");
+            const { mergeOcrIntoExisting } = await import("@/lib/ocr/merge");
+            const provider = getOcrProvider();
+            const ocrResult = await provider.extract({
+              source: { kind: "url", url: upload.signedUrl },
+              hintLanguage: "mixed",
+            });
+            if (ocrResult.ok) {
+              const current = {
+                nameZh: card.nameZh,
+                nameEn: card.nameEn,
+                jobTitleZh: card.jobTitleZh,
+                jobTitleEn: card.jobTitleEn,
+                department: card.department,
+                companyZh: card.companyZh,
+                companyEn: card.companyEn,
+                phones: card.phones,
+                emails: card.emails,
+                social: card.social ?? {},
+              };
+              ocrPatch = mergeOcrIntoExisting(current, ocrResult.fields, "fill-empty");
+              fieldsExtracted = Object.keys(ocrPatch).length;
+            }
+          }
+        } catch (err) {
+          console.error("[cards/attachCardImage] OCR step failed:", err);
+        }
+      }
+
       try {
-        const patch =
+        const sidePatch =
           parsedInput.side === "back"
             ? { backImagePath: upload.path }
             : { frontImagePath: upload.path };
-        await updateCardForUser(parsedInput.cardId, patch, { uid: ctx.user.uid });
+        // Single update with both image path and any OCR-merged fields.
+        await updateCardForUser(
+          parsedInput.cardId,
+          { ...ocrPatch, ...sidePatch },
+          { uid: ctx.user.uid },
+        );
       } catch (err) {
         return { ok: false, reason: err instanceof Error ? err.message : "card update failed" };
       }
@@ -840,6 +886,6 @@ export const attachCardImageAction = authedAction
       revalidatePath("/");
       revalidatePath("/cards");
       revalidatePath(`/cards/${parsedInput.cardId}`);
-      return { ok: true, path: upload.path };
+      return { ok: true, path: upload.path, fieldsExtracted };
     },
   );

--- a/src/components/cards/CardImageUploader.module.css
+++ b/src/components/cards/CardImageUploader.module.css
@@ -44,3 +44,19 @@
   color: var(--color-error, #b00020);
   margin: 0;
 }
+
+.toast {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-accent-ink);
+  background: color-mix(
+    in oklch,
+    var(--color-accent-soft, var(--color-paper)) 50%,
+    var(--color-paper)
+  );
+  border: var(--border-hair) solid var(--color-accent-ink);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-sm);
+  margin: 0;
+  letter-spacing: var(--tracking-wide);
+}

--- a/src/components/cards/CardImageUploader.tsx
+++ b/src/components/cards/CardImageUploader.tsx
@@ -38,10 +38,12 @@ export function CardImageUploader({ cardId, hasFrontImage }: CardImageUploaderPr
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
   const router = useRouter();
 
   const onFile = (file: File) => {
     setError(null);
+    setToast(null);
     if (file.size > MAX_BYTES) {
       setError("檔案超過 10MB");
       return;
@@ -67,6 +69,11 @@ export function CardImageUploader({ cardId, hasFrontImage }: CardImageUploaderPr
         if (!res.data.ok) {
           setError(res.data.reason);
           return;
+        }
+        if (res.data.fieldsExtracted > 0) {
+          setToast(`✨ AI 從照片補了 ${res.data.fieldsExtracted} 個空白欄位`);
+          // Auto-clear so the toast doesn't linger after the page rehydrates.
+          setTimeout(() => setToast(null), 5000);
         }
         router.refresh();
       } catch (err) {
@@ -101,6 +108,11 @@ export function CardImageUploader({ cardId, hasFrontImage }: CardImageUploaderPr
       {error && (
         <p role="alert" className={styles.error}>
           {error}
+        </p>
+      )}
+      {toast && (
+        <p role="status" className={styles.toast}>
+          {toast}
         </p>
       )}
     </div>


### PR DESCRIPTION
## Summary
- \`attachCardImageAction\` now also runs OCR on the uploaded front image and merges fields into the card via the existing \`fill-empty\` strategy.
- Fields the user has typed are never overwritten.
- Returns \`fieldsExtracted: number\`; uploader shows "✨ AI 從照片補了 N 個空白欄位" toast on success.
- OCR is best-effort: any failure leaves the photo saved with no merged fields, no error to user.

## Why
PR #153 made photo upload work — but just as visual decoration. Users with the "manually create card → take photo later" workflow still had to hand-type every field. Pulling OCR into the same action closes that loop: snap a photo, AI fills phone/email/company/title, your typing stays untouched.

## Files
- \`src/app/(app)/cards/actions.ts\` — \`attachCardImageAction\` extended with OCR + merge step. Lazy-imports \`getOcrProvider\` + \`mergeOcrIntoExisting\` only when uploading an image. Single \`updateCardForUser\` writes both image path and OCR-merged fields atomically.
- \`src/components/cards/CardImageUploader.tsx\` — toast state, 5-second auto-clear; also clears on each new pick.
- \`src/components/cards/CardImageUploader.module.css\` — \`.toast\` pill style.

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.59% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: create a card with only name + whyRemember → upload a real namecard photo → expect toast "✨ AI 從照片補了 N 個欄位" + reload shows phone/email/company filled in; upload another photo to a fully-typed card → expect no overwrite, no toast (or "0 fields")

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)