### PR TITLE
feat(mobile): MobileFab gets ⏰ 追蹤 action + numeric badge

### DIFF
--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -108,7 +108,7 @@ export function AppShell({ user, followupsTotal = 0, children }: AppShellProps) 
         </aside>
       </MobileNavWrapper>
       <main className={styles.main}>{children}</main>
-      <MobileFab />
+      <MobileFab followupsTotal={followupsTotal} />
       <GlobalShortcuts />
     </div>
   );

--- a/src/components/shell/MobileFab.module.css
+++ b/src/components/shell/MobileFab.module.css
@@ -85,6 +85,24 @@
     background var(--duration-fast) var(--ease-standard);
 }
 
+.fabBadge {
+  position: absolute;
+  top: -0.25rem;
+  right: -0.25rem;
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  background: var(--color-accent);
+  color: var(--color-paper);
+  padding: 0.2rem 0.4rem;
+  border-radius: 999px;
+  min-width: 1.25rem;
+  text-align: center;
+  border: 2px solid var(--color-ink);
+  box-sizing: content-box;
+}
+
 .fab:hover,
 .fab:focus-visible,
 .fabOpen:hover,

--- a/src/components/shell/MobileFab.tsx
+++ b/src/components/shell/MobileFab.tsx
@@ -12,13 +12,23 @@ import styles from "./MobileFab.module.css";
  */
 export const OPEN_SEARCH_EVENT = "namecard:openSearch";
 
+interface MobileFabProps {
+  /** Total pending follow-ups; if > 0, surfaces a 4th sheet action + count badge. */
+  followupsTotal?: number;
+}
+
 /**
  * Mobile-only floating action button. Defaults to a single ⊕ glyph in
  * the bottom-right; tap toggles a small action sheet with the three
- * highest-frequency captures (對話速記, 語音建卡, 找人). Backdrop click
- * + Esc both close. Hidden on ≥769px via media query in the .css module.
+ * highest-frequency captures (對話速記, 語音建卡, 找人). When pending
+ * follow-ups exist, a 4th 「⏰ 追蹤」 action appears in the sheet and
+ * a numeric badge overlays the closed FAB — same urgency cue as the
+ * desktop AppShell rail badge.
+ *
+ * Backdrop click + Esc both close. Hidden on ≥769px via media query
+ * in the .css module.
  */
-export function MobileFab() {
+export function MobileFab({ followupsTotal = 0 }: MobileFabProps) {
   const [open, setOpen] = useState(false);
   const sheetRef = useRef<HTMLDivElement | null>(null);
 
@@ -50,6 +60,16 @@ export function MobileFab() {
       )}
       {open && (
         <div ref={sheetRef} className={styles.sheet} role="menu" aria-label="快速動作">
+          {followupsTotal > 0 && (
+            <Link
+              href="/followups"
+              className={styles.action}
+              role="menuitem"
+              onClick={() => setOpen(false)}
+            >
+              ⏰ 追蹤 ({followupsTotal} 個)
+            </Link>
+          )}
           <Link
             href="/log"
             className={styles.action}
@@ -79,6 +99,11 @@ export function MobileFab() {
         aria-label={open ? "關閉快速動作" : "打開快速動作"}
       >
         {open ? "×" : "⊕"}
+        {!open && followupsTotal > 0 && (
+          <span className={styles.fabBadge} aria-label={`${followupsTotal} 個人該 ping 了`}>
+            {followupsTotal}
+          </span>
+        )}
       </button>
     </div>
   );

--- a/src/components/shell/__tests__/MobileFab.test.tsx
+++ b/src/components/shell/__tests__/MobileFab.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { MobileFab } from "../MobileFab";
+
+describe("MobileFab follow-up integration", () => {
+  it("renders the closed FAB with no badge by default", () => {
+    render(<MobileFab />);
+    expect(screen.getByLabelText("打開快速動作")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/個人該 ping 了/)).toBeNull();
+  });
+
+  it("renders the count badge on the closed FAB when followupsTotal > 0", () => {
+    render(<MobileFab followupsTotal={5} />);
+    const badge = screen.getByLabelText("5 個人該 ping 了");
+    expect(badge).toBeInTheDocument();
+    expect(badge.textContent).toBe("5");
+  });
+
+  it("hides the badge once the FAB is open (sheet shown instead)", () => {
+    render(<MobileFab followupsTotal={3} />);
+    fireEvent.click(screen.getByLabelText("打開快速動作"));
+    expect(screen.queryByLabelText("3 個人該 ping 了")).toBeNull();
+  });
+
+  it("includes ⏰ 追蹤 (N 個) sheet action when followupsTotal > 0", () => {
+    render(<MobileFab followupsTotal={4} />);
+    fireEvent.click(screen.getByLabelText("打開快速動作"));
+    const link = screen.getByText(/⏰ 追蹤 \(4 個\)/).closest("a");
+    expect(link?.getAttribute("href")).toBe("/followups");
+  });
+
+  it("does NOT include ⏰ 追蹤 in the sheet when followupsTotal is 0", () => {
+    render(<MobileFab followupsTotal={0} />);
+    fireEvent.click(screen.getByLabelText("打開快速動作"));
+    expect(screen.queryByText(/⏰ 追蹤/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- MobileFab accepts \`followupsTotal\` prop (plumbed through AppShell — already computed in the layout).
- When count > 0:
  - A small numeric badge overlays the closed ⊕ FAB
  - A 4th sheet action 「⏰ 追蹤 (N 個)」 links to /followups
- Mobile-equivalent of the desktop rail badge from PR #189.

Closes #204

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.01%; 5 new MobileFab tests
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`