### PR TITLE
feat(followups): show 📅 today/tomorrow/M/D on reminder rows

### DIFF
--- a/src/app/(app)/followups/page.tsx
+++ b/src/app/(app)/followups/page.tsx
@@ -4,6 +4,7 @@ import { ActionItemsSection } from "@/components/coach/ActionItemsSection";
 import { FollowupCardRow } from "@/components/followups/FollowupCardRow";
 import { listCardsForUser } from "@/db/cards";
 import { isCoachConfigured } from "@/lib/coach/llm";
+import { reminderDateLabel } from "@/lib/cards/reminder-label";
 import { readSession } from "@/lib/firebase/session";
 import {
   bucketFollowups,
@@ -73,7 +74,15 @@ export default async function FollowupsPage() {
           </header>
           <ol className={styles.list}>
             {reminders.map(({ card, days }) => (
-              <FollowupCardRow key={card.id} card={card} days={days} showAiDrafts={showAiDrafts} />
+              <FollowupCardRow
+                key={card.id}
+                card={card}
+                days={days}
+                daysLabel={
+                  card.followUpAt ? `📅 ${reminderDateLabel(card.followUpAt, now)}` : undefined
+                }
+                showAiDrafts={showAiDrafts}
+              />
             ))}
           </ol>
         </section>
@@ -90,7 +99,15 @@ export default async function FollowupsPage() {
           </header>
           <ol className={styles.list}>
             {upcoming.map(({ card, days }) => (
-              <FollowupCardRow key={card.id} card={card} days={days} showAiDrafts={showAiDrafts} />
+              <FollowupCardRow
+                key={card.id}
+                card={card}
+                days={days}
+                daysLabel={
+                  card.followUpAt ? `📅 ${reminderDateLabel(card.followUpAt, now)}` : undefined
+                }
+                showAiDrafts={showAiDrafts}
+              />
             ))}
           </ol>
         </section>

--- a/src/components/followups/FollowupCardRow.tsx
+++ b/src/components/followups/FollowupCardRow.tsx
@@ -30,6 +30,12 @@ const NEXT_OPTIONS: readonly NextOption[] = [
 interface FollowupCardRowProps {
   card: CardSummary;
   days: number;
+  /**
+   * Override for the right-side label (default `${days} 天`).
+   * Reminder sections pass a planning-friendly label like
+   * "📅 今天" / "📅 明天" / "📅 4/29".
+   */
+  daysLabel?: string;
   /** When false, hides the ✨ AI 草稿 disclosure (e.g. server didn't config LLM). */
   showAiDrafts?: boolean;
 }
@@ -40,7 +46,12 @@ interface FollowupCardRowProps {
  * purpose — triage flow should be fast; typing a note is an extra
  * click the user can do from the detail page when they want to.
  */
-export function FollowupCardRow({ card, days, showAiDrafts = false }: FollowupCardRowProps) {
+export function FollowupCardRow({
+  card,
+  days,
+  daysLabel,
+  showAiDrafts = false,
+}: FollowupCardRowProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [stage, setStage] = useState<"idle" | "picking">("idle");
@@ -84,7 +95,7 @@ export function FollowupCardRow({ card, days, showAiDrafts = false }: FollowupCa
             <TemperatureBadge temperature={computeTemperature(card, new Date())} compact />
             {secondary && <span className={styles.secondary}>{secondary}</span>}
           </div>
-          <span className={styles.days}>{days} 天</span>
+          <span className={styles.days}>{daysLabel ?? `${days} 天`}</span>
         </Link>
         <div className={styles.actions}>
           {primaryEmail && (

--- a/src/components/followups/__tests__/FollowupCardRow.test.tsx
+++ b/src/components/followups/__tests__/FollowupCardRow.test.tsx
@@ -66,6 +66,17 @@ describe("FollowupCardRow quick contact links", () => {
     const link = screen.getByLabelText(/LINE 聯絡/) as HTMLAnchorElement;
     expect(link.getAttribute("href")).toBe("https://line.me/R/ti/p/~wang%2Fda");
   });
+
+  it("shows default '{days} 天' when daysLabel prop omitted", () => {
+    render(<FollowupCardRow card={makeCard()} days={42} />);
+    expect(screen.getByText("42 天")).toBeInTheDocument();
+  });
+
+  it("renders daysLabel override when provided (used by reminder sections)", () => {
+    render(<FollowupCardRow card={makeCard()} days={0} daysLabel="📅 今天" />);
+    expect(screen.getByText("📅 今天")).toBeInTheDocument();
+    expect(screen.queryByText("0 天")).toBeNull();
+  });
 });
 
 describe("FollowupCardRow next-pick flow", () => {

--- a/src/lib/cards/__tests__/reminder-label.test.ts
+++ b/src/lib/cards/__tests__/reminder-label.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { reminderDateLabel } from "../reminder-label";
+
+describe("reminderDateLabel", () => {
+  it("returns 今天 for same-day reminder (any time)", () => {
+    const today = new Date(2026, 3, 26, 12, 0, 0);
+    const reminder = new Date(2026, 3, 26, 9, 0, 0);
+    expect(reminderDateLabel(reminder, today)).toBe("今天");
+  });
+
+  it("returns 今天 for past reminder (overdue surfaces under today)", () => {
+    const today = new Date(2026, 3, 26, 9, 0, 0);
+    const reminder = new Date(2026, 3, 20, 9, 0, 0);
+    expect(reminderDateLabel(reminder, today)).toBe("今天");
+  });
+
+  it("returns 明天 for next-day reminder regardless of clock time", () => {
+    const today = new Date(2026, 3, 26, 23, 0, 0);
+    const tomorrowMorning = new Date(2026, 3, 27, 9, 0, 0);
+    const tomorrowNight = new Date(2026, 3, 27, 23, 30, 0);
+    expect(reminderDateLabel(tomorrowMorning, today)).toBe("明天");
+    expect(reminderDateLabel(tomorrowNight, today)).toBe("明天");
+  });
+
+  it("returns M/D for ≥2 days out", () => {
+    const today = new Date(2026, 3, 26, 12, 0, 0);
+    const future = new Date(2026, 3, 30, 12, 0, 0);
+    expect(reminderDateLabel(future, today)).toBe("4/30");
+  });
+
+  it("month/day printed without leading zeros", () => {
+    const today = new Date(2026, 3, 26, 12, 0, 0);
+    const future = new Date(2026, 4, 3, 12, 0, 0); // May 3
+    expect(reminderDateLabel(future, today)).toBe("5/3");
+  });
+
+  it("crosses month boundary cleanly", () => {
+    const apr29 = new Date(2026, 3, 29, 12, 0, 0);
+    const may2 = new Date(2026, 4, 2, 12, 0, 0);
+    expect(reminderDateLabel(may2, apr29)).toBe("5/2");
+  });
+});

--- a/src/lib/cards/reminder-label.ts
+++ b/src/lib/cards/reminder-label.ts
@@ -1,0 +1,28 @@
+/**
+ * Short human label for an upcoming follow-up reminder row.
+ *
+ * Used by /followups (今日提醒 / 下週提醒) so each row shows a
+ * planning-friendly cue ("今天" / "明天" / "4/29") instead of
+ * the staleness-based "{days} 天" — those numbers don't help when
+ * planning the future.
+ *
+ * Diff is computed by calendar-day, not raw 24h, so a reminder
+ * for tomorrow morning and a reminder for tomorrow night both
+ * say "明天".
+ */
+export function reminderDateLabel(followUpAt: Date, now: Date): string {
+  const startOfNow = new Date(now);
+  startOfNow.setHours(0, 0, 0, 0);
+  const startOfReminder = new Date(followUpAt);
+  startOfReminder.setHours(0, 0, 0, 0);
+
+  const diffMs = startOfReminder.getTime() - startOfNow.getTime();
+  const diffDays = Math.round(diffMs / (24 * 60 * 60 * 1000));
+
+  if (diffDays <= 0) return "今天";
+  if (diffDays === 1) return "明天";
+  // No leading zeros — feels native in Traditional Chinese contexts.
+  const month = followUpAt.getMonth() + 1;
+  const day = followUpAt.getDate();
+  return `${month}/${day}`;
+}


### PR DESCRIPTION
## Summary
- Adds optional \`daysLabel\` prop to FollowupCardRow that overrides the default \`{days} 天\` rendering.
- Adds \`reminderDateLabel(followUpAt, now)\` helper returning 「今天」 / 「明天」 / 「M/D」.
- /followups passes \`📅 {label}\` for both 今日提醒 and 下週提醒 sections so each row tells you WHEN the reminder is due — not just how long it's been since contact.
- Default behavior preserved for the 4 staleness buckets.

Closes #180

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.43% (above 80% gate); 6 + 2 = 8 new tests
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`
- [ ] Verify on Mac mini: schedule someone for today → row shows 「📅 今天」; schedule for +3 days → row shows 「📅 4/29」 (or whatever the date is)