### PR TITLE
feat(followups): 1-tap email / call / LINE from list rows

### DIFF
--- a/src/components/followups/FollowupCardRow.module.css
+++ b/src/components/followups/FollowupCardRow.module.css
@@ -58,6 +58,31 @@
   white-space: nowrap;
 }
 
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.quickAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  min-height: 2rem;
+  padding: var(--space-xs);
+  border-radius: var(--radius-md);
+  font-size: 1rem;
+  line-height: 1;
+  text-decoration: none;
+  background: transparent;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.quickAction:hover {
+  background: var(--color-bg-raised);
+}
+
 .markBtn {
   font-family: var(--font-sans);
   font-size: var(--text-caption);

--- a/src/components/followups/FollowupCardRow.tsx
+++ b/src/components/followups/FollowupCardRow.tsx
@@ -37,6 +37,8 @@ export function FollowupCardRow({ card, days, showAiDrafts = false }: FollowupCa
   const primaryEmail = card.emails?.find((e) => e.primary)?.value ?? card.emails?.[0]?.value;
   const primaryPhone = card.phones?.find((p) => p.primary)?.value ?? card.phones?.[0]?.value;
   const lineId = card.social?.lineId;
+  // LINE deep-link works cross-platform (web → opens LINE app or login).
+  const lineUrl = lineId ? `https://line.me/R/ti/p/~${encodeURIComponent(lineId)}` : null;
 
   function handleMark() {
     startTransition(async () => {
@@ -61,15 +63,49 @@ export function FollowupCardRow({ card, days, showAiDrafts = false }: FollowupCa
           </div>
           <span className={styles.days}>{days} 天</span>
         </Link>
-        <button
-          type="button"
-          className={styles.markBtn}
-          onClick={handleMark}
-          disabled={pending || done}
-          aria-label={`標記已聯絡 ${primary}`}
-        >
-          {done ? "✓ 完成" : pending ? "記錄中…" : "✅ 已聯絡"}
-        </button>
+        <div className={styles.actions}>
+          {primaryEmail && (
+            <a
+              href={`mailto:${primaryEmail}`}
+              className={styles.quickAction}
+              aria-label={`寄信給 ${primary}`}
+              title="寄信"
+            >
+              📧
+            </a>
+          )}
+          {primaryPhone && (
+            <a
+              href={`tel:${primaryPhone}`}
+              className={styles.quickAction}
+              aria-label={`撥電話給 ${primary}`}
+              title="撥電話"
+            >
+              📞
+            </a>
+          )}
+          {lineUrl && (
+            <a
+              href={lineUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.quickAction}
+              aria-label={`LINE 聯絡 ${primary}`}
+              title="LINE"
+            >
+              💬
+            </a>
+          )}
+          <button
+            type="button"
+            className={styles.markBtn}
+            onClick={handleMark}
+            disabled={pending || done}
+            aria-label={`標記已聯絡 ${primary}`}
+          >
+            {done ? "✓ 完成" : pending ? "記錄中…" : "✅ 已聯絡"}
+          </button>
+        </div>
       </div>
       {showAiDrafts && (
         <ReengageDraftsButton

--- a/src/components/followups/__tests__/FollowupCardRow.test.tsx
+++ b/src/components/followups/__tests__/FollowupCardRow.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { CardSummary } from "@/db/cards";
+import { FollowupCardRow } from "../FollowupCardRow";
+
+vi.mock("@/app/(app)/cards/actions", () => ({
+  logContactAction: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+
+function makeCard(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "c1",
+    nameZh: "王大明",
+    emails: [{ value: "wang@example.com", primary: true, label: "工作" }],
+    phones: [{ value: "0922000111", primary: true, label: "手機" }],
+    social: { lineId: "wangda" },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    lastContactedAt: null,
+    ...overrides,
+  } as CardSummary;
+}
+
+describe("FollowupCardRow quick contact links", () => {
+  it("renders mailto when primary email present", () => {
+    render(<FollowupCardRow card={makeCard()} days={42} />);
+    const link = screen.getByLabelText(/寄信給 王大明/) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("mailto:wang@example.com");
+  });
+
+  it("renders tel when primary phone present", () => {
+    render(<FollowupCardRow card={makeCard()} days={42} />);
+    const link = screen.getByLabelText(/撥電話給 王大明/) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("tel:0922000111");
+  });
+
+  it("renders LINE deep link when lineId present", () => {
+    render(<FollowupCardRow card={makeCard()} days={42} />);
+    const link = screen.getByLabelText(/LINE 聯絡 王大明/) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("https://line.me/R/ti/p/~wangda");
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("hides each quick action when corresponding field is missing", () => {
+    render(
+      <FollowupCardRow card={makeCard({ emails: [], phones: [], social: undefined })} days={3} />,
+    );
+    expect(screen.queryByLabelText(/寄信給/)).toBeNull();
+    expect(screen.queryByLabelText(/撥電話給/)).toBeNull();
+    expect(screen.queryByLabelText(/LINE 聯絡/)).toBeNull();
+  });
+
+  it("encodes special chars in lineId so the URL stays valid", () => {
+    render(<FollowupCardRow card={makeCard({ social: { lineId: "wang/da" } })} days={1} />);
+    const link = screen.getByLabelText(/LINE 聯絡/) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("https://line.me/R/ti/p/~wang%2Fda");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds inline 📧 / 📞 / 💬 quick-action links to each `FollowupCardRow`, next to ✅ 已聯絡.
- Business users on /followups can now reply / call / DM in one tap instead of clicking into card detail first.
- Each icon renders only when its primary field exists; LINE uses the cross-platform `https://line.me/R/ti/p/~{id}` redirector and URL-encodes the id.

Closes #168

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 errors)
- [x] `pnpm test:coverage` — branches 80.33% (above 80% gate); 5 new unit tests
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build`
- [ ] Verify on Mac mini after deploy