### PR TITLE
feat(home): render 🎉 anniversaries as actionable rows + drive-by TZ test fix

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { DailyBriefingSection } from "@/components/coach/DailyBriefingSection";
 import { OnboardingHero } from "@/components/home/OnboardingHero";
 import { PwaInstallHint } from "@/components/home/PwaInstallHint";
+import { AnniversariesSection } from "@/components/timeline/AnniversariesSection";
 import { DueTodaySection } from "@/components/timeline/DueTodaySection";
 import { TimelineSection } from "@/components/timeline/TimelineSection";
 import { listCardsForUser } from "@/db/cards";
@@ -79,18 +80,29 @@ export default async function HomePage() {
         <>
           {isCoachConfigured() && cards.length >= 3 && <DailyBriefingSection />}
           <div className={styles.sections}>
-            {sections.map((section) =>
-              section.id === "due-today" ? (
-                <DueTodaySection
-                  key={section.id}
-                  section={section}
-                  now={now}
-                  showAiDrafts={isCoachConfigured()}
-                />
-              ) : (
-                <TimelineSection key={section.id} section={section} />
-              ),
-            )}
+            {sections.map((section) => {
+              if (section.id === "due-today") {
+                return (
+                  <DueTodaySection
+                    key={section.id}
+                    section={section}
+                    now={now}
+                    showAiDrafts={isCoachConfigured()}
+                  />
+                );
+              }
+              if (section.id === "anniversaries") {
+                return (
+                  <AnniversariesSection
+                    key={section.id}
+                    section={section}
+                    now={now}
+                    showAiDrafts={isCoachConfigured()}
+                  />
+                );
+              }
+              return <TimelineSection key={section.id} section={section} />;
+            })}
           </div>
         </>
       )}

--- a/src/components/cards/__tests__/CardActions.test.tsx
+++ b/src/components/cards/__tests__/CardActions.test.tsx
@@ -176,6 +176,7 @@ describe("CardActions quick CTA row", () => {
 
     it("clicking +7 天 fires setFollowUpAction with 7-day-out date", async () => {
       const { setFollowUpAction } = await import("@/app/(app)/cards/actions");
+      const { localYmdAfterDays } = await import("@/lib/cards/follow-up-date");
       const mocked = vi.mocked(setFollowUpAction);
       mocked.mockClear();
       render(<CardActions cardId="abc" />);
@@ -185,11 +186,10 @@ describe("CardActions quick CTA row", () => {
         expect(mocked).toHaveBeenCalledTimes(1);
       });
       const call = mocked.mock.calls[0]![0]!;
-      // Check it's an ISO date 7 days out (allow 1-day skew across timezones).
-      const target = new Date();
-      target.setDate(target.getDate() + 7);
-      const expected = target.toISOString().slice(0, 10);
-      expect(call.followUpAt).toBe(expected);
+      // Compare against the same TZ-safe helper the production code uses
+      // (PR #175). Older versions of this test used toISOString() which is
+      // UTC-based and would skew on dates near the local-day boundary.
+      expect(call.followUpAt).toBe(localYmdAfterDays(7));
     });
 
     it("clicking 取消提醒 fires setFollowUpAction with null", async () => {

--- a/src/components/timeline/AnniversariesSection.tsx
+++ b/src/components/timeline/AnniversariesSection.tsx
@@ -1,0 +1,64 @@
+import { FollowupCardRow } from "@/components/followups/FollowupCardRow";
+import type { CardSummary } from "@/db/cards";
+import { findAnniversariesToday } from "@/lib/timeline/anniversaries";
+import type { TimelineSection as TimelineSectionData } from "@/lib/timeline/categorize";
+import { daysSinceContact } from "@/lib/timeline/staleness";
+
+import styles from "./TimelineSection.module.css";
+
+interface AnniversariesSectionProps {
+  section: TimelineSectionData;
+  now: Date;
+  showAiDrafts?: boolean;
+}
+
+/**
+ * Home-page rendering of the `anniversaries` timeline section using
+ * FollowupCardRow — same actionable UX (📧📞💬 + ✅ + picker) as
+ * due-today (PR #183). Per-row label shows the anniversary year
+ * count (「🎉 1 年」 / 「🎉 5 年」).
+ *
+ * The section.cards list comes pre-filtered from categorizeTimeline,
+ * so we only re-run findAnniversariesToday over those cards to recover
+ * the lost `years` field — cheap because the list is small (typically
+ * 0-3 cards).
+ */
+export function AnniversariesSection({
+  section,
+  now,
+  showAiDrafts = false,
+}: AnniversariesSectionProps) {
+  if (section.cards.length === 0) return null;
+
+  // Recover years per card (categorizeTimeline drops the per-entry
+  // metadata when it builds section.cards as plain CardSummary[]).
+  const yearsByCard = new Map<string, number>();
+  for (const entry of findAnniversariesToday(section.cards, now)) {
+    yearsByCard.set(entry.card.id, entry.years);
+  }
+
+  return (
+    <section className={styles.section} aria-labelledby={`section-${section.id}`}>
+      <header className={styles.header}>
+        <h2 id={`section-${section.id}`} className={styles.title}>
+          {section.title}
+        </h2>
+        <p className={styles.description}>{section.description}</p>
+      </header>
+      <ol className={styles.actionableList}>
+        {section.cards.map((card: CardSummary) => {
+          const years = yearsByCard.get(card.id) ?? 1;
+          return (
+            <FollowupCardRow
+              key={card.id}
+              card={card}
+              days={daysSinceContact(card, now) ?? 0}
+              daysLabel={`🎉 ${years} 年`}
+              showAiDrafts={showAiDrafts}
+            />
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/src/components/timeline/__tests__/AnniversariesSection.test.tsx
+++ b/src/components/timeline/__tests__/AnniversariesSection.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { CardSummary } from "@/db/cards";
+import type { TimelineSection } from "@/lib/timeline/categorize";
+import { AnniversariesSection } from "../AnniversariesSection";
+
+vi.mock("@/app/(app)/cards/actions", () => ({
+  logContactAction: vi.fn(),
+  setFollowUpAction: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+
+const NOW = new Date(2026, 3, 27, 12, 0, 0); // April 27 2026
+
+function makeCard(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "c1",
+    nameZh: "王大明",
+    emails: [{ value: "wang@example.com", primary: true, label: "工作" }],
+    phones: [],
+    social: {},
+    createdAt: NOW,
+    updatedAt: NOW,
+    deletedAt: null,
+    lastContactedAt: null,
+    ...overrides,
+  } as CardSummary;
+}
+
+describe("AnniversariesSection", () => {
+  it("renders nothing when section has no cards", () => {
+    const { container } = render(
+      <AnniversariesSection
+        section={
+          {
+            id: "anniversaries",
+            title: "🎉 一年前的今天",
+            description: "...",
+            cards: [],
+          } as TimelineSection
+        }
+        now={NOW}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders 「🎉 1 年」 for a card met exactly 1 year ago today", () => {
+    const card = makeCard({ id: "a", firstMetDate: "2025-04-27" }); // 1 year ago
+    render(
+      <AnniversariesSection
+        section={
+          {
+            id: "anniversaries",
+            title: "🎉 一年前的今天",
+            description: "...",
+            cards: [card],
+          } as TimelineSection
+        }
+        now={NOW}
+      />,
+    );
+    expect(screen.getByText("🎉 1 年")).toBeInTheDocument();
+    // FollowupCardRow wired up — quick action visible
+    expect(screen.getByLabelText(/寄信給 王大明/)).toBeInTheDocument();
+  });
+
+  it("renders 「🎉 5 年」 for a 5-year anniversary", () => {
+    const card = makeCard({ id: "b", firstMetDate: "2021-04-27" });
+    render(
+      <AnniversariesSection
+        section={
+          {
+            id: "anniversaries",
+            title: "🎉 五 年前的今天",
+            description: "...",
+            cards: [card],
+          } as TimelineSection
+        }
+        now={NOW}
+      />,
+    );
+    expect(screen.getByText("🎉 5 年")).toBeInTheDocument();
+  });
+
+  it("falls back to 1 year if the year lookup misses (defensive)", () => {
+    // Card whose firstMetDate doesn't match today — findAnniversariesToday
+    // returns no entry, so the Map lookup misses and we fall back.
+    const card = makeCard({ id: "c", firstMetDate: "2024-12-15" });
+    render(
+      <AnniversariesSection
+        section={
+          {
+            id: "anniversaries",
+            title: "🎉 週年提醒",
+            description: "...",
+            cards: [card],
+          } as TimelineSection
+        }
+        now={NOW}
+      />,
+    );
+    expect(screen.getByText("🎉 1 年")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- New \`AnniversariesSection\` wrapper renders home's anniversary cards with FollowupCardRow (📧📞💬 + ✅ + picker), parallel to PR #183's DueTodaySection.
- Per-row label shows 「🎉 N 年」 specific to each card's anniversary count.
- Recovers per-card \`years\` by re-running \`findAnniversariesToday\` over the small section list — avoids reshaping the categorize lib's data contract.
- Other home sections (pinned / met-this-month / newly-added / uncontacted) keep TimelineSection — passive context surfaces.

## Drive-by test fix
- \`CardActions.test.tsx\` "+7 天" assertion used \`toISOString().slice(0, 10)\` (UTC) for its expected value. PR #175 made the production code TZ-safe (\`localYmdAfterDays\`). The mismatch happened to fire today on the local-day boundary in Taipei (UTC+8). Now both sides use the same helper.

Closes #194

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.43%; 4 new AnniversariesSection tests + 1 CardActions test fix
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`