### PR TITLE
feat(timeline): 🌡️ TemperatureBadge on home timeline rows

### DIFF
--- a/src/components/timeline/TimelineSection.module.css
+++ b/src/components/timeline/TimelineSection.module.css
@@ -74,6 +74,13 @@
   gap: 0.1rem;
 }
 
+.nameRow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
 .name {
   font-family: var(--font-display);
   font-size: var(--text-h4);

--- a/src/components/timeline/TimelineSection.tsx
+++ b/src/components/timeline/TimelineSection.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 
+import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
 import type { CardSummary } from "@/db/cards";
+import { computeTemperature } from "@/lib/cards/relationship-temp";
 import type { TimelineSection as TimelineSectionData } from "@/lib/timeline/categorize";
 
 import styles from "./TimelineSection.module.css";
@@ -51,6 +53,10 @@ function sectionMeta(section: TimelineSectionData, card: CardSummary): string | 
 
 export function TimelineSection({ section }: TimelineSectionProps) {
   if (section.cards.length === 0) return null;
+  // Compute `now` once per render so all rows share the same reference
+  // moment (otherwise tens of microsecond drifts between calls could
+  // straddle a daysSince boundary).
+  const now = new Date();
   return (
     <section className={styles.section} aria-labelledby={`section-${section.id}`}>
       <header className={styles.header}>
@@ -64,7 +70,10 @@ export function TimelineSection({ section }: TimelineSectionProps) {
           <li key={card.id}>
             <Link href={`/cards/${card.id}`} className={styles.row}>
               <div className={styles.who}>
-                <span className={styles.name}>{primaryName(card)}</span>
+                <span className={styles.nameRow}>
+                  <span className={styles.name}>{primaryName(card)}</span>
+                  <TemperatureBadge temperature={computeTemperature(card, now)} compact />
+                </span>
                 {subline(card) && <span className={styles.sub}>{subline(card)}</span>}
               </div>
               <p className={styles.why}>{card.whyRemember}</p>


### PR DESCRIPTION
## Summary
- Each card row in home TimelineSection now shows a compact 🔥/✨/💫/🌙/💤 badge next to the name.
- Visual-language consistency with /cards list, /cards gallery, /cards/[id], /prep, /stats — all surfaces now share the temperature shorthand.
- \`now\` computed once per render so daysSince doesn\\'t drift across rows.

## Why
Home is where users land most. The temperature badge is the single most-glanced piece of relationship metadata in the app, but TimelineSection rows didn\\'t carry it. Adding it closes the visual gap.

## Files
- \`src/components/timeline/TimelineSection.tsx\` — adds compact badge in a new \`.nameRow\` wrapper inside the existing \`.who\` column-flex
- \`src/components/timeline/TimelineSection.module.css\` — \`.nameRow\` inline-flex helper

## Test plan
- [x] \`pnpm typecheck\` / \`lint\` / \`format\` — clean
- [x] \`pnpm test:coverage\` — branches 82.59% (above gate)
- [x] \`pnpm build\` — green
- [ ] Live smoke after merge: open home with active cards → expect each row in newly-added / met-this-month / uncontacted sections to show the temperature emoji next to the name

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)