### PR TITLE
feat(tags): client-side filter input on /tags list

### DIFF
--- a/src/app/(app)/tags/TagsClient.tsx
+++ b/src/app/(app)/tags/TagsClient.tsx
@@ -24,6 +24,13 @@ export function TagsClient({ tags }: TagsClientProps) {
   const [pending, startTransition] = useTransition();
   const [newTagName, setNewTagName] = useState("");
   const [newTagColor, setNewTagColor] = useState(DEFAULT_TAG_COLOR);
+  const [filter, setFilter] = useState("");
+
+  const filteredTags = (() => {
+    const lower = filter.trim().toLowerCase();
+    if (!lower) return tags;
+    return tags.filter((t) => t.name.toLowerCase().includes(lower));
+  })();
 
   function runWithRefresh(fn: () => Promise<void>) {
     startTransition(async () => {
@@ -47,11 +54,32 @@ export function TagsClient({ tags }: TagsClientProps) {
       {tags.length === 0 ? (
         <p className={styles.empty}>還沒有標籤。先新增一個吧。</p>
       ) : (
-        <ul className={styles.list}>
-          {tags.map((tag) => (
-            <TagRow key={tag.id} tag={tag} disabled={pending} onDone={() => router.refresh()} />
-          ))}
-        </ul>
+        <>
+          <div className={styles.filterRow}>
+            <input
+              type="search"
+              className={styles.filterInput}
+              placeholder="搜尋標籤…"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              aria-label="搜尋標籤"
+            />
+            {filter && (
+              <span className={styles.filterCount}>
+                {filteredTags.length} / {tags.length}
+              </span>
+            )}
+          </div>
+          {filteredTags.length === 0 ? (
+            <p className={styles.empty}>沒有符合「{filter}」的標籤</p>
+          ) : (
+            <ul className={styles.list}>
+              {filteredTags.map((tag) => (
+                <TagRow key={tag.id} tag={tag} disabled={pending} onDone={() => router.refresh()} />
+              ))}
+            </ul>
+          )}
+        </>
       )}
 
       <div className={styles.createRow}>

--- a/src/app/(app)/tags/__tests__/TagsClient.test.tsx
+++ b/src/app/(app)/tags/__tests__/TagsClient.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import type { TagSummary } from "@/db/tags";
+import { TagsClient } from "../TagsClient";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+vi.mock("../actions", () => ({
+  createTagAction: vi.fn(),
+  deleteTagAction: vi.fn(),
+  recolorTagAction: vi.fn(),
+  renameTagAction: vi.fn(),
+}));
+
+function tag(id: string, name: string): TagSummary {
+  return { id, name, color: "#888888", createdAt: null };
+}
+
+const tags: TagSummary[] = [
+  tag("t-acme", "ACME 客戶"),
+  tag("t-ces", "CES 2024"),
+  tag("t-comp", "COMPUTEX 2025"),
+  tag("t-vc", "VC 投資人"),
+];
+
+describe("TagsClient filter", () => {
+  it("renders all tags by default", () => {
+    render(<TagsClient tags={tags} />);
+    expect(screen.getByDisplayValue("ACME 客戶")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("CES 2024")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("COMPUTEX 2025")).toBeInTheDocument();
+  });
+
+  it("filters by case-insensitive substring on tag name", () => {
+    render(<TagsClient tags={tags} />);
+    fireEvent.change(screen.getByLabelText("搜尋標籤"), { target: { value: "ces" } });
+    expect(screen.getByDisplayValue("CES 2024")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("ACME 客戶")).toBeNull();
+    expect(screen.queryByDisplayValue("COMPUTEX 2025")).toBeNull();
+  });
+
+  it("shows '沒有符合' message when nothing matches", () => {
+    render(<TagsClient tags={tags} />);
+    fireEvent.change(screen.getByLabelText("搜尋標籤"), { target: { value: "xyz" } });
+    expect(screen.getByText(/沒有符合「xyz」/)).toBeInTheDocument();
+  });
+
+  it("displays filtered/total count when filter is active", () => {
+    render(<TagsClient tags={tags} />);
+    fireEvent.change(screen.getByLabelText("搜尋標籤"), { target: { value: "20" } });
+    // 'CES 2024' and 'COMPUTEX 2025' both contain '20'
+    expect(screen.getByText("2 / 4")).toBeInTheDocument();
+  });
+
+  it("does not render the filter row when there are no tags at all", () => {
+    render(<TagsClient tags={[]} />);
+    expect(screen.queryByLabelText("搜尋標籤")).toBeNull();
+    expect(screen.getByText(/還沒有標籤/)).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/tags/tags.module.css
+++ b/src/app/(app)/tags/tags.module.css
@@ -32,6 +32,36 @@
   font-weight: 500;
 }
 
+.filterRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.filterInput {
+  flex: 1;
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  padding: var(--space-sm) var(--space-md);
+  border: var(--border-hair) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+}
+
+.filterInput:focus {
+  outline: none;
+  border-color: var(--color-accent-ink);
+}
+
+.filterCount {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  color: var(--color-ink-muted);
+  white-space: nowrap;
+}
+
 .list {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
## Summary
- Adds an instant text filter above the existing /tags list — same UX PR #201 brought to /companies and /events.
- Filter is case-insensitive substring on \`tag.name\`. Local state, no router round-trip.
- Filter row hidden when there are no tags at all (empty-state UX preserved).

Closes #202

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.00% (above gate); 5 new TagsClient tests
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`