### PR TITLE
feat(group-detail): ⏰ N 該追蹤 link in /companies/[slug] + /events/[tag] headers

### DIFF
--- a/src/app/(app)/companies/[slug]/company.module.css
+++ b/src/app/(app)/companies/[slug]/company.module.css
@@ -56,6 +56,16 @@
   margin: var(--space-xs) 0 0;
 }
 
+.urgency {
+  color: var(--color-accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.urgency:hover {
+  text-decoration: underline;
+}
+
 .headerActions {
   display: flex;
   gap: var(--space-sm);

--- a/src/app/(app)/companies/[slug]/page.tsx
+++ b/src/app/(app)/companies/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { listCardsForUser } from "@/db/cards";
 import { computeTemperature } from "@/lib/cards/relationship-temp";
 import { findCompanyBySlug } from "@/lib/companies/group";
 import { readSession } from "@/lib/firebase/session";
+import { countFollowupsInCards } from "@/lib/timeline/followups";
 
 import styles from "./company.module.css";
 
@@ -48,6 +49,7 @@ export default async function CompanyDetailPage({ params }: PageProps) {
   const sharedEvents = Array.from(
     new Set(group.cards.map((c) => c.firstMetEventTag).filter(Boolean) as string[]),
   );
+  const followupCount = countFollowupsInCards(group.cards, new Date());
 
   return (
     <article className={styles.article}>
@@ -64,6 +66,14 @@ export default async function CompanyDetailPage({ params }: PageProps) {
         <h1 className={styles.title}>{group.displayName}</h1>
         <p className={styles.lead}>
           {group.cards.length} 位聯絡人 · {totalContacted} 位有互動紀錄
+          {followupCount > 0 && (
+            <>
+              {" · "}
+              <Link href="/followups" className={styles.urgency}>
+                ⏰ {followupCount} 該追蹤
+              </Link>
+            </>
+          )}
           {sharedEvents.length > 0 && <> · 認識場合：{sharedEvents.join("、")}</>}
         </p>
         <div className={styles.headerActions}>

--- a/src/app/(app)/events/[tag]/event.module.css
+++ b/src/app/(app)/events/[tag]/event.module.css
@@ -49,6 +49,16 @@
   color: var(--color-ink);
 }
 
+.urgency {
+  color: var(--color-accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.urgency:hover {
+  text-decoration: underline;
+}
+
 .lead {
   font-family: var(--font-sans);
   font-size: var(--text-body);

--- a/src/app/(app)/events/[tag]/page.tsx
+++ b/src/app/(app)/events/[tag]/page.tsx
@@ -6,6 +6,7 @@ import { listCardsForUser } from "@/db/cards";
 import { computeTemperature } from "@/lib/cards/relationship-temp";
 import { findEventBySlug } from "@/lib/events/group";
 import { readSession } from "@/lib/firebase/session";
+import { countFollowupsInCards } from "@/lib/timeline/followups";
 
 import styles from "./event.module.css";
 
@@ -51,6 +52,7 @@ export default async function EventDetailPage({ params }: PageProps) {
       group.cards.map((c) => c.companyZh || c.companyEn || "").filter((s) => s.trim().length > 0),
     ),
   );
+  const followupCount = countFollowupsInCards(group.cards, new Date());
 
   return (
     <article className={styles.article}>
@@ -67,6 +69,14 @@ export default async function EventDetailPage({ params }: PageProps) {
         <h1 className={styles.title}>{group.displayName}</h1>
         <p className={styles.lead}>
           {group.cards.length} 位聯絡人
+          {followupCount > 0 && (
+            <>
+              {" · "}
+              <Link href="/followups" className={styles.urgency}>
+                ⏰ {followupCount} 該追蹤
+              </Link>
+            </>
+          )}
           {companies.length > 0 && <> · 公司：{companies.join("、")}</>}
         </p>
       </header>


### PR DESCRIPTION
## Summary
- /companies/[slug] and /events/[tag] now show "· ⏰ N 該追蹤" inline in the header lead line when there are pending follow-ups in that group.
- Linked to /followups so users get a 1-click escape hatch to act.
- Inline-link style (color + weight) keeps the lead readable, vs the pill-shaped badges used in list rows.

Closes #196

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.43% (no test changes; existing followups tests cover the helper)
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`