### PR TITLE
feat(companies/events): hybrid-sort — needs-attention groups bubble to top

### DIFF
--- a/src/app/(app)/companies/page.tsx
+++ b/src/app/(app)/companies/page.tsx
@@ -31,8 +31,20 @@ export default async function CompaniesPage() {
     orderBy: "createdAt",
     order: "desc",
   });
-  const groups = groupCardsByCompany(cards);
+  const rawGroups = groupCardsByCompany(cards);
   const now = new Date();
+
+  // Decorate with follow-up count, then hybrid-sort: groups that need
+  // attention bubble to the top (by count desc), and the calm-tail
+  // keeps the original mostRecentTouch ordering.
+  const groups = rawGroups
+    .map((g) => ({ group: g, followupCount: countFollowupsInCards(g.cards, now) }))
+    .sort((a, b) => {
+      if (a.followupCount !== b.followupCount) return b.followupCount - a.followupCount;
+      const aTouch = a.group.mostRecentTouch?.getTime() ?? 0;
+      const bTouch = b.group.mostRecentTouch?.getTime() ?? 0;
+      return bTouch - aTouch;
+    });
 
   return (
     <article className={styles.article}>
@@ -49,7 +61,7 @@ export default async function CompaniesPage() {
         </h1>
         {groups.length > 0 ? (
           <p className={styles.lead}>
-            按最近互動排序。點進去看同公司的所有人、彼此職位、互動歷史。
+            該追蹤的公司排前面，其他按最近互動排序。點進去看同公司的所有人、彼此職位、互動歷史。
           </p>
         ) : (
           <p className={styles.lead}>
@@ -66,10 +78,9 @@ export default async function CompaniesPage() {
         </section>
       ) : (
         <ul className={styles.companyList}>
-          {groups.map((group) => {
+          {groups.map(({ group, followupCount }) => {
             const head = group.cards[0];
             const headRole = head?.jobTitleZh || head?.jobTitleEn;
-            const followupCount = countFollowupsInCards(group.cards, now);
             return (
               <li key={group.slug}>
                 <Link

--- a/src/app/(app)/events/page.tsx
+++ b/src/app/(app)/events/page.tsx
@@ -27,8 +27,20 @@ export default async function EventsPage() {
     orderBy: "createdAt",
     order: "desc",
   });
-  const groups = groupCardsByEvent(cards);
+  const rawGroups = groupCardsByEvent(cards);
   const now = new Date();
+
+  // Decorate with follow-up count and hybrid-sort: groups that need
+  // attention come first (by count desc), the rest keep mostRecentMet
+  // ordering. Same pattern as /companies.
+  const groups = rawGroups
+    .map((g) => ({ group: g, followupCount: countFollowupsInCards(g.cards, now) }))
+    .sort((a, b) => {
+      if (a.followupCount !== b.followupCount) return b.followupCount - a.followupCount;
+      const aTouch = a.group.mostRecentMet?.getTime() ?? 0;
+      const bTouch = b.group.mostRecentMet?.getTime() ?? 0;
+      return bTouch - aTouch;
+    });
 
   return (
     <article className={styles.article}>
@@ -44,7 +56,9 @@ export default async function EventsPage() {
           <em>{groups.length}</em> 個場合
         </h1>
         {groups.length > 0 ? (
-          <p className={styles.lead}>按最近見面排序。點進去看那場見過誰、職位、為什麼記得。</p>
+          <p className={styles.lead}>
+            該追蹤的場合排前面，其他按最近見面排序。點進去看那場見過誰、職位、為什麼記得。
+          </p>
         ) : (
           <p className={styles.lead}>
             還沒有名片標註「第一次見面場合」。建立或編輯名片時填入場合，這裡會自動聚合。
@@ -60,8 +74,7 @@ export default async function EventsPage() {
         </section>
       ) : (
         <ul className={styles.eventList}>
-          {groups.map((group) => {
-            const followupCount = countFollowupsInCards(group.cards, now);
+          {groups.map(({ group, followupCount }) => {
             return (
               <li key={group.slug}>
                 <Link


### PR DESCRIPTION
## Summary
- Hybrid sort on /companies and /events: groups with pending follow-ups (\`followupCount > 0\`) come first by count desc, then groups with 0 pending sorted by mostRecentTouch / mostRecentMet desc.
- Decorate-then-sort pattern keeps complexity at O(n log n) instead of recomputing per comparison.
- Lead text updated to reflect the new ordering: 「該追蹤的公司排前面，其他按最近互動排序」.
- No new Firestore reads — uses the same \`countFollowupsInCards\` we already compute for the row badges.

Closes #192

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.41% (no test changes needed; existing followups tests cover the helper)
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`
- [ ] Verify on Mac mini: companies/events with ⏰ badges appear at the top