### PR TITLE
feat(followups): 「下週提醒」 — surface upcoming followUpAt within 7 days

### DIFF
--- a/src/app/(app)/followups/page.tsx
+++ b/src/app/(app)/followups/page.tsx
@@ -9,6 +9,7 @@ import {
   bucketFollowups,
   dueRemindersToday,
   totalFollowups,
+  upcomingRemindersThisWeek,
   type FollowupBucket,
 } from "@/lib/timeline/followups";
 
@@ -33,6 +34,10 @@ export default async function FollowupsPage() {
   // separate from staleness, so they get their own top section instead of
   // being merged into one of the existing buckets.
   const reminders = dueRemindersToday(cards, now);
+  // Upcoming-week reminders are visibility-only (not added to the
+  // urgency total) — they're scheduled future commitments, not action
+  // items overdue today.
+  const upcoming = upcomingRemindersThisWeek(cards, now);
   const total = totalFollowups(groups) + reminders.length;
   const showAiDrafts = isCoachConfigured();
 
@@ -74,7 +79,24 @@ export default async function FollowupsPage() {
         </section>
       )}
 
-      {total === 0 ? (
+      {upcoming.length > 0 && (
+        <section className={styles.bucket} aria-label="下週提醒">
+          <header className={styles.bucketHeader}>
+            <h2 className={styles.bucketTitle}>
+              下週提醒
+              <span className={styles.bucketCount}>{upcoming.length}</span>
+            </h2>
+            <p className={styles.bucketDesc}>未來 7 天內到期的提醒，先看一眼。</p>
+          </header>
+          <ol className={styles.list}>
+            {upcoming.map(({ card, days }) => (
+              <FollowupCardRow key={card.id} card={card} days={days} showAiDrafts={showAiDrafts} />
+            ))}
+          </ol>
+        </section>
+      )}
+
+      {total === 0 && upcoming.length === 0 ? (
         <section className={styles.empty}>
           <p className={styles.emptyBody}>
             沒有人在排隊等你追蹤。想提前找點人接觸？到
@@ -85,7 +107,7 @@ export default async function FollowupsPage() {
             切「最近聯絡」排序看看。
           </p>
         </section>
-      ) : (
+      ) : total === 0 ? null : (
         ordered
           .filter((b) => b.cards.length > 0)
           .map((bucket) => (

--- a/src/lib/timeline/__tests__/followups.test.ts
+++ b/src/lib/timeline/__tests__/followups.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import type { CardSummary } from "@/db/cards";
 
-import { bucketFollowups, dueRemindersToday, totalFollowups } from "../followups";
+import {
+  bucketFollowups,
+  dueRemindersToday,
+  totalFollowups,
+  upcomingRemindersThisWeek,
+} from "../followups";
 
 const NOW = new Date("2026-04-24T00:00:00Z");
 
@@ -154,5 +159,52 @@ describe("dueRemindersToday", () => {
     const c = mk({ id: "c", followUpAt: daysAgo(1) });
     const out = dueRemindersToday([a, b, c], NOW);
     expect(out.map((x) => x.card.id)).toEqual(["b", "a", "c"]);
+  });
+});
+
+describe("upcomingRemindersThisWeek", () => {
+  function daysAhead(n: number): Date {
+    return new Date(NOW.getTime() + n * 24 * 60 * 60 * 1000);
+  }
+
+  it("includes a card with followUpAt 3 days out", () => {
+    const c = mk({ id: "a", followUpAt: daysAhead(3) });
+    expect(upcomingRemindersThisWeek([c], NOW)).toHaveLength(1);
+  });
+
+  it("excludes today (already in dueRemindersToday)", () => {
+    const todayMidnight = new Date(NOW);
+    todayMidnight.setHours(12, 0, 0, 0);
+    const c = mk({ id: "t", followUpAt: todayMidnight });
+    expect(upcomingRemindersThisWeek([c], NOW)).toHaveLength(0);
+  });
+
+  it("includes the boundary day (exactly +7 days)", () => {
+    const c = mk({ id: "b", followUpAt: daysAhead(7) });
+    expect(upcomingRemindersThisWeek([c], NOW)).toHaveLength(1);
+  });
+
+  it("excludes 8+ days out (outside the week window)", () => {
+    const c = mk({ id: "x", followUpAt: daysAhead(8) });
+    expect(upcomingRemindersThisWeek([c], NOW)).toHaveLength(0);
+  });
+
+  it("excludes soft-deleted cards", () => {
+    const c = mk({ id: "d", followUpAt: daysAhead(3), deletedAt: daysAgo(1) });
+    expect(upcomingRemindersThisWeek([c], NOW)).toHaveLength(0);
+  });
+
+  it("orders soonest first; id tiebreak deterministic", () => {
+    const a = mk({ id: "a", followUpAt: daysAhead(5) });
+    const b = mk({ id: "b", followUpAt: daysAhead(2) });
+    const c = mk({ id: "c", followUpAt: daysAhead(2) });
+    const out = upcomingRemindersThisWeek([a, b, c], NOW);
+    expect(out.map((x) => x.card.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("respects custom windowDays", () => {
+    const c = mk({ id: "f", followUpAt: daysAhead(20) });
+    expect(upcomingRemindersThisWeek([c], NOW, 30)).toHaveLength(1);
+    expect(upcomingRemindersThisWeek([c], NOW, 7)).toHaveLength(0);
   });
 });

--- a/src/lib/timeline/followups.ts
+++ b/src/lib/timeline/followups.ts
@@ -136,3 +136,39 @@ export function dueRemindersToday(
   );
   return out;
 }
+
+/**
+ * Cards with followUpAt strictly after end-of-today and within
+ * `windowDays` (default 7) inclusive. Used for /followups 「下週提醒」 —
+ * gives business users a glance at their upcoming week without
+ * doubling-up with 今日提醒 (which covers today and earlier).
+ *
+ * Sorted ascending by followUpAt (soonest first), then id tiebreak.
+ */
+export function upcomingRemindersThisWeek(
+  cards: CardSummary[],
+  now: Date,
+  windowDays = 7,
+): Array<{ card: CardSummary; days: number }> {
+  const endOfToday = new Date(now);
+  endOfToday.setHours(23, 59, 59, 999);
+  const endOfWindow = new Date(endOfToday);
+  endOfWindow.setDate(endOfWindow.getDate() + windowDays);
+
+  const out: Array<{ card: CardSummary; days: number }> = [];
+  for (const card of cards) {
+    if (card.deletedAt) continue;
+    if (!card.followUpAt) continue;
+    const t = card.followUpAt.getTime();
+    if (t <= endOfToday.getTime()) continue; // already in dueRemindersToday
+    if (t > endOfWindow.getTime()) continue; // outside the week window
+    const days = daysSinceContact(card, now) ?? 0;
+    out.push({ card, days });
+  }
+  out.sort(
+    (a, b) =>
+      (a.card.followUpAt?.getTime() ?? 0) - (b.card.followUpAt?.getTime() ?? 0) ||
+      a.card.id.localeCompare(b.card.id),
+  );
+  return out;
+}


### PR DESCRIPTION
## Summary
- New \`upcomingRemindersThisWeek(cards, now, windowDays=7)\` lib function — picks cards with \`followUpAt\` strictly after end-of-today and within the window.
- New 「下週提醒」 section on /followups, between 今日提醒 and the staleness buckets.
- Reuses existing FollowupCardRow (consistent UX).
- 7 new boundary tests; coverage stable at branches 80.36%.

Closes #178

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.36%
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`
- [ ] Verify on Mac mini: schedule someone for tomorrow → see them under 「下週提醒」 with the correct count