### PR TITLE
feat(public-profile): 🌐 richer Open Graph metadata + dynamic OG image

### DIFF
--- a/src/app/u/[slug]/opengraph-image.tsx
+++ b/src/app/u/[slug]/opengraph-image.tsx
@@ -1,0 +1,95 @@
+import { ImageResponse } from "next/og";
+
+import { getCardByPublicSlug } from "@/db/cards";
+
+export const runtime = "nodejs";
+export const alt = "數位名片";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+interface Params {
+  params: Promise<{ slug: string }>;
+}
+
+/**
+ * Dynamic Open Graph image for /u/{slug} public profile. Server-rendered
+ * via Next.js's ImageResponse — no external service. Uses only system
+ * fonts so we don't have to bundle a heavy WOFF for the OG path. Falls
+ * back to a generic card design when the slug doesn't resolve so the
+ * graph crawler never gets a 404 image.
+ */
+export default async function Image({ params }: Params) {
+  const { slug } = await params;
+  const card = await getCardByPublicSlug(decodeURIComponent(slug));
+
+  const name = card?.nameZh || card?.nameEn || "Namecard";
+  const role = card?.jobTitleZh || card?.jobTitleEn || "";
+  const company = card?.companyZh || card?.companyEn || "";
+  const subtitle = [role, company].filter(Boolean).join(" @ ");
+
+  return new ImageResponse(
+    <div
+      style={{
+        height: "100%",
+        width: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-start",
+        justifyContent: "center",
+        padding: "80px",
+        background: "linear-gradient(135deg, #fbf9f4 0%, #f1ebe0 100%)",
+        color: "#1a1814",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 28,
+          letterSpacing: 4,
+          textTransform: "uppercase",
+          color: "#7a6a4f",
+          marginBottom: 24,
+        }}
+      >
+        數位名片 · DIGITAL CARD
+      </div>
+      <div
+        style={{
+          fontSize: 96,
+          fontWeight: 600,
+          lineHeight: 1.1,
+          marginBottom: 16,
+          maxWidth: "1000px",
+        }}
+      >
+        {name}
+      </div>
+      {subtitle && (
+        <div
+          style={{
+            fontSize: 40,
+            color: "#403828",
+            maxWidth: "1000px",
+          }}
+        >
+          {subtitle}
+        </div>
+      )}
+      <div
+        style={{
+          position: "absolute",
+          right: "80px",
+          bottom: "60px",
+          fontSize: 24,
+          letterSpacing: 2,
+          color: "#7a6a4f",
+        }}
+      >
+        namecard
+      </div>
+    </div>,
+    {
+      ...size,
+    },
+  );
+}

--- a/src/app/u/[slug]/page.tsx
+++ b/src/app/u/[slug]/page.tsx
@@ -16,7 +16,29 @@ export async function generateMetadata({ params }: PageProps) {
   const card = await getCardByPublicSlug(decodeURIComponent(slug));
   if (!card) return { title: "找不到名片" };
   const name = card.nameZh || card.nameEn || "名片";
-  return { title: `${name} · 數位名片` };
+  const role = card.jobTitleZh || card.jobTitleEn;
+  const company = card.companyZh || card.companyEn;
+  const subtitle = [role, company].filter(Boolean).join(" @ ");
+  // Description doubles as social-card preview text — keep it short and
+  // human, not a SEO keyword stuff. Falls back to whyRemember when role
+  // and company are both blank so the preview always says *something*.
+  const description = subtitle || card.whyRemember || `${name} · 數位名片`;
+  const title = `${name} · 數位名片`;
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: "profile",
+      siteName: "Namecard",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
 }
 
 function lineUrl(lineId: string): string {


### PR DESCRIPTION
## Summary
- \`/u/[slug]\` \`generateMetadata\` returns description / openGraph / twitter — no longer just a bare title.
- New \`opengraph-image.tsx\` (Next.js convention) renders a 1200×630 card-style PNG via \`ImageResponse\`. System fonts only — no extra bundle weight.
- Fallback render when slug doesn\\'t resolve so the crawler never gets a 404 image.

## Why
Sharing a public profile on LINE / WhatsApp / Slack rendered as a plain link with no preview text or image. That underplays what the link is. Standard OG metadata + a card-style image transforms the preview into a real digital business card.

## Files
- \`src/app/u/[slug]/page.tsx\` — \`generateMetadata\` extended (description, openGraph type=profile, twitter summary_large_image)
- \`src/app/u/[slug]/opengraph-image.tsx\` — new; ImageResponse with name (96px), role @ company (40px), quiet "namecard" wordmark in the corner

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.59% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: paste \`https://mac-mini.tailde842d.ts.net/namecard-web/u/{slug}\` in a chat → expect rich preview with OG image; visit \`/u/{slug}/opengraph-image\` directly → expect the PNG

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)