### PR TITLE
feat(home): render due-today reminders as actionable rows (📧📞💬 + ✅ + picker)

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { DailyBriefingSection } from "@/components/coach/DailyBriefingSection";
 import { OnboardingHero } from "@/components/home/OnboardingHero";
 import { PwaInstallHint } from "@/components/home/PwaInstallHint";
+import { DueTodaySection } from "@/components/timeline/DueTodaySection";
 import { TimelineSection } from "@/components/timeline/TimelineSection";
 import { listCardsForUser } from "@/db/cards";
 import { isCoachConfigured } from "@/lib/coach/llm";
@@ -79,9 +80,18 @@ export default async function HomePage() {
         <>
           {isCoachConfigured() && cards.length >= 3 && <DailyBriefingSection />}
           <div className={styles.sections}>
-            {sections.map((section) => (
-              <TimelineSection key={section.id} section={section} />
-            ))}
+            {sections.map((section) =>
+              section.id === "due-today" ? (
+                <DueTodaySection
+                  key={section.id}
+                  section={section}
+                  now={now}
+                  showAiDrafts={isCoachConfigured()}
+                />
+              ) : (
+                <TimelineSection key={section.id} section={section} />
+              ),
+            )}
           </div>
         </>
       )}

--- a/src/components/timeline/DueTodaySection.tsx
+++ b/src/components/timeline/DueTodaySection.tsx
@@ -1,0 +1,45 @@
+import { FollowupCardRow } from "@/components/followups/FollowupCardRow";
+import { reminderDateLabel } from "@/lib/cards/reminder-label";
+import type { TimelineSection as TimelineSectionData } from "@/lib/timeline/categorize";
+import { daysSinceContact } from "@/lib/timeline/staleness";
+
+import styles from "./TimelineSection.module.css";
+
+interface DueTodaySectionProps {
+  section: TimelineSectionData;
+  now: Date;
+  showAiDrafts?: boolean;
+}
+
+/**
+ * Home-page rendering of the `due-today` timeline section using
+ * FollowupCardRow (mailto/tel/LINE quick-actions, ✅ 已聯絡, inline next
+ * picker) instead of the passive TimelineSection link layout. Keeps
+ * /home and /followups visually consistent for the same data.
+ */
+export function DueTodaySection({ section, now, showAiDrafts = false }: DueTodaySectionProps) {
+  if (section.cards.length === 0) return null;
+  return (
+    <section className={styles.section} aria-labelledby={`section-${section.id}`}>
+      <header className={styles.header}>
+        <h2 id={`section-${section.id}`} className={styles.title}>
+          {section.title}
+        </h2>
+        <p className={styles.description}>{section.description}</p>
+      </header>
+      <ol className={styles.actionableList}>
+        {section.cards.map((card) => (
+          <FollowupCardRow
+            key={card.id}
+            card={card}
+            days={daysSinceContact(card, now) ?? 0}
+            daysLabel={
+              card.followUpAt ? `📅 ${reminderDateLabel(card.followUpAt, now)}` : "📅 今天"
+            }
+            showAiDrafts={showAiDrafts}
+          />
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/src/components/timeline/TimelineSection.module.css
+++ b/src/components/timeline/TimelineSection.module.css
@@ -38,6 +38,19 @@
   flex-direction: column;
 }
 
+/*
+ * For sections that host externally-styled rows (FollowupCardRow brings
+ * its own border/padding). Keep the unstyled list semantics without
+ * imposing the timeline .list > li borders.
+ */
+.actionableList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .list > li {
   border-bottom: var(--border-hair) solid var(--color-border);
 }

--- a/src/components/timeline/__tests__/DueTodaySection.test.tsx
+++ b/src/components/timeline/__tests__/DueTodaySection.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { CardSummary } from "@/db/cards";
+import type { TimelineSection } from "@/lib/timeline/categorize";
+import { DueTodaySection } from "../DueTodaySection";
+
+vi.mock("@/app/(app)/cards/actions", () => ({
+  logContactAction: vi.fn(),
+  setFollowUpAction: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+
+const NOW = new Date(2026, 3, 26, 12, 0, 0);
+
+function makeCard(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "c1",
+    nameZh: "王大明",
+    emails: [{ value: "wang@example.com", primary: true, label: "工作" }],
+    phones: [{ value: "0922000111", primary: true, label: "手機" }],
+    social: {},
+    createdAt: NOW,
+    updatedAt: NOW,
+    deletedAt: null,
+    lastContactedAt: null,
+    ...overrides,
+  } as CardSummary;
+}
+
+describe("DueTodaySection", () => {
+  it("renders nothing when section has no cards", () => {
+    const { container } = render(
+      <DueTodaySection
+        section={
+          {
+            id: "due-today",
+            title: "今天該聯絡",
+            description: "...",
+            cards: [],
+          } as TimelineSection
+        }
+        now={NOW}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders header + actionable rows for each due-today card", () => {
+    const card = makeCard();
+    render(
+      <DueTodaySection
+        section={
+          {
+            id: "due-today",
+            title: "今天該聯絡",
+            description: "你之前設定提醒到期了。",
+            cards: [card],
+          } as TimelineSection
+        }
+        now={NOW}
+      />,
+    );
+    expect(screen.getByRole("heading", { name: "今天該聯絡" })).toBeInTheDocument();
+    // FollowupCardRow gives mailto/tel quick actions
+    expect(screen.getByLabelText(/寄信給 王大明/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/撥電話給 王大明/)).toBeInTheDocument();
+    // ✅ 已聯絡 button present
+    expect(screen.getByLabelText(/標記已聯絡 王大明/)).toBeInTheDocument();
+  });
+
+  it("uses 📅 today label when card has no followUpAt (overdue picked up by section)", () => {
+    const card = makeCard({ followUpAt: undefined });
+    render(
+      <DueTodaySection
+        section={
+          {
+            id: "due-today",
+            title: "今天該聯絡",
+            description: "...",
+            cards: [card],
+          } as TimelineSection
+        }
+        now={NOW}
+      />,
+    );
+    expect(screen.getByText("📅 今天")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`DueTodaySection\` wrapper that renders the home page's \`due-today\` reminders using \`FollowupCardRow\` instead of the passive \`TimelineSection\`.
- Same UX as /followups: 📧 📞 💬 quick contact, ✅ 已聯絡, the inline 「下次聯絡」 picker, and 📅 今天 / 明天 / M/D labels.
- Other home sections (anniversaries / pinned / met-this-month / newly-added / uncontacted) keep TimelineSection — those are passive context surfaces.
- Reuses TimelineSection.module.css for header/title visual continuity; new \`.actionableList\` class hosts FollowupCardRow children without conflicting borders.

Closes #182

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.39%; 3 new component tests
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`
- [ ] Verify on Mac mini: home page due-today rows show the same icons as /followups