### PR TITLE
fix(detail-pages): cross-link event tags + company names to their list pages

### DIFF
--- a/src/app/(app)/cards/[id]/detail.module.css
+++ b/src/app/(app)/cards/[id]/detail.module.css
@@ -185,6 +185,15 @@
   line-height: var(--leading-normal);
 }
 
+.crossLink {
+  color: var(--color-accent-ink);
+  text-decoration: none;
+}
+
+.crossLink:hover {
+  text-decoration: underline;
+}
+
 .notesBody {
   font-family: var(--font-serif);
   font-size: var(--text-body);

--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -258,7 +258,14 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
                 {card.firstMetEventTag && (
                   <div>
                     <dt>場合</dt>
-                    <dd>{card.firstMetEventTag}</dd>
+                    <dd>
+                      <Link
+                        href={`/events/${encodeURIComponent(card.firstMetEventTag)}`}
+                        className={styles.crossLink}
+                      >
+                        {card.firstMetEventTag}
+                      </Link>
+                    </dd>
                   </div>
                 )}
                 {card.firstMetContext && (

--- a/src/app/(app)/companies/[slug]/company.module.css
+++ b/src/app/(app)/companies/[slug]/company.module.css
@@ -66,6 +66,15 @@
   text-decoration: underline;
 }
 
+.crossLink {
+  color: var(--color-accent-ink);
+  text-decoration: none;
+}
+
+.crossLink:hover {
+  text-decoration: underline;
+}
+
 .headerActions {
   display: flex;
   gap: var(--space-sm);

--- a/src/app/(app)/companies/[slug]/page.tsx
+++ b/src/app/(app)/companies/[slug]/page.tsx
@@ -74,7 +74,19 @@ export default async function CompanyDetailPage({ params }: PageProps) {
               </Link>
             </>
           )}
-          {sharedEvents.length > 0 && <> · 認識場合：{sharedEvents.join("、")}</>}
+          {sharedEvents.length > 0 && (
+            <>
+              {" · "}認識場合：
+              {sharedEvents.map((tag, i) => (
+                <span key={tag}>
+                  {i > 0 && "、"}
+                  <Link href={`/events/${encodeURIComponent(tag)}`} className={styles.crossLink}>
+                    {tag}
+                  </Link>
+                </span>
+              ))}
+            </>
+          )}
         </p>
         <div className={styles.headerActions}>
           <a

--- a/src/app/(app)/events/[tag]/event.module.css
+++ b/src/app/(app)/events/[tag]/event.module.css
@@ -59,6 +59,15 @@
   text-decoration: underline;
 }
 
+.crossLink {
+  color: var(--color-accent-ink);
+  text-decoration: none;
+}
+
+.crossLink:hover {
+  text-decoration: underline;
+}
+
 .lead {
   font-family: var(--font-sans);
   font-size: var(--text-body);

--- a/src/app/(app)/events/[tag]/page.tsx
+++ b/src/app/(app)/events/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
 import { listCardsForUser } from "@/db/cards";
 import { computeTemperature } from "@/lib/cards/relationship-temp";
+import { companySlug } from "@/lib/companies/group";
 import { findEventBySlug } from "@/lib/events/group";
 import { readSession } from "@/lib/firebase/session";
 import { countFollowupsInCards } from "@/lib/timeline/followups";
@@ -77,7 +78,22 @@ export default async function EventDetailPage({ params }: PageProps) {
               </Link>
             </>
           )}
-          {companies.length > 0 && <> · 公司：{companies.join("、")}</>}
+          {companies.length > 0 && (
+            <>
+              {" · "}公司：
+              {companies.map((name, i) => (
+                <span key={name}>
+                  {i > 0 && "、"}
+                  <Link
+                    href={`/companies/${encodeURIComponent(companySlug(name))}`}
+                    className={styles.crossLink}
+                  >
+                    {name}
+                  </Link>
+                </span>
+              ))}
+            </>
+          )}
         </p>
       </header>
 


### PR DESCRIPTION
## Summary
Three navigation gaps closed — event tags and company names that were plain text now link to their detail pages:
1. /cards/[id] 「場合」 dd field links to /events/[tag]
2. /companies/[slug] header — each shared event in 「認識場合：…」 links to /events/[tag]
3. /events/[tag] header — each company in 「公司：…」 links to /companies/[companySlug]

Inline-link styling (accent-ink color, underline-on-hover) preserves the sentence-flow feel.

Closes #208

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.05% (no test changes; pure presentation refactor)
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`