### PR TITLE
feat(temp-badge): expand to /followups, /companies, /events rows

### DIFF
--- a/src/app/(app)/companies/[slug]/page.tsx
+++ b/src/app/(app)/companies/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
 import { listCardsForUser } from "@/db/cards";
+import { computeTemperature } from "@/lib/cards/relationship-temp";
 import { findCompanyBySlug } from "@/lib/companies/group";
 import { readSession } from "@/lib/firebase/session";
 
@@ -92,6 +94,7 @@ export default async function CompanyDetailPage({ params }: PageProps) {
                   {card.whyRemember && <p className={styles.why}>{card.whyRemember}</p>}
                 </div>
                 <div className={styles.cardSide}>
+                  <TemperatureBadge temperature={computeTemperature(card, new Date())} compact />
                   {card.isPinned && (
                     <span className={styles.pin} title="重要聯絡人">
                       📍

--- a/src/app/(app)/events/[tag]/page.tsx
+++ b/src/app/(app)/events/[tag]/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
 import { listCardsForUser } from "@/db/cards";
+import { computeTemperature } from "@/lib/cards/relationship-temp";
 import { findEventBySlug } from "@/lib/events/group";
 import { readSession } from "@/lib/firebase/session";
 
@@ -84,6 +86,7 @@ export default async function EventDetailPage({ params }: PageProps) {
                   {card.whyRemember && <p className={styles.why}>{card.whyRemember}</p>}
                 </div>
                 <div className={styles.cardSide}>
+                  <TemperatureBadge temperature={computeTemperature(card, new Date())} compact />
                   <span className={styles.metDate}>見面日：{formatYmd(card.firstMetDate)}</span>
                   {card.firstMetContext && (
                     <span className={styles.context}>{card.firstMetContext}</span>

--- a/src/components/followups/FollowupCardRow.tsx
+++ b/src/components/followups/FollowupCardRow.tsx
@@ -6,7 +6,9 @@ import { useState, useTransition } from "react";
 
 import { logContactAction } from "@/app/(app)/cards/actions";
 import { ReengageDraftsButton } from "@/components/coach/ReengageDraftsButton";
+import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
 import type { CardSummary } from "@/db/cards";
+import { computeTemperature } from "@/lib/cards/relationship-temp";
 
 import styles from "./FollowupCardRow.module.css";
 
@@ -54,6 +56,7 @@ export function FollowupCardRow({ card, days, showAiDrafts = false }: FollowupCa
           <div className={styles.primary}>
             {card.isPinned && <span className={styles.pin}>📍</span>}
             <span className={styles.name}>{primary}</span>
+            <TemperatureBadge temperature={computeTemperature(card, new Date())} compact />
             {secondary && <span className={styles.secondary}>{secondary}</span>}
           </div>
           <span className={styles.days}>{days} 天</span>


### PR DESCRIPTION
## Summary
- Adds `<TemperatureBadge compact />` to `FollowupCardRow`, `/companies/[slug]` and `/events/[tag]` row layouts.
- Closes the gap noticed after #165 (home timeline got the badge; other listing surfaces did not).
- Business users now get the same hot/warm/cold/dormant signal across every screen that lists contacts.

Closes #166

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 errors)
- [x] `pnpm format` (clean)
- [x] `pnpm test:coverage` — branches 82.59% (above 80% gate)
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build`
- [ ] Verify on Mac mini after deploy