### PR TITLE
feat(stats): 本月最常聊到的公司 — top companies by conversation

### DIFF
--- a/src/app/(app)/stats/page.tsx
+++ b/src/app/(app)/stats/page.tsx
@@ -6,6 +6,7 @@ import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
 import { listCardsForUser, listRecentContactEventsForUser } from "@/db/cards";
 import { computeTemperature } from "@/lib/cards/relationship-temp";
 import { isCoachConfigured } from "@/lib/coach/llm";
+import { companySlug } from "@/lib/companies/group";
 import { readSession } from "@/lib/firebase/session";
 import { aggregateStats } from "@/lib/stats/aggregate";
 
@@ -97,6 +98,29 @@ export default async function StatsPage() {
                 <span className={styles.topMeta}>
                   <TemperatureBadge temperature={computeTemperature(p.card, now)} compact />
                   <span className={styles.topCount}>{p.logCount} 次對話</span>
+                </span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
+
+      {stats.topCompanies.length > 0 && (
+        <section aria-label="本月最常聊到的公司" className={styles.statBlock}>
+          <h2 className={styles.blockTitle}>本月最常聊到的公司</h2>
+          <ol className={styles.topList}>
+            {stats.topCompanies.map((c) => (
+              <li key={c.companyName} className={styles.topItem}>
+                <Link
+                  href={`/companies/${encodeURIComponent(companySlug(c.companyName))}`}
+                  className={styles.topName}
+                >
+                  {c.companyName}
+                </Link>
+                <span className={styles.topMeta}>
+                  <span className={styles.topCount}>
+                    {c.logCount} 次 · {c.distinctPeople} 人
+                  </span>
                 </span>
               </li>
             ))}

--- a/src/lib/stats/__tests__/aggregate.test.ts
+++ b/src/lib/stats/__tests__/aggregate.test.ts
@@ -45,6 +45,20 @@ function evItem(cardId: string, daysAgo: number, name = cardId): RecapItem {
   };
 }
 
+function evItemWithCompany(cardId: string, daysAgo: number, companyName: string): RecapItem {
+  const event: ContactEvent = {
+    id: `e-${cardId}-${daysAgo}`,
+    at: dayOffset(NOW, daysAgo),
+    note: "n",
+    authorUid: "u",
+    authorDisplay: null,
+  };
+  return {
+    card: aCard({ id: cardId, nameZh: cardId, companyZh: companyName }),
+    event,
+  };
+}
+
 describe("aggregateStats", () => {
   it("empty cards + empty events → zeros across the board", () => {
     const out = aggregateStats([], [], NOW);
@@ -52,6 +66,7 @@ describe("aggregateStats", () => {
     expect(out.thisMonth).toEqual({ logCount: 0, newCardCount: 0, distinctPeople: 0 });
     expect(out.streak).toEqual({ current: 0, longest: 0 });
     expect(out.topPeople).toEqual([]);
+    expect(out.topCompanies).toEqual([]);
     expect(out.totalCards).toBe(0);
   });
 
@@ -174,5 +189,55 @@ describe("aggregateStats", () => {
     const out = aggregateStats([], [epochEvent], NOW);
     expect(out.thisWeek.logCount).toBe(0);
     expect(out.streak).toEqual({ current: 0, longest: 0 });
+  });
+});
+
+describe("aggregateStats — topCompanies", () => {
+  it("aggregates by company name with logCount + distinctPeople", () => {
+    const events = [
+      evItemWithCompany("a", 1, "Acme"),
+      evItemWithCompany("a", 2, "Acme"), // same person twice
+      evItemWithCompany("b", 3, "Acme"), // different person same company
+      evItemWithCompany("c", 5, "Beta"),
+      evItemWithCompany("d", 7, "Beta"),
+    ];
+    const out = aggregateStats([], events, NOW);
+    expect(out.topCompanies).toEqual([
+      { companyName: "Acme", logCount: 3, distinctPeople: 2 },
+      { companyName: "Beta", logCount: 2, distinctPeople: 2 },
+    ]);
+  });
+
+  it("excludes events whose card has no company", () => {
+    const events = [
+      evItem("nocompany", 1), // no company on card
+      evItemWithCompany("withcompany", 2, "Acme"),
+    ];
+    const out = aggregateStats([], events, NOW);
+    expect(out.topCompanies.map((c) => c.companyName)).toEqual(["Acme"]);
+  });
+
+  it("excludes events outside the 30-day window", () => {
+    const events = [
+      evItemWithCompany("recent", 5, "Acme"),
+      evItemWithCompany("old", 60, "Acme"), // outside window
+    ];
+    const out = aggregateStats([], events, NOW);
+    expect(out.topCompanies[0]).toEqual({ companyName: "Acme", logCount: 1, distinctPeople: 1 });
+  });
+
+  it("caps at 3 companies and sorts by logCount desc", () => {
+    const events = [
+      evItemWithCompany("a", 1, "C1"),
+      evItemWithCompany("a", 2, "C1"),
+      evItemWithCompany("a", 3, "C1"),
+      evItemWithCompany("a", 1, "C2"),
+      evItemWithCompany("a", 2, "C2"),
+      evItemWithCompany("a", 1, "C3"),
+      evItemWithCompany("a", 1, "C4"), // tied with C3, but C4 sorts after by name tiebreak so C3 wins
+    ];
+    const out = aggregateStats([], events, NOW);
+    expect(out.topCompanies).toHaveLength(3);
+    expect(out.topCompanies.map((c) => c.companyName)).toEqual(["C1", "C2", "C3"]);
   });
 });

--- a/src/lib/stats/__tests__/digest.test.ts
+++ b/src/lib/stats/__tests__/digest.test.ts
@@ -10,6 +10,7 @@ function emptyStats(over: Partial<AggregatedStats> = {}): AggregatedStats {
     temperature: { hot: 0, warm: 0, active: 0, quiet: 0, cold: 0 },
     streak: { current: 0, longest: 0 },
     topPeople: [],
+    topCompanies: [],
     totalCards: 0,
     ...over,
   };

--- a/src/lib/stats/aggregate.ts
+++ b/src/lib/stats/aggregate.ts
@@ -16,6 +16,15 @@ export interface TopPerson {
   logCount: number;
 }
 
+export interface TopCompany {
+  /** Display name as it appears on the card (companyZh || companyEn). */
+  companyName: string;
+  /** Total log events from this company in the window. */
+  logCount: number;
+  /** Distinct people from this company logged with in the window. */
+  distinctPeople: number;
+}
+
 export interface Streak {
   /** Consecutive days back-to-back from today with ≥1 log. */
   current: number;
@@ -30,6 +39,8 @@ export interface AggregatedStats {
   streak: Streak;
   /** Top 3 most-logged-with people in last 30 days. */
   topPeople: TopPerson[];
+  /** Top 3 most-logged-with companies in last 30 days. */
+  topCompanies: TopCompany[];
   /** Total live (non-deleted) cards in the workspace. */
   totalCards: number;
 }
@@ -151,6 +162,43 @@ function computeStreak(items: readonly RecapItem[], now: Date): Streak {
   return { current, longest };
 }
 
+function computeTopCompanies(items: readonly RecapItem[], cutoff: Date, limit = 3): TopCompany[] {
+  const counts = new Map<
+    string,
+    { companyName: string; logCount: number; people: Set<string>; lastAt: number }
+  >();
+  for (const item of items) {
+    if (!item.event.at || item.event.at.getTime() < cutoff.getTime()) continue;
+    const companyName = (item.card.companyZh || item.card.companyEn || "").trim();
+    if (!companyName) continue; // skip events whose card has no company
+    const cur = counts.get(companyName);
+    if (cur) {
+      cur.logCount++;
+      cur.people.add(item.card.id);
+      cur.lastAt = Math.max(cur.lastAt, item.event.at.getTime());
+    } else {
+      counts.set(companyName, {
+        companyName,
+        logCount: 1,
+        people: new Set([item.card.id]),
+        lastAt: item.event.at.getTime(),
+      });
+    }
+  }
+  const list = [...counts.values()];
+  list.sort((a, b) => {
+    if (b.logCount !== a.logCount) return b.logCount - a.logCount;
+    if (b.people.size !== a.people.size) return b.people.size - a.people.size;
+    if (b.lastAt !== a.lastAt) return b.lastAt - a.lastAt;
+    return a.companyName < b.companyName ? -1 : 1;
+  });
+  return list.slice(0, limit).map((x) => ({
+    companyName: x.companyName,
+    logCount: x.logCount,
+    distinctPeople: x.people.size,
+  }));
+}
+
 function computeTopPeople(items: readonly RecapItem[], cutoff: Date, limit = 3): TopPerson[] {
   const counts = new Map<string, { card: CardSummary; logCount: number; lastAt: number }>();
   for (const item of items) {
@@ -196,6 +244,7 @@ export function aggregateStats(
     temperature: temperatureCounts(live, now),
     streak: computeStreak(events, now),
     topPeople: computeTopPeople(events, monthCutoff, 3),
+    topCompanies: computeTopCompanies(events, monthCutoff, 3),
     totalCards: live.length,
   };
 }


### PR DESCRIPTION
## Summary
- New 「本月最常聊到的公司」 section on /stats — mirrors top-people but aggregates by company name.
- Each row: company name + \`{logCount} 次 · {distinctPeople} 人\`. Both metrics matter: 12 logs from 1 person ≠ 12 logs from 6 people.
- New \`TopCompany\` type + \`computeTopCompanies\` aggregator. Sort: logCount desc → distinctPeople desc → recency desc → name.
- Each row links to /companies/[slug] via the shared \`companySlug\` helper (URLs stay consistent with what \`groupCardsByCompany\` would emit).
- 4 new unit tests cover aggregation, no-company exclusion, 30-day window, cap-at-3 + sort tiebreak.

Closes #198

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.48%
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`