### PR TITLE
feat(cards): surface follow-up urgency chip on /cards header

### DIFF
--- a/src/app/(app)/cards/cards.module.css
+++ b/src/app/(app)/cards/cards.module.css
@@ -78,6 +78,27 @@
     color var(--duration-fast) var(--ease-standard);
 }
 
+.followupChip {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-accent);
+  color: var(--color-paper);
+  border: var(--border-hair) solid var(--color-accent);
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 500;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.followupChip:hover {
+  background: var(--color-accent-ink, var(--color-accent));
+  border-color: var(--color-accent-ink, var(--color-accent));
+}
+
 .duplicatesLink:hover {
   background: var(--color-accent-ink);
   color: var(--color-paper);

--- a/src/app/(app)/cards/page.tsx
+++ b/src/app/(app)/cards/page.tsx
@@ -17,6 +17,7 @@ import { getTypesenseClient } from "@/lib/search/client";
 import { buildSearchParams } from "@/lib/search/query";
 import { CARDS_COLLECTION_NAME } from "@/lib/search/schema";
 import { parseSearchParams } from "@/lib/search/url";
+import { bucketFollowups, dueRemindersToday, totalFollowups } from "@/lib/timeline/followups";
 
 import styles from "./cards.module.css";
 
@@ -139,6 +140,13 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
   // its own independent scan, so this is just a notification.
   const duplicateGroupCount = hasSearchState ? 0 : findDuplicateGroups(allCards).length;
 
+  // Follow-up urgency chip — staleness + scheduled reminders, identical
+  // to the home chip. Always computed against the full corpus (not the
+  // currently-filtered view) so users can't lose sight of pending
+  // action items by accidentally filtering them out.
+  const followupsTotal =
+    totalFollowups(bucketFollowups(allCards, now)) + dueRemindersToday(allCards, now).length;
+
   // Mint signed URLs only for the visible cards' frontImagePath. Batched
   // via Promise.allSettled so a stale/missing storage object doesn't
   // bring down the whole list. Backed by the storage CDN behind a 15-min
@@ -175,6 +183,11 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
           </h1>
         </div>
         <div className={styles.controls}>
+          {followupsTotal > 0 && (
+            <Link href="/followups" className={styles.followupChip} title="到追蹤頁查看待聯絡的人">
+              ⏰ {followupsTotal} 個人該 ping 了
+            </Link>
+          )}
           {duplicateGroupCount > 0 && (
             <Link
               href="/cards/duplicates"


### PR DESCRIPTION
## Summary
- Adds the same 「⏰ N 個人該 ping 了」 chip from home (PR #171) to the /cards header controls row.
- Counts staleness buckets PLUS scheduled reminders (\`bucketFollowups + dueRemindersToday\`).
- Uses unfiltered corpus (\`allCards\`), not the currently-filtered view — so applying a tag/temp/search filter can't accidentally hide pending urgency.
- Pill-shaped urgent chip, mirrors home styling.

Closes #186

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.41%
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`
- [ ] Verify on Mac mini: chip visible on /cards when there are pending follow-ups; clicks deep-link to /followups