### PR TITLE
feat(stats): 本月最常聊到的場合 — top events by conversation

### DIFF
--- a/src/app/(app)/stats/page.tsx
+++ b/src/app/(app)/stats/page.tsx
@@ -128,6 +128,26 @@ export default async function StatsPage() {
         </section>
       )}
 
+      {stats.topEvents.length > 0 && (
+        <section aria-label="本月最常聊到的場合" className={styles.statBlock}>
+          <h2 className={styles.blockTitle}>本月最常聊到的場合</h2>
+          <ol className={styles.topList}>
+            {stats.topEvents.map((e) => (
+              <li key={e.eventTag} className={styles.topItem}>
+                <Link href={`/events/${encodeURIComponent(e.eventTag)}`} className={styles.topName}>
+                  {e.eventTag}
+                </Link>
+                <span className={styles.topMeta}>
+                  <span className={styles.topCount}>
+                    {e.logCount} 次 · {e.distinctPeople} 人
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
+
       {stats.thisMonth.logCount === 0 && (
         <section className={styles.empty}>
           <p>

--- a/src/lib/stats/__tests__/aggregate.test.ts
+++ b/src/lib/stats/__tests__/aggregate.test.ts
@@ -67,6 +67,7 @@ describe("aggregateStats", () => {
     expect(out.streak).toEqual({ current: 0, longest: 0 });
     expect(out.topPeople).toEqual([]);
     expect(out.topCompanies).toEqual([]);
+    expect(out.topEvents).toEqual([]);
     expect(out.totalCards).toBe(0);
   });
 
@@ -239,5 +240,61 @@ describe("aggregateStats — topCompanies", () => {
     const out = aggregateStats([], events, NOW);
     expect(out.topCompanies).toHaveLength(3);
     expect(out.topCompanies.map((c) => c.companyName)).toEqual(["C1", "C2", "C3"]);
+  });
+});
+
+function evItemWithEvent(cardId: string, daysAgo: number, eventTag: string): RecapItem {
+  const event: ContactEvent = {
+    id: `e-${cardId}-${daysAgo}`,
+    at: dayOffset(NOW, daysAgo),
+    note: "n",
+    authorUid: "u",
+    authorDisplay: null,
+  };
+  return {
+    card: aCard({ id: cardId, nameZh: cardId, firstMetEventTag: eventTag }),
+    event,
+  };
+}
+
+describe("aggregateStats — topEvents", () => {
+  it("aggregates by firstMetEventTag with logCount + distinctPeople", () => {
+    const events = [
+      evItemWithEvent("a", 1, "CES 2024"),
+      evItemWithEvent("a", 2, "CES 2024"),
+      evItemWithEvent("b", 3, "CES 2024"),
+      evItemWithEvent("c", 5, "GitHub Universe"),
+    ];
+    const out = aggregateStats([], events, NOW);
+    expect(out.topEvents).toEqual([
+      { eventTag: "CES 2024", logCount: 3, distinctPeople: 2 },
+      { eventTag: "GitHub Universe", logCount: 1, distinctPeople: 1 },
+    ]);
+  });
+
+  it("excludes events whose card has no firstMetEventTag", () => {
+    const events = [evItem("noevent", 1), evItemWithEvent("withevent", 2, "CES 2024")];
+    const out = aggregateStats([], events, NOW);
+    expect(out.topEvents.map((e) => e.eventTag)).toEqual(["CES 2024"]);
+  });
+
+  it("excludes events outside the 30-day window", () => {
+    const events = [
+      evItemWithEvent("recent", 5, "CES 2024"),
+      evItemWithEvent("old", 60, "CES 2024"),
+    ];
+    const out = aggregateStats([], events, NOW);
+    expect(out.topEvents[0]).toEqual({ eventTag: "CES 2024", logCount: 1, distinctPeople: 1 });
+  });
+
+  it("caps at 3 events", () => {
+    const events = [
+      evItemWithEvent("a", 1, "C1"),
+      evItemWithEvent("a", 1, "C2"),
+      evItemWithEvent("a", 1, "C3"),
+      evItemWithEvent("a", 1, "C4"),
+    ];
+    const out = aggregateStats([], events, NOW);
+    expect(out.topEvents).toHaveLength(3);
   });
 });

--- a/src/lib/stats/__tests__/digest.test.ts
+++ b/src/lib/stats/__tests__/digest.test.ts
@@ -11,6 +11,7 @@ function emptyStats(over: Partial<AggregatedStats> = {}): AggregatedStats {
     streak: { current: 0, longest: 0 },
     topPeople: [],
     topCompanies: [],
+    topEvents: [],
     totalCards: 0,
     ...over,
   };

--- a/src/lib/stats/aggregate.ts
+++ b/src/lib/stats/aggregate.ts
@@ -25,6 +25,15 @@ export interface TopCompany {
   distinctPeople: number;
 }
 
+export interface TopEvent {
+  /** firstMetEventTag value as it appears on the card. */
+  eventTag: string;
+  /** Total log events with people first met at this event in the window. */
+  logCount: number;
+  /** Distinct people from this event logged with in the window. */
+  distinctPeople: number;
+}
+
 export interface Streak {
   /** Consecutive days back-to-back from today with ≥1 log. */
   current: number;
@@ -41,6 +50,8 @@ export interface AggregatedStats {
   topPeople: TopPerson[];
   /** Top 3 most-logged-with companies in last 30 days. */
   topCompanies: TopCompany[];
+  /** Top 3 events whose people we've talked to most in last 30 days. */
+  topEvents: TopEvent[];
   /** Total live (non-deleted) cards in the workspace. */
   totalCards: number;
 }
@@ -199,6 +210,43 @@ function computeTopCompanies(items: readonly RecapItem[], cutoff: Date, limit = 
   }));
 }
 
+function computeTopEvents(items: readonly RecapItem[], cutoff: Date, limit = 3): TopEvent[] {
+  const counts = new Map<
+    string,
+    { eventTag: string; logCount: number; people: Set<string>; lastAt: number }
+  >();
+  for (const item of items) {
+    if (!item.event.at || item.event.at.getTime() < cutoff.getTime()) continue;
+    const eventTag = (item.card.firstMetEventTag || "").trim();
+    if (!eventTag) continue; // skip events whose card has no firstMetEventTag
+    const cur = counts.get(eventTag);
+    if (cur) {
+      cur.logCount++;
+      cur.people.add(item.card.id);
+      cur.lastAt = Math.max(cur.lastAt, item.event.at.getTime());
+    } else {
+      counts.set(eventTag, {
+        eventTag,
+        logCount: 1,
+        people: new Set([item.card.id]),
+        lastAt: item.event.at.getTime(),
+      });
+    }
+  }
+  const list = [...counts.values()];
+  list.sort((a, b) => {
+    if (b.logCount !== a.logCount) return b.logCount - a.logCount;
+    if (b.people.size !== a.people.size) return b.people.size - a.people.size;
+    if (b.lastAt !== a.lastAt) return b.lastAt - a.lastAt;
+    return a.eventTag < b.eventTag ? -1 : 1;
+  });
+  return list.slice(0, limit).map((x) => ({
+    eventTag: x.eventTag,
+    logCount: x.logCount,
+    distinctPeople: x.people.size,
+  }));
+}
+
 function computeTopPeople(items: readonly RecapItem[], cutoff: Date, limit = 3): TopPerson[] {
   const counts = new Map<string, { card: CardSummary; logCount: number; lastAt: number }>();
   for (const item of items) {
@@ -245,6 +293,7 @@ export function aggregateStats(
     streak: computeStreak(events, now),
     topPeople: computeTopPeople(events, monthCutoff, 3),
     topCompanies: computeTopCompanies(events, monthCutoff, 3),
+    topEvents: computeTopEvents(events, monthCutoff, 3),
     totalCards: live.length,
   };
 }


### PR DESCRIPTION
## Summary
- New 「本月最常聊到的場合」 section on /stats — completes the trinity (people / companies / events) of engagement metrics.
- Aggregates last-30-day events by \`firstMetEventTag\` of the card → lead-source insight ("most of my recent conversations are with people first met at CES").
- New \`TopEvent\` type + \`computeTopEvents\` aggregator. Sort: logCount desc → distinctPeople desc → recency → tag.
- Each row links to /events/[tag].
- 4 new aggregator tests + digest.test.ts fixture update.
- Coverage went UP (80.01% → 80.05%) — tested aggregator code is the right shape.

Closes #206

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.05%
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`