### PR TITLE
feat(home): surface follow-up count chip on home header

### DIFF
--- a/src/app/(app)/home.module.css
+++ b/src/app/(app)/home.module.css
@@ -78,6 +78,19 @@
   );
 }
 
+.quickActionUrgent {
+  background: var(--color-accent);
+  color: var(--color-paper);
+  border-color: var(--color-accent);
+  font-weight: 500;
+}
+
+.quickActionUrgent:hover {
+  background: var(--color-accent-ink, var(--color-accent));
+  border-color: var(--color-accent-ink, var(--color-accent));
+  color: var(--color-paper);
+}
+
 .sections {
   display: flex;
   flex-direction: column;

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -8,6 +8,7 @@ import { listCardsForUser } from "@/db/cards";
 import { isCoachConfigured } from "@/lib/coach/llm";
 import { readSession } from "@/lib/firebase/session";
 import { categorizeTimeline } from "@/lib/timeline/categorize";
+import { bucketFollowups, totalFollowups } from "@/lib/timeline/followups";
 
 import styles from "./home.module.css";
 
@@ -24,8 +25,12 @@ export default async function HomePage() {
     order: "desc",
     limit: 200,
   });
-  const sections = categorizeTimeline(cards, { now: new Date() });
+  const now = new Date();
+  const sections = categorizeTimeline(cards, { now });
   const totalInSections = sections.reduce((sum, section) => sum + section.cards.length, 0);
+  // Follow-up urgency chip — same data path the dedicated /followups page
+  // uses, just summarized into a count for the home header.
+  const followupsTotal = totalFollowups(bucketFollowups(cards, now));
   const firstName = user.displayName?.split(" ")[0] ?? "";
 
   return (
@@ -41,6 +46,14 @@ export default async function HomePage() {
         </p>
         {cards.length > 0 && (
           <div className={styles.quickActions}>
+            {followupsTotal > 0 && (
+              <Link
+                href="/followups"
+                className={`${styles.quickAction} ${styles.quickActionUrgent}`}
+              >
+                ⏰ {followupsTotal} 個人該 ping 了
+              </Link>
+            )}
             <Link href="/log" className={styles.quickAction}>
               🗣️ 對話速記
             </Link>


### PR DESCRIPTION
## Summary
- Adds a 「⏰ N 個人該 ping 了」 urgency chip to the home `.quickActions` row when there are pending follow-ups.
- Reuses `bucketFollowups` + `totalFollowups` from \`@/lib/timeline/followups\` — single source of truth shared with /followups, zero extra Firestore reads.
- Hoists the page-level `now` constant so `categorizeTimeline` and `bucketFollowups` share the same boundary timestamp.

Closes #170

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 errors)
- [x] `pnpm test:coverage` — branches 80.33% (above 80% gate)
- [x] `NAMECARD_BASE_PATH=/namecard-web pnpm build`
- [ ] Verify on Mac mini (chip should appear when there are pending follow-ups)