### PR TITLE
feat(shell): badge follow-up count globally on the 「追蹤」 nav link

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,7 +1,9 @@
 import { redirect } from "next/navigation";
 
 import { AppShell } from "@/components/shell/AppShell";
+import { listCardsForUser } from "@/db/cards";
 import { readSession } from "@/lib/firebase/session";
+import { bucketFollowups, dueRemindersToday, totalFollowups } from "@/lib/timeline/followups";
 import { ensurePersonalWorkspace } from "@/lib/workspace/ensure";
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
@@ -10,5 +12,28 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   // First-login idempotent bootstrap.
   await ensurePersonalWorkspace({ uid: user.uid, displayName: user.displayName });
 
-  return <AppShell user={user}>{children}</AppShell>;
+  // Compute the follow-up urgency count once, here, so every page in the
+  // (app) group can show a global badge in the rail without repeating
+  // the query per-page. Costs +1 Firestore read on pages that don't
+  // already query cards — acceptable at personal-workspace scale.
+  let followupsTotal = 0;
+  try {
+    const cards = await listCardsForUser(user.uid, {
+      limit: 200,
+      orderBy: "createdAt",
+      order: "desc",
+    });
+    const now = new Date();
+    followupsTotal =
+      totalFollowups(bucketFollowups(cards, now)) + dueRemindersToday(cards, now).length;
+  } catch (err) {
+    // Don't take down the entire app shell if the count query fails.
+    console.error("[layout] followups count failed:", err instanceof Error ? err.message : err);
+  }
+
+  return (
+    <AppShell user={user} followupsTotal={followupsTotal}>
+      {children}
+    </AppShell>
+  );
 }

--- a/src/components/shell/AppShell.module.css
+++ b/src/components/shell/AppShell.module.css
@@ -93,6 +93,22 @@
   font-family: var(--font-serif);
   font-size: var(--text-body);
   color: var(--color-fg);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.followupBadge {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
+  background: var(--color-accent);
+  color: var(--color-paper);
+  padding: 0.125rem 0.4rem;
+  border-radius: 999px;
+  min-width: 1.25rem;
+  text-align: center;
 }
 
 .linkHint {

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -35,10 +35,12 @@ const PRIMARY: NavItem[] = [
 
 interface AppShellProps {
   user: SessionUser;
+  /** Total pending follow-ups (staleness + scheduled reminders due today). */
+  followupsTotal?: number;
   children: React.ReactNode;
 }
 
-export function AppShell({ user, children }: AppShellProps) {
+export function AppShell({ user, followupsTotal = 0, children }: AppShellProps) {
   return (
     <div className={styles.shell}>
       {/* SearchBox lives at the shell root so the trigger stays reachable
@@ -57,14 +59,29 @@ export function AppShell({ user, children }: AppShellProps) {
           <nav>
             <p className={styles.navLabel}>導覽</p>
             <ul className={styles.navList}>
-              {PRIMARY.map((item) => (
-                <li key={item.href}>
-                  <Link href={item.href} className={styles.link}>
-                    <span className={styles.linkLabel}>{item.label}</span>
-                    <span className={styles.linkHint}>{item.description}</span>
-                  </Link>
-                </li>
-              ))}
+              {PRIMARY.map((item) => {
+                // Surface a global urgency badge on the 「追蹤」 entry so
+                // users see pending action items from any page.
+                const showBadge = item.href === "/followups" && followupsTotal > 0;
+                return (
+                  <li key={item.href}>
+                    <Link href={item.href} className={styles.link}>
+                      <span className={styles.linkLabel}>
+                        {item.label}
+                        {showBadge && (
+                          <span
+                            className={styles.followupBadge}
+                            aria-label={`${followupsTotal} 個人該 ping 了`}
+                          >
+                            {followupsTotal}
+                          </span>
+                        )}
+                      </span>
+                      <span className={styles.linkHint}>{item.description}</span>
+                    </Link>
+                  </li>
+                );
+              })}
             </ul>
           </nav>
 

--- a/src/components/shell/__tests__/AppShell.test.tsx
+++ b/src/components/shell/__tests__/AppShell.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { SessionUser } from "@/lib/firebase/session";
+import { AppShell } from "../AppShell";
+
+// Mock the client-only sub-components — we're testing AppShell's own
+// rendering decisions (badge logic), not the children.
+vi.mock("@/components/search/SearchBox", () => ({
+  SearchBox: () => <div data-testid="searchbox" />,
+}));
+vi.mock("../GlobalShortcuts", () => ({
+  GlobalShortcuts: () => null,
+}));
+vi.mock("../MobileFab", () => ({
+  MobileFab: () => null,
+}));
+vi.mock("../MobileNavWrapper", () => ({
+  MobileNavWrapper: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/app/(auth)/login/actions", () => ({
+  signOutAction: vi.fn(),
+}));
+
+const user: SessionUser = {
+  uid: "u",
+  email: "u@example.com",
+  displayName: "User",
+};
+
+describe("AppShell follow-up badge", () => {
+  it("does not render the badge when followupsTotal is 0", () => {
+    render(
+      <AppShell user={user} followupsTotal={0}>
+        body
+      </AppShell>,
+    );
+    expect(screen.queryByLabelText(/個人該 ping 了/)).toBeNull();
+  });
+
+  it("renders the badge with count when followupsTotal > 0", () => {
+    render(
+      <AppShell user={user} followupsTotal={7}>
+        body
+      </AppShell>,
+    );
+    const badge = screen.getByLabelText("7 個人該 ping 了");
+    expect(badge).toBeInTheDocument();
+    expect(badge.textContent).toBe("7");
+  });
+
+  it("badge appears in the 「追蹤」 nav link, not other entries", () => {
+    render(
+      <AppShell user={user} followupsTotal={3}>
+        body
+      </AppShell>,
+    );
+    const badge = screen.getByLabelText("3 個人該 ping 了");
+    // Walk up to find nearest link with href /followups
+    const link = badge.closest("a");
+    expect(link?.getAttribute("href")).toBe("/followups");
+  });
+
+  it("defaults to 0 (no badge) when prop omitted", () => {
+    render(<AppShell user={user}>body</AppShell>);
+    expect(screen.queryByLabelText(/個人該 ping 了/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Layout-level fetch + badge on the 「追蹤」 entry in the left rail of \`AppShell\`.
- Globally visible across every (app) route — no more per-page chip duplication.
- Same data path as home (#171) + /cards (#187) chips: \`bucketFollowups + dueRemindersToday\`.
- Try/catch around the count query → graceful degrade to no-badge if Firestore fails.

Closes #188

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.41%; 4 new AppShell tests
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`
- [ ] Verify on Mac mini: badge appears in rail on every page (not just home and /cards)