### PR TITLE
feat(followups): surface scheduled reminders in /followups + home chip

### DIFF
--- a/src/app/(app)/followups/page.tsx
+++ b/src/app/(app)/followups/page.tsx
@@ -5,7 +5,12 @@ import { FollowupCardRow } from "@/components/followups/FollowupCardRow";
 import { listCardsForUser } from "@/db/cards";
 import { isCoachConfigured } from "@/lib/coach/llm";
 import { readSession } from "@/lib/firebase/session";
-import { bucketFollowups, totalFollowups, type FollowupBucket } from "@/lib/timeline/followups";
+import {
+  bucketFollowups,
+  dueRemindersToday,
+  totalFollowups,
+  type FollowupBucket,
+} from "@/lib/timeline/followups";
 
 import styles from "./followups.module.css";
 
@@ -22,8 +27,13 @@ export default async function FollowupsPage() {
     orderBy: "createdAt",
     order: "desc",
   });
-  const groups = bucketFollowups(cards, new Date());
-  const total = totalFollowups(groups);
+  const now = new Date();
+  const groups = bucketFollowups(cards, now);
+  // Explicit reminders the user committed to with the picker. Conceptually
+  // separate from staleness, so they get their own top section instead of
+  // being merged into one of the existing buckets.
+  const reminders = dueRemindersToday(cards, now);
+  const total = totalFollowups(groups) + reminders.length;
   const showAiDrafts = isCoachConfigured();
 
   const ordered: FollowupBucket[] = [
@@ -46,6 +56,23 @@ export default async function FollowupsPage() {
       </header>
 
       {showAiDrafts && <ActionItemsSection />}
+
+      {reminders.length > 0 && (
+        <section className={styles.bucket} aria-label="今日提醒">
+          <header className={styles.bucketHeader}>
+            <h2 className={styles.bucketTitle}>
+              今日提醒
+              <span className={styles.bucketCount}>{reminders.length}</span>
+            </h2>
+            <p className={styles.bucketDesc}>你預先排好的聯絡日已到。</p>
+          </header>
+          <ol className={styles.list}>
+            {reminders.map(({ card, days }) => (
+              <FollowupCardRow key={card.id} card={card} days={days} showAiDrafts={showAiDrafts} />
+            ))}
+          </ol>
+        </section>
+      )}
 
       {total === 0 ? (
         <section className={styles.empty}>

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -8,7 +8,7 @@ import { listCardsForUser } from "@/db/cards";
 import { isCoachConfigured } from "@/lib/coach/llm";
 import { readSession } from "@/lib/firebase/session";
 import { categorizeTimeline } from "@/lib/timeline/categorize";
-import { bucketFollowups, totalFollowups } from "@/lib/timeline/followups";
+import { bucketFollowups, dueRemindersToday, totalFollowups } from "@/lib/timeline/followups";
 
 import styles from "./home.module.css";
 
@@ -28,9 +28,11 @@ export default async function HomePage() {
   const now = new Date();
   const sections = categorizeTimeline(cards, { now });
   const totalInSections = sections.reduce((sum, section) => sum + section.cards.length, 0);
-  // Follow-up urgency chip — same data path the dedicated /followups page
-  // uses, just summarized into a count for the home header.
-  const followupsTotal = totalFollowups(bucketFollowups(cards, now));
+  // Follow-up urgency chip — staleness buckets PLUS user-scheduled
+  // reminders due today. Same data path the dedicated /followups page
+  // uses, summarized into a count for the home header.
+  const followupsTotal =
+    totalFollowups(bucketFollowups(cards, now)) + dueRemindersToday(cards, now).length;
   const firstName = user.displayName?.split(" ")[0] ?? "";
 
   return (

--- a/src/lib/timeline/__tests__/followups.test.ts
+++ b/src/lib/timeline/__tests__/followups.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { CardSummary } from "@/db/cards";
 
-import { bucketFollowups, totalFollowups } from "../followups";
+import { bucketFollowups, dueRemindersToday, totalFollowups } from "../followups";
 
 const NOW = new Date("2026-04-24T00:00:00Z");
 
@@ -113,5 +113,46 @@ describe("totalFollowups", () => {
 
   it("is 0 for an empty or all-fresh corpus", () => {
     expect(totalFollowups(bucketFollowups([], NOW))).toBe(0);
+  });
+});
+
+describe("dueRemindersToday", () => {
+  it("includes a card with followUpAt today", () => {
+    const todayMidnight = new Date(NOW);
+    todayMidnight.setHours(0, 0, 0, 0);
+    const c = mk({ id: "a", followUpAt: todayMidnight });
+    const out = dueRemindersToday([c], NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].card.id).toBe("a");
+  });
+
+  it("includes a card with followUpAt in the past", () => {
+    const lastWeek = daysAgo(7);
+    const c = mk({ id: "p", followUpAt: lastWeek });
+    expect(dueRemindersToday([c], NOW)).toHaveLength(1);
+  });
+
+  it("excludes a card with followUpAt in the future", () => {
+    const tomorrow = new Date(NOW.getTime() + 36 * 60 * 60 * 1000);
+    const c = mk({ id: "f", followUpAt: tomorrow });
+    expect(dueRemindersToday([c], NOW)).toHaveLength(0);
+  });
+
+  it("excludes a card with no followUpAt", () => {
+    const c = mk({ id: "n", lastContactedAt: daysAgo(45) });
+    expect(dueRemindersToday([c], NOW)).toHaveLength(0);
+  });
+
+  it("excludes soft-deleted cards", () => {
+    const c = mk({ id: "d", followUpAt: daysAgo(2), deletedAt: daysAgo(1) });
+    expect(dueRemindersToday([c], NOW)).toHaveLength(0);
+  });
+
+  it("orders most-overdue reminder first; id tiebreak is deterministic", () => {
+    const a = mk({ id: "a", followUpAt: daysAgo(1) });
+    const b = mk({ id: "b", followUpAt: daysAgo(5) });
+    const c = mk({ id: "c", followUpAt: daysAgo(1) });
+    const out = dueRemindersToday([a, b, c], NOW);
+    expect(out.map((x) => x.card.id)).toEqual(["b", "a", "c"]);
   });
 });

--- a/src/lib/timeline/followups.ts
+++ b/src/lib/timeline/followups.ts
@@ -101,3 +101,38 @@ export function totalFollowups(groups: FollowupGroups): number {
     groups.pinnedStale.cards.length
   );
 }
+
+/**
+ * Cards with an explicit followUpAt scheduled for today or earlier.
+ * This is conceptually distinct from staleness-based buckets — these
+ * are reminders the user committed to. Not soft-deleted; "today" =
+ * end-of-day in the caller-supplied `now`'s local representation, so
+ * a midnight-stored Date for the current calendar day still counts.
+ *
+ * Days = days-since-last-contact (so the row UX is consistent with the
+ * other buckets, which all show "N 天" of staleness).
+ */
+export function dueRemindersToday(
+  cards: CardSummary[],
+  now: Date,
+): Array<{ card: CardSummary; days: number }> {
+  const endOfToday = new Date(now);
+  endOfToday.setHours(23, 59, 59, 999);
+  const out: Array<{ card: CardSummary; days: number }> = [];
+  for (const card of cards) {
+    if (card.deletedAt) continue;
+    if (!card.followUpAt) continue;
+    if (card.followUpAt.getTime() > endOfToday.getTime()) continue;
+    // Use staleness if available, fall back to 0 so a never-contacted
+    // scheduled reminder still renders sensibly.
+    const days = daysSinceContact(card, now) ?? 0;
+    out.push({ card, days });
+  }
+  // Most-overdue reminder first, then deterministic id tiebreak.
+  out.sort(
+    (a, b) =>
+      (a.card.followUpAt?.getTime() ?? 0) - (b.card.followUpAt?.getTime() ?? 0) ||
+      a.card.id.localeCompare(b.card.id),
+  );
+  return out;
+}


### PR DESCRIPTION
## Summary
- New \`dueRemindersToday(cards, now)\` lib function — picks cards with \`followUpAt <= today\`, kept conceptually separate from staleness bucketing.
- /followups now leads with a 「今日提醒」 section above the existing pinned/critical/overdue/due buckets, so user-scheduled reminders (PR #173's picker) become visible action items.
- Home 「⏰ N 個人該 ping 了」 chip count now adds these reminders too.
- 7 new unit tests on the new function.

Closes #176

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.35%; 7 new tests in followups.test.ts
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`
- [ ] Verify on Mac mini: schedule someone for today via picker → see them under 「今日提醒」 in /followups