### PR TITLE
feat(companies/events): ⏰ per-group follow-up badges + extract countFollowupsInCards helper

### DIFF
--- a/src/app/(app)/cards/page.tsx
+++ b/src/app/(app)/cards/page.tsx
@@ -17,7 +17,7 @@ import { getTypesenseClient } from "@/lib/search/client";
 import { buildSearchParams } from "@/lib/search/query";
 import { CARDS_COLLECTION_NAME } from "@/lib/search/schema";
 import { parseSearchParams } from "@/lib/search/url";
-import { bucketFollowups, dueRemindersToday, totalFollowups } from "@/lib/timeline/followups";
+import { countFollowupsInCards } from "@/lib/timeline/followups";
 
 import styles from "./cards.module.css";
 
@@ -140,12 +140,10 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
   // its own independent scan, so this is just a notification.
   const duplicateGroupCount = hasSearchState ? 0 : findDuplicateGroups(allCards).length;
 
-  // Follow-up urgency chip — staleness + scheduled reminders, identical
-  // to the home chip. Always computed against the full corpus (not the
-  // currently-filtered view) so users can't lose sight of pending
-  // action items by accidentally filtering them out.
-  const followupsTotal =
-    totalFollowups(bucketFollowups(allCards, now)) + dueRemindersToday(allCards, now).length;
+  // Follow-up urgency chip — always computed against the full corpus
+  // (not the currently-filtered view) so users can't lose sight of
+  // pending action items by accidentally filtering them out.
+  const followupsTotal = countFollowupsInCards(allCards, now);
 
   // Mint signed URLs only for the visible cards' frontImagePath. Batched
   // via Promise.allSettled so a stale/missing storage object doesn't

--- a/src/app/(app)/companies/companies.module.css
+++ b/src/app/(app)/companies/companies.module.css
@@ -120,6 +120,20 @@
   font-weight: 600;
   margin: 0;
   color: var(--color-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.followupBadge {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
+  background: var(--color-accent);
+  color: var(--color-paper);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
 }
 
 .companyMeta {

--- a/src/app/(app)/companies/page.tsx
+++ b/src/app/(app)/companies/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { listCardsForUser } from "@/db/cards";
 import { groupCardsByCompany } from "@/lib/companies/group";
 import { readSession } from "@/lib/firebase/session";
+import { countFollowupsInCards } from "@/lib/timeline/followups";
 
 import styles from "./companies.module.css";
 
@@ -31,6 +32,7 @@ export default async function CompaniesPage() {
     order: "desc",
   });
   const groups = groupCardsByCompany(cards);
+  const now = new Date();
 
   return (
     <article className={styles.article}>
@@ -67,6 +69,7 @@ export default async function CompaniesPage() {
           {groups.map((group) => {
             const head = group.cards[0];
             const headRole = head?.jobTitleZh || head?.jobTitleEn;
+            const followupCount = countFollowupsInCards(group.cards, now);
             return (
               <li key={group.slug}>
                 <Link
@@ -74,7 +77,17 @@ export default async function CompaniesPage() {
                   className={styles.companyRow}
                 >
                   <div className={styles.companyMain}>
-                    <h2 className={styles.companyName}>{group.displayName}</h2>
+                    <h2 className={styles.companyName}>
+                      {group.displayName}
+                      {followupCount > 0 && (
+                        <span
+                          className={styles.followupBadge}
+                          aria-label={`${followupCount} 個人該 ping 了`}
+                        >
+                          ⏰ {followupCount}
+                        </span>
+                      )}
+                    </h2>
                     <p className={styles.companyMeta}>
                       {group.cards.length} 位 · 最近：{formatYmd(group.mostRecentTouch)}
                     </p>

--- a/src/app/(app)/events/events.module.css
+++ b/src/app/(app)/events/events.module.css
@@ -120,6 +120,20 @@
   font-weight: 600;
   margin: 0;
   color: var(--color-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.followupBadge {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
+  background: var(--color-accent);
+  color: var(--color-paper);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
 }
 
 .eventMeta {

--- a/src/app/(app)/events/page.tsx
+++ b/src/app/(app)/events/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { listCardsForUser } from "@/db/cards";
 import { groupCardsByEvent } from "@/lib/events/group";
 import { readSession } from "@/lib/firebase/session";
+import { countFollowupsInCards } from "@/lib/timeline/followups";
 
 import styles from "./events.module.css";
 
@@ -27,6 +28,7 @@ export default async function EventsPage() {
     order: "desc",
   });
   const groups = groupCardsByEvent(cards);
+  const now = new Date();
 
   return (
     <article className={styles.article}>
@@ -58,21 +60,37 @@ export default async function EventsPage() {
         </section>
       ) : (
         <ul className={styles.eventList}>
-          {groups.map((group) => (
-            <li key={group.slug}>
-              <Link href={`/events/${encodeURIComponent(group.slug)}`} className={styles.eventRow}>
-                <div className={styles.eventMain}>
-                  <h2 className={styles.eventName}>{group.displayName}</h2>
-                  <p className={styles.eventMeta}>
-                    {group.cards.length} 位 · 最近見面：{formatYmd(group.mostRecentMet)}
-                  </p>
-                </div>
-                <span className={styles.chevron} aria-hidden="true">
-                  →
-                </span>
-              </Link>
-            </li>
-          ))}
+          {groups.map((group) => {
+            const followupCount = countFollowupsInCards(group.cards, now);
+            return (
+              <li key={group.slug}>
+                <Link
+                  href={`/events/${encodeURIComponent(group.slug)}`}
+                  className={styles.eventRow}
+                >
+                  <div className={styles.eventMain}>
+                    <h2 className={styles.eventName}>
+                      {group.displayName}
+                      {followupCount > 0 && (
+                        <span
+                          className={styles.followupBadge}
+                          aria-label={`${followupCount} 個人該 ping 了`}
+                        >
+                          ⏰ {followupCount}
+                        </span>
+                      )}
+                    </h2>
+                    <p className={styles.eventMeta}>
+                      {group.cards.length} 位 · 最近見面：{formatYmd(group.mostRecentMet)}
+                    </p>
+                  </div>
+                  <span className={styles.chevron} aria-hidden="true">
+                    →
+                  </span>
+                </Link>
+              </li>
+            );
+          })}
         </ul>
       )}
     </article>

--- a/src/app/(app)/followups/page.tsx
+++ b/src/app/(app)/followups/page.tsx
@@ -13,6 +13,8 @@ import {
   upcomingRemindersThisWeek,
   type FollowupBucket,
 } from "@/lib/timeline/followups";
+// /followups uses bucketFollowups+dueRemindersToday directly (it
+// renders each bucket separately), not the count-only helper.
 
 import styles from "./followups.module.css";
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import { AppShell } from "@/components/shell/AppShell";
 import { listCardsForUser } from "@/db/cards";
 import { readSession } from "@/lib/firebase/session";
-import { bucketFollowups, dueRemindersToday, totalFollowups } from "@/lib/timeline/followups";
+import { countFollowupsInCards } from "@/lib/timeline/followups";
 import { ensurePersonalWorkspace } from "@/lib/workspace/ensure";
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
@@ -23,9 +23,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       orderBy: "createdAt",
       order: "desc",
     });
-    const now = new Date();
-    followupsTotal =
-      totalFollowups(bucketFollowups(cards, now)) + dueRemindersToday(cards, now).length;
+    followupsTotal = countFollowupsInCards(cards, new Date());
   } catch (err) {
     // Don't take down the entire app shell if the count query fails.
     console.error("[layout] followups count failed:", err instanceof Error ? err.message : err);

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -9,7 +9,7 @@ import { listCardsForUser } from "@/db/cards";
 import { isCoachConfigured } from "@/lib/coach/llm";
 import { readSession } from "@/lib/firebase/session";
 import { categorizeTimeline } from "@/lib/timeline/categorize";
-import { bucketFollowups, dueRemindersToday, totalFollowups } from "@/lib/timeline/followups";
+import { countFollowupsInCards } from "@/lib/timeline/followups";
 
 import styles from "./home.module.css";
 
@@ -30,10 +30,9 @@ export default async function HomePage() {
   const sections = categorizeTimeline(cards, { now });
   const totalInSections = sections.reduce((sum, section) => sum + section.cards.length, 0);
   // Follow-up urgency chip — staleness buckets PLUS user-scheduled
-  // reminders due today. Same data path the dedicated /followups page
-  // uses, summarized into a count for the home header.
-  const followupsTotal =
-    totalFollowups(bucketFollowups(cards, now)) + dueRemindersToday(cards, now).length;
+  // reminders due today. Single source of truth shared with /cards,
+  // /followups, AppShell rail, and per-group badges.
+  const followupsTotal = countFollowupsInCards(cards, now);
   const firstName = user.displayName?.split(" ")[0] ?? "";
 
   return (

--- a/src/lib/timeline/__tests__/followups.test.ts
+++ b/src/lib/timeline/__tests__/followups.test.ts
@@ -4,6 +4,7 @@ import type { CardSummary } from "@/db/cards";
 
 import {
   bucketFollowups,
+  countFollowupsInCards,
   dueRemindersToday,
   totalFollowups,
   upcomingRemindersThisWeek,
@@ -206,5 +207,27 @@ describe("upcomingRemindersThisWeek", () => {
     const c = mk({ id: "f", followUpAt: daysAhead(20) });
     expect(upcomingRemindersThisWeek([c], NOW, 30)).toHaveLength(1);
     expect(upcomingRemindersThisWeek([c], NOW, 7)).toHaveLength(0);
+  });
+});
+
+describe("countFollowupsInCards", () => {
+  it("sums staleness buckets and todays scheduled reminders", () => {
+    const todayMid = new Date(NOW);
+    todayMid.setHours(12, 0, 0, 0);
+    const cards = [
+      mk({ id: "stale", lastContactedAt: daysAgo(45) }), // due bucket
+      mk({ id: "older", lastContactedAt: daysAgo(95) }), // critical bucket
+      mk({ id: "rem-today", followUpAt: todayMid }), // due today
+    ];
+    expect(countFollowupsInCards(cards, NOW)).toBe(3);
+  });
+
+  it("returns 0 for an empty corpus", () => {
+    expect(countFollowupsInCards([], NOW)).toBe(0);
+  });
+
+  it("ignores soft-deleted cards", () => {
+    const c = mk({ id: "d", lastContactedAt: daysAgo(100), deletedAt: daysAgo(1) });
+    expect(countFollowupsInCards([c], NOW)).toBe(0);
   });
 });

--- a/src/lib/timeline/followups.ts
+++ b/src/lib/timeline/followups.ts
@@ -138,6 +138,16 @@ export function dueRemindersToday(
 }
 
 /**
+ * Composite count: staleness buckets + scheduled reminders due today.
+ * Used by the home/cards/AppShell urgency chips and per-group badges
+ * on /companies and /events. Single source of truth for "how many
+ * action items does this slice of cards represent right now?".
+ */
+export function countFollowupsInCards(cards: CardSummary[], now: Date): number {
+  return totalFollowups(bucketFollowups(cards, now)) + dueRemindersToday(cards, now).length;
+}
+
+/**
  * Cards with followUpAt strictly after end-of-today and within
  * `windowDays` (default 7) inclusive. Used for /followups 「下週提醒」 —
  * gives business users a glance at their upcoming week without


### PR DESCRIPTION
## Summary
- New \`countFollowupsInCards(cards, now)\` helper in \`@/lib/timeline/followups\` — single source of truth for "how many action items in this slice".
- Refactored 4 existing call sites (home, /cards, AppShell layout, /followups had its own composition) to use the helper.
- /companies and /events list rows now show ⏰ N badges on groups with pending follow-ups, so business users can prioritize "which group needs my attention".
- 3 new unit tests for the helper.

Closes #190

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.41%
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`
- [ ] Verify on Mac mini: company/event rows show ⏰ N badge when applicable