### PR TITLE
feat(companies/events): client-side filter input — type to narrow the list

### DIFF
--- a/src/app/(app)/companies/page.tsx
+++ b/src/app/(app)/companies/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { CompanyList, type CompanyListItem } from "@/components/companies/CompanyList";
 import { listCardsForUser } from "@/db/cards";
 import { groupCardsByCompany } from "@/lib/companies/group";
 import { readSession } from "@/lib/firebase/session";
@@ -34,16 +35,28 @@ export default async function CompaniesPage() {
   const rawGroups = groupCardsByCompany(cards);
   const now = new Date();
 
-  // Decorate with follow-up count, then hybrid-sort: groups that need
-  // attention bubble to the top (by count desc), and the calm-tail
-  // keeps the original mostRecentTouch ordering.
-  const groups = rawGroups
+  // Decorate, sort (urgency first then recency), and project to the
+  // serializable shape the client list component consumes.
+  const items: CompanyListItem[] = rawGroups
     .map((g) => ({ group: g, followupCount: countFollowupsInCards(g.cards, now) }))
     .sort((a, b) => {
       if (a.followupCount !== b.followupCount) return b.followupCount - a.followupCount;
       const aTouch = a.group.mostRecentTouch?.getTime() ?? 0;
       const bTouch = b.group.mostRecentTouch?.getTime() ?? 0;
       return bTouch - aTouch;
+    })
+    .map(({ group, followupCount }) => {
+      const head = group.cards[0];
+      const headRole = head?.jobTitleZh || head?.jobTitleEn;
+      return {
+        slug: group.slug,
+        displayName: group.displayName,
+        count: group.cards.length,
+        mostRecentTouchYmd: formatYmd(group.mostRecentTouch),
+        headName: head ? cardName(head) : undefined,
+        headRole,
+        followupCount,
+      };
     });
 
   return (
@@ -57,9 +70,9 @@ export default async function CompaniesPage() {
       <header className={styles.header}>
         <p className={styles.kicker}>公司視角</p>
         <h1 className={styles.title}>
-          <em>{groups.length}</em> 家公司
+          <em>{items.length}</em> 家公司
         </h1>
-        {groups.length > 0 ? (
+        {items.length > 0 ? (
           <p className={styles.lead}>
             該追蹤的公司排前面，其他按最近互動排序。點進去看同公司的所有人、彼此職位、互動歷史。
           </p>
@@ -70,50 +83,14 @@ export default async function CompaniesPage() {
         )}
       </header>
 
-      {groups.length === 0 ? (
+      {items.length === 0 ? (
         <section className={styles.empty}>
           <Link href="/cards/new" className={styles.backLink}>
             建立第一張名片 →
           </Link>
         </section>
       ) : (
-        <ul className={styles.companyList}>
-          {groups.map(({ group, followupCount }) => {
-            const head = group.cards[0];
-            const headRole = head?.jobTitleZh || head?.jobTitleEn;
-            return (
-              <li key={group.slug}>
-                <Link
-                  href={`/companies/${encodeURIComponent(group.slug)}`}
-                  className={styles.companyRow}
-                >
-                  <div className={styles.companyMain}>
-                    <h2 className={styles.companyName}>
-                      {group.displayName}
-                      {followupCount > 0 && (
-                        <span
-                          className={styles.followupBadge}
-                          aria-label={`${followupCount} 個人該 ping 了`}
-                        >
-                          ⏰ {followupCount}
-                        </span>
-                      )}
-                    </h2>
-                    <p className={styles.companyMeta}>
-                      {group.cards.length} 位 · 最近：{formatYmd(group.mostRecentTouch)}
-                    </p>
-                  </div>
-                  {head && (
-                    <div className={styles.headPreview}>
-                      <span className={styles.headName}>{cardName(head)}</span>
-                      {headRole && <span className={styles.headRole}>{headRole}</span>}
-                    </div>
-                  )}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
+        <CompanyList items={items} />
       )}
     </article>
   );

--- a/src/app/(app)/events/page.tsx
+++ b/src/app/(app)/events/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { EventList, type EventListItem } from "@/components/events/EventList";
 import { listCardsForUser } from "@/db/cards";
 import { groupCardsByEvent } from "@/lib/events/group";
 import { readSession } from "@/lib/firebase/session";
@@ -30,17 +31,23 @@ export default async function EventsPage() {
   const rawGroups = groupCardsByEvent(cards);
   const now = new Date();
 
-  // Decorate with follow-up count and hybrid-sort: groups that need
-  // attention come first (by count desc), the rest keep mostRecentMet
-  // ordering. Same pattern as /companies.
-  const groups = rawGroups
+  // Decorate, sort (urgency first then recency), and project to the
+  // serializable shape the client list component consumes.
+  const items: EventListItem[] = rawGroups
     .map((g) => ({ group: g, followupCount: countFollowupsInCards(g.cards, now) }))
     .sort((a, b) => {
       if (a.followupCount !== b.followupCount) return b.followupCount - a.followupCount;
       const aTouch = a.group.mostRecentMet?.getTime() ?? 0;
       const bTouch = b.group.mostRecentMet?.getTime() ?? 0;
       return bTouch - aTouch;
-    });
+    })
+    .map(({ group, followupCount }) => ({
+      slug: group.slug,
+      displayName: group.displayName,
+      count: group.cards.length,
+      mostRecentMetYmd: formatYmd(group.mostRecentMet),
+      followupCount,
+    }));
 
   return (
     <article className={styles.article}>
@@ -53,9 +60,9 @@ export default async function EventsPage() {
       <header className={styles.header}>
         <p className={styles.kicker}>場合視角</p>
         <h1 className={styles.title}>
-          <em>{groups.length}</em> 個場合
+          <em>{items.length}</em> 個場合
         </h1>
-        {groups.length > 0 ? (
+        {items.length > 0 ? (
           <p className={styles.lead}>
             該追蹤的場合排前面，其他按最近見面排序。點進去看那場見過誰、職位、為什麼記得。
           </p>
@@ -66,45 +73,14 @@ export default async function EventsPage() {
         )}
       </header>
 
-      {groups.length === 0 ? (
+      {items.length === 0 ? (
         <section className={styles.empty}>
           <Link href="/cards/new" className={styles.backLink}>
             建立第一張名片 →
           </Link>
         </section>
       ) : (
-        <ul className={styles.eventList}>
-          {groups.map(({ group, followupCount }) => {
-            return (
-              <li key={group.slug}>
-                <Link
-                  href={`/events/${encodeURIComponent(group.slug)}`}
-                  className={styles.eventRow}
-                >
-                  <div className={styles.eventMain}>
-                    <h2 className={styles.eventName}>
-                      {group.displayName}
-                      {followupCount > 0 && (
-                        <span
-                          className={styles.followupBadge}
-                          aria-label={`${followupCount} 個人該 ping 了`}
-                        >
-                          ⏰ {followupCount}
-                        </span>
-                      )}
-                    </h2>
-                    <p className={styles.eventMeta}>
-                      {group.cards.length} 位 · 最近見面：{formatYmd(group.mostRecentMet)}
-                    </p>
-                  </div>
-                  <span className={styles.chevron} aria-hidden="true">
-                    →
-                  </span>
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
+        <EventList items={items} />
       )}
     </article>
   );

--- a/src/components/companies/CompanyList.module.css
+++ b/src/components/companies/CompanyList.module.css
@@ -1,0 +1,122 @@
+.filterRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.filter {
+  flex: 1;
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  padding: var(--space-sm) var(--space-md);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+}
+
+.filter:focus {
+  outline: none;
+  border-color: var(--color-accent-ink);
+}
+
+.filterCount {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  white-space: nowrap;
+}
+
+.empty {
+  padding: var(--space-xl) var(--space-md);
+  text-align: center;
+  font-family: var(--font-sans);
+  color: var(--color-ink-muted);
+}
+
+.companyList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.companyRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.companyRow:hover {
+  border-color: var(--color-accent-ink);
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.companyMain {
+  flex: 1;
+  min-width: 0;
+}
+
+.companyName {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.followupBadge {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
+  background: var(--color-accent);
+  color: var(--color-paper);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+}
+
+.companyMeta {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0.2em 0 0;
+}
+
+.headPreview {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  text-align: right;
+  gap: 0.15em;
+  min-width: 0;
+}
+
+.headName {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink);
+  font-weight: 500;
+}
+
+.headRole {
+  font-family: var(--font-sans);
+  font-size: var(--text-micro, 0.72rem);
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-wide);
+}

--- a/src/components/companies/CompanyList.tsx
+++ b/src/components/companies/CompanyList.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import styles from "./CompanyList.module.css";
+
+export interface CompanyListItem {
+  slug: string;
+  displayName: string;
+  count: number;
+  /** Pre-formatted YMD or "—" — avoids Date serialization across RSC boundary. */
+  mostRecentTouchYmd: string;
+  headName?: string;
+  headRole?: string;
+  followupCount: number;
+}
+
+interface CompanyListProps {
+  items: CompanyListItem[];
+}
+
+export function CompanyList({ items }: CompanyListProps) {
+  const [q, setQ] = useState("");
+  const lower = q.trim().toLowerCase();
+  const filtered = lower ? items.filter((i) => i.displayName.toLowerCase().includes(lower)) : items;
+
+  return (
+    <>
+      <div className={styles.filterRow}>
+        <input
+          type="search"
+          className={styles.filter}
+          placeholder="搜尋公司…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          aria-label="搜尋公司"
+        />
+        {q && (
+          <span className={styles.filterCount}>
+            {filtered.length} / {items.length}
+          </span>
+        )}
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className={styles.empty}>沒有符合「{q}」的公司</p>
+      ) : (
+        <ul className={styles.companyList}>
+          {filtered.map((item) => (
+            <li key={item.slug}>
+              <Link
+                href={`/companies/${encodeURIComponent(item.slug)}`}
+                className={styles.companyRow}
+              >
+                <div className={styles.companyMain}>
+                  <h2 className={styles.companyName}>
+                    {item.displayName}
+                    {item.followupCount > 0 && (
+                      <span
+                        className={styles.followupBadge}
+                        aria-label={`${item.followupCount} 個人該 ping 了`}
+                      >
+                        ⏰ {item.followupCount}
+                      </span>
+                    )}
+                  </h2>
+                  <p className={styles.companyMeta}>
+                    {item.count} 位 · 最近：{item.mostRecentTouchYmd}
+                  </p>
+                </div>
+                {item.headName && (
+                  <div className={styles.headPreview}>
+                    <span className={styles.headName}>{item.headName}</span>
+                    {item.headRole && <span className={styles.headRole}>{item.headRole}</span>}
+                  </div>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/src/components/companies/__tests__/CompanyList.test.tsx
+++ b/src/components/companies/__tests__/CompanyList.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { CompanyList, type CompanyListItem } from "../CompanyList";
+
+const items: CompanyListItem[] = [
+  {
+    slug: "acme",
+    displayName: "Acme Inc",
+    count: 5,
+    mostRecentTouchYmd: "2026/04/27",
+    followupCount: 2,
+  },
+  {
+    slug: "beta",
+    displayName: "Beta Labs",
+    count: 3,
+    mostRecentTouchYmd: "2026/04/20",
+    followupCount: 0,
+  },
+  {
+    slug: "global-foo",
+    displayName: "Global Foo",
+    count: 1,
+    mostRecentTouchYmd: "—",
+    followupCount: 0,
+  },
+];
+
+describe("CompanyList filter", () => {
+  it("renders all items by default", () => {
+    render(<CompanyList items={items} />);
+    expect(screen.getByText("Acme Inc")).toBeInTheDocument();
+    expect(screen.getByText("Beta Labs")).toBeInTheDocument();
+    expect(screen.getByText("Global Foo")).toBeInTheDocument();
+  });
+
+  it("filters by case-insensitive substring", () => {
+    render(<CompanyList items={items} />);
+    fireEvent.change(screen.getByLabelText("搜尋公司"), { target: { value: "ACM" } });
+    expect(screen.getByText("Acme Inc")).toBeInTheDocument();
+    expect(screen.queryByText("Beta Labs")).toBeNull();
+    expect(screen.queryByText("Global Foo")).toBeNull();
+  });
+
+  it("shows '沒有符合' message when nothing matches", () => {
+    render(<CompanyList items={items} />);
+    fireEvent.change(screen.getByLabelText("搜尋公司"), { target: { value: "xyz" } });
+    expect(screen.getByText(/沒有符合「xyz」/)).toBeInTheDocument();
+  });
+
+  it("shows the filtered/total count when filter is active", () => {
+    render(<CompanyList items={items} />);
+    fireEvent.change(screen.getByLabelText("搜尋公司"), { target: { value: "a" } });
+    // 'Acme', 'Beta Labs', 'Global Foo' — the first two contain 'a' (case-insensitive)
+    expect(screen.getByText("3 / 3")).toBeInTheDocument();
+  });
+
+  it("renders ⏰ N badge only on rows with followupCount > 0", () => {
+    render(<CompanyList items={items} />);
+    expect(screen.getByLabelText("2 個人該 ping 了")).toBeInTheDocument();
+    // Only one badge in the list
+    expect(screen.getAllByLabelText(/個人該 ping 了/)).toHaveLength(1);
+  });
+
+  it("each row has a link to /companies/{slug}", () => {
+    render(<CompanyList items={items} />);
+    const link = screen.getByText("Acme Inc").closest("a");
+    expect(link?.getAttribute("href")).toBe("/companies/acme");
+  });
+});

--- a/src/components/events/EventList.module.css
+++ b/src/components/events/EventList.module.css
@@ -1,0 +1,105 @@
+.filterRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.filter {
+  flex: 1;
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  padding: var(--space-sm) var(--space-md);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+}
+
+.filter:focus {
+  outline: none;
+  border-color: var(--color-accent-ink);
+}
+
+.filterCount {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  white-space: nowrap;
+}
+
+.empty {
+  padding: var(--space-xl) var(--space-md);
+  text-align: center;
+  font-family: var(--font-sans);
+  color: var(--color-ink-muted);
+}
+
+.eventList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.eventRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.eventRow:hover {
+  border-color: var(--color-accent-ink);
+  background: var(--color-accent-soft, var(--color-paper));
+}
+
+.eventMain {
+  flex: 1;
+  min-width: 0;
+}
+
+.eventName {
+  font-family: var(--font-display);
+  font-size: var(--text-body);
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.followupBadge {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
+  background: var(--color-accent);
+  color: var(--color-paper);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+}
+
+.eventMeta {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  margin: 0.2em 0 0;
+}
+
+.chevron {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--color-ink-muted);
+}

--- a/src/components/events/EventList.tsx
+++ b/src/components/events/EventList.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import styles from "./EventList.module.css";
+
+export interface EventListItem {
+  slug: string;
+  displayName: string;
+  count: number;
+  /** Pre-formatted YMD or "—" — avoids Date serialization across RSC boundary. */
+  mostRecentMetYmd: string;
+  followupCount: number;
+}
+
+interface EventListProps {
+  items: EventListItem[];
+}
+
+export function EventList({ items }: EventListProps) {
+  const [q, setQ] = useState("");
+  const lower = q.trim().toLowerCase();
+  const filtered = lower ? items.filter((i) => i.displayName.toLowerCase().includes(lower)) : items;
+
+  return (
+    <>
+      <div className={styles.filterRow}>
+        <input
+          type="search"
+          className={styles.filter}
+          placeholder="搜尋場合…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          aria-label="搜尋場合"
+        />
+        {q && (
+          <span className={styles.filterCount}>
+            {filtered.length} / {items.length}
+          </span>
+        )}
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className={styles.empty}>沒有符合「{q}」的場合</p>
+      ) : (
+        <ul className={styles.eventList}>
+          {filtered.map((item) => (
+            <li key={item.slug}>
+              <Link href={`/events/${encodeURIComponent(item.slug)}`} className={styles.eventRow}>
+                <div className={styles.eventMain}>
+                  <h2 className={styles.eventName}>
+                    {item.displayName}
+                    {item.followupCount > 0 && (
+                      <span
+                        className={styles.followupBadge}
+                        aria-label={`${item.followupCount} 個人該 ping 了`}
+                      >
+                        ⏰ {item.followupCount}
+                      </span>
+                    )}
+                  </h2>
+                  <p className={styles.eventMeta}>
+                    {item.count} 位 · 最近見面：{item.mostRecentMetYmd}
+                  </p>
+                </div>
+                <span className={styles.chevron} aria-hidden="true">
+                  →
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds an instant text filter above /companies and /events lists. Two keystrokes to find "Acme" instead of scrolling.
- Server (page) does all the work — query, decorate with followupCount, sort by urgency-then-recency, project to a serializable shape. Client component owns just the filter state.
- Pre-formatted YMD string in the projection avoids Date reconstitution on the client.
- Native \`<input type="search">\` picks up the browser clear button for free.

Closes #200

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.45%; 6 new CompanyList tests
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`