### PR TITLE
feat(followups): inline 「+ 加備註」 textarea before ✅ 已聯絡

### DIFF
--- a/src/components/followups/FollowupCardRow.module.css
+++ b/src/components/followups/FollowupCardRow.module.css
@@ -110,6 +110,50 @@
   cursor: default;
 }
 
+.noteDisclosure {
+  margin: 0;
+  padding: 0;
+}
+
+.noteSummary {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  padding: var(--space-xs) 0;
+  list-style: none;
+  user-select: none;
+}
+
+.noteSummary::-webkit-details-marker {
+  display: none;
+}
+
+.noteSummary:hover {
+  color: var(--color-fg);
+}
+
+.noteTextarea {
+  width: 100%;
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  line-height: var(--leading-snug);
+  padding: var(--space-sm);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-raised);
+  color: var(--color-fg);
+  resize: vertical;
+  min-height: 3rem;
+  margin-top: var(--space-xs);
+}
+
+.noteTextarea:focus {
+  outline: none;
+  border-color: var(--color-accent-ink);
+}
+
 .nextPicker {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/followups/FollowupCardRow.tsx
+++ b/src/components/followups/FollowupCardRow.tsx
@@ -55,6 +55,10 @@ export function FollowupCardRow({
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [stage, setStage] = useState<"idle" | "picking">("idle");
+  // Optional capture-while-fresh note. We avoid revealing the textarea
+  // by default — most triage clicks are sub-2-second and would resent
+  // the visual noise.
+  const [note, setNote] = useState("");
 
   const primary = card.nameZh || card.nameEn || "（未命名）";
   const secondary = [card.jobTitleZh || card.jobTitleEn, card.companyZh || card.companyEn]
@@ -68,7 +72,7 @@ export function FollowupCardRow({
 
   function handleMark() {
     startTransition(async () => {
-      const result = await logContactAction({ id: card.id, note: "" });
+      const result = await logContactAction({ id: card.id, note: note.trim() });
       if (result?.serverError) return;
       // Stay in the row and offer the next-contact picker — this is the
       // moment the user is most likely to commit to a reminder.
@@ -141,6 +145,20 @@ export function FollowupCardRow({
           </button>
         </div>
       </div>
+      {stage === "idle" && (
+        <details className={styles.noteDisclosure}>
+          <summary className={styles.noteSummary}>+ 加備註</summary>
+          <textarea
+            className={styles.noteTextarea}
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="例：談 Q3 計畫，下週二再聯絡"
+            rows={2}
+            maxLength={500}
+            aria-label={`備註 ${primary}`}
+          />
+        </details>
+      )}
       {stage === "picking" && (
         <div className={styles.nextPicker} aria-label={`下次聯絡 ${primary}`}>
           <span className={styles.nextLabel}>下次聯絡：</span>

--- a/src/components/followups/__tests__/FollowupCardRow.test.tsx
+++ b/src/components/followups/__tests__/FollowupCardRow.test.tsx
@@ -79,6 +79,27 @@ describe("FollowupCardRow quick contact links", () => {
   });
 });
 
+describe("FollowupCardRow inline note disclosure", () => {
+  it("renders the '+ 加備註' disclosure in idle stage", () => {
+    render(<FollowupCardRow card={makeCard()} days={42} />);
+    expect(screen.getByText("+ 加備註")).toBeInTheDocument();
+  });
+
+  it("textarea is reachable via aria-label and accepts max 500 chars", () => {
+    render(<FollowupCardRow card={makeCard()} days={42} />);
+    const textarea = screen.getByLabelText(/備註 王大明/) as HTMLTextAreaElement;
+    expect(textarea.tagName).toBe("TEXTAREA");
+    expect(textarea.maxLength).toBe(500);
+  });
+
+  it("textarea reflects typed value via React state", () => {
+    render(<FollowupCardRow card={makeCard()} days={42} />);
+    const textarea = screen.getByLabelText(/備註 王大明/) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "下週二再聯絡" } });
+    expect(textarea.value).toBe("下週二再聯絡");
+  });
+});
+
 describe("FollowupCardRow next-pick flow", () => {
   it("shows the picker after marking contacted, with all 5 options", async () => {
     render(<FollowupCardRow card={makeCard()} days={42} />);


### PR DESCRIPTION
## Summary
- Adds a native \`<details><summary>+ 加備註</summary>\` disclosure with a textarea (max 500 chars, matches server schema).
- Default-collapsed: zero impact on the existing 1-click triage flow from PR #173.
- Typed value (trimmed) flows into \`logContactAction(id, note)\`, ending up on the contact event log.
- Disclosure hides once stage transitions to "picking".

Closes #184

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.41%; 3 new unit tests
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`
- [ ] Verify on Mac mini: expand 「+ 加備註」 → type → click ✅ → contact event on /cards/[id] shows the note