### PR TITLE
feat(cards): 📍 只看重要 filter chip on /cards header

### DIFF
--- a/src/app/(app)/cards/page.tsx
+++ b/src/app/(app)/cards/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { CardsSelectionShell } from "@/components/cards/CardsSelectionShell";
 import { ExportButton } from "@/components/cards/ExportButton";
+import { PinnedFilterChip } from "@/components/cards/PinnedFilterChip";
 import { TagFilterBar } from "@/components/cards/TagFilterBar";
 import { TemperatureFilterBar } from "@/components/cards/TemperatureFilterBar";
 import { ViewToggle } from "@/components/cards/ViewToggle";
@@ -134,6 +135,15 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
     cards = filterByTemperature(cards, selectedTempLevels, now);
   }
 
+  // Pinned-only filter — composable with all other filters. URL: ?pinned=1.
+  const pinnedOnly = raw.pinned === "1";
+  if (pinnedOnly) {
+    cards = cards.filter((c) => c.isPinned);
+  }
+  // Total pinned count for the chip label, computed from the pre-pinned-
+  // filter universe so users can see how many they have to choose from.
+  const pinnedCount = allCards.filter((c) => c.isPinned).length;
+
   // Surface a duplicate-count nudge in the header. Computed over the
   // unfiltered list so the link is visible regardless of the current
   // search/tag state — the actual /cards/duplicates page also runs
@@ -211,6 +221,7 @@ export default async function CardsPage({ searchParams }: CardsPageProps) {
 
       <TagFilterBar tags={allTags} selectedIds={tag} tagMode={tagMode} />
       <TemperatureFilterBar counts={tempCounts} selected={selectedTempLevels} />
+      <PinnedFilterChip active={pinnedOnly} totalPinned={pinnedCount} />
 
       {cards.length === 0 ? (
         <div className={styles.empty}>

--- a/src/components/cards/PinnedFilterChip.module.css
+++ b/src/components/cards/PinnedFilterChip.module.css
@@ -1,0 +1,41 @@
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.chip,
+.chipActive {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  padding: var(--space-xs) var(--space-md);
+  border-radius: 999px;
+  border: var(--border-hair) solid var(--color-border);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.chip {
+  background: var(--color-paper);
+  color: var(--color-ink);
+}
+
+.chip:hover {
+  border-color: var(--color-accent-ink);
+}
+
+.chipActive {
+  background: var(--color-ink);
+  color: var(--color-paper);
+  border-color: var(--color-ink);
+  font-weight: 500;
+}
+
+.chipActive:hover {
+  background: var(--color-accent-ink);
+  border-color: var(--color-accent-ink);
+}

--- a/src/components/cards/PinnedFilterChip.tsx
+++ b/src/components/cards/PinnedFilterChip.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+
+import styles from "./PinnedFilterChip.module.css";
+
+interface PinnedFilterChipProps {
+  /** True when the page is currently filtering to pinned-only. */
+  active: boolean;
+  /** Total pinned cards in the workspace, shown in the chip label. */
+  totalPinned: number;
+}
+
+/**
+ * Toggle chip that adds/removes ?pinned=1 from the URL. Server reads
+ * the URL on the next render and applies the filter; this component
+ * only owns the URL mutation.
+ */
+export function PinnedFilterChip({ active, totalPinned }: PinnedFilterChipProps) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [pending, startTransition] = useTransition();
+
+  if (totalPinned === 0) return null;
+
+  const toggle = () => {
+    const next = new URLSearchParams(params.toString());
+    if (active) next.delete("pinned");
+    else next.set("pinned", "1");
+    startTransition(() => {
+      router.replace(next.toString() ? `?${next.toString()}` : "?", { scroll: false });
+    });
+  };
+
+  return (
+    <div className={styles.row}>
+      <button
+        type="button"
+        className={active ? styles.chipActive : styles.chip}
+        onClick={toggle}
+        disabled={pending}
+        aria-pressed={active}
+        title={active ? "顯示全部" : "只看重要聯絡人"}
+      >
+        📍 只看重要 ({totalPinned})
+      </button>
+    </div>
+  );
+}

--- a/src/components/cards/__tests__/PinnedFilterChip.test.tsx
+++ b/src/components/cards/__tests__/PinnedFilterChip.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { PinnedFilterChip } from "../PinnedFilterChip";
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams("tag=acme&temp=hot"),
+}));
+
+describe("PinnedFilterChip", () => {
+  it("renders nothing when totalPinned is 0", () => {
+    const { container } = render(<PinnedFilterChip active={false} totalPinned={0} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the chip with the count when totalPinned > 0", () => {
+    render(<PinnedFilterChip active={false} totalPinned={5} />);
+    expect(screen.getByRole("button", { name: /📍 只看重要 \(5\)/ })).toBeInTheDocument();
+  });
+
+  it("aria-pressed reflects active state", () => {
+    const { rerender } = render(<PinnedFilterChip active={false} totalPinned={3} />);
+    expect(screen.getByRole("button").getAttribute("aria-pressed")).toBe("false");
+    rerender(<PinnedFilterChip active={true} totalPinned={3} />);
+    expect(screen.getByRole("button").getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("clicking when inactive adds pinned=1 while preserving other params", () => {
+    replaceMock.mockClear();
+    render(<PinnedFilterChip active={false} totalPinned={2} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(replaceMock).toHaveBeenCalledTimes(1);
+    const url = replaceMock.mock.calls[0]![0] as string;
+    expect(url).toContain("pinned=1");
+    expect(url).toContain("tag=acme");
+    expect(url).toContain("temp=hot");
+  });
+
+  it("clicking when active removes pinned param", () => {
+    // Override the mock for this test only by re-rendering with active=true
+    // — the URL fixture above doesn't include `pinned`; the toggle still
+    // produces the right "removed" URL via active-state logic.
+    replaceMock.mockClear();
+    render(<PinnedFilterChip active={true} totalPinned={2} />);
+    fireEvent.click(screen.getByRole("button"));
+    const url = replaceMock.mock.calls[0]![0] as string;
+    expect(url).not.toContain("pinned");
+  });
+});


### PR DESCRIPTION
## Summary
- New 「📍 只看重要 (N)」 toggle pill on /cards filter row.
- URL state (\`?pinned=1\`) — shareable, refresh-safe, composes with existing tag/temp filters (AND).
- Chip count is from the unfiltered universe so users see total available, not post-filter subset.
- Hidden when there are zero pinned cards (no false affordance).

Closes #210

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.1% (up from 80.05%); 5 new PinnedFilterChip tests
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`