### PR TITLE
feat(cards): 「上次互動 N 天前」 inline next to temperature badge

### DIFF
--- a/src/app/(app)/cards/[id]/detail.module.css
+++ b/src/app/(app)/cards/[id]/detail.module.css
@@ -60,6 +60,20 @@
   flex-wrap: wrap;
 }
 
+.kickerMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.lastSeen {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-fg-muted);
+  letter-spacing: var(--tracking-wide);
+}
+
 .name {
   font-family: var(--font-display);
   font-size: var(--text-h1);

--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -166,7 +166,21 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
           <header className={styles.header}>
             <div className={styles.kickerRow}>
               <p className={styles.kicker}>名片</p>
-              <TemperatureBadge temperature={computeTemperature(card, new Date())} />
+              {(() => {
+                const temp = computeTemperature(card, new Date());
+                const lastSeen =
+                  temp.daysSince === null
+                    ? "從未聯絡"
+                    : temp.daysSince === 0
+                      ? "今天聯絡過"
+                      : `上次互動 ${temp.daysSince} 天前`;
+                return (
+                  <span className={styles.kickerMeta}>
+                    <TemperatureBadge temperature={temp} />
+                    <span className={styles.lastSeen}>{lastSeen}</span>
+                  </span>
+                );
+              })()}
             </div>
             <h1 className={styles.name}>
               <CardInlineEdit


### PR DESCRIPTION
## Summary
- Card detail header now shows the actual day-count next to the temperature badge: 「上次互動 N 天前」 / 「今天聯絡過」 / 「從未聯絡」.
- Pulls the info from existing \`computeTemperature(card, now).daysSince\`. No new computation, no new I/O.
- Visible without hover so mobile users get the same grounding as desktop tooltip-readers.

## Why
The TemperatureBadge tooltip already had this info, but tooltips don\\'t exist on touch devices. "60 天前 vs 13 天前 — should I ping or wait?" is the question users ask themselves looking at a card; this answers it before they even tap.

## Files
- \`src/app/(app)/cards/[id]/page.tsx\` — kicker row wraps badge + new .lastSeen sibling in a .kickerMeta inline-flex
- \`src/app/(app)/cards/[id]/detail.module.css\` — .kickerMeta + .lastSeen muted-caption styles

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.59% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open a never-contacted card → "從未聯絡"; open today\\'s logged card → "今天聯絡過"; open a 60-day-old card → "上次互動 60 天前"

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)