### PR TITLE
feat(cards): 「今天」 quick-chip in CardActions follow-up picker

### DIFF
--- a/src/components/cards/CardActions.tsx
+++ b/src/components/cards/CardActions.tsx
@@ -346,6 +346,14 @@ export function CardActions({
               <button
                 type="button"
                 className={styles.secondary}
+                onClick={() => submitFollowUp(localYmdAfterDays(0))}
+                disabled={pending}
+              >
+                今天
+              </button>
+              <button
+                type="button"
+                className={styles.secondary}
                 onClick={() => submitFollowUp(localYmdAfterDays(3))}
                 disabled={pending}
               >

--- a/src/components/cards/__tests__/CardActions.test.tsx
+++ b/src/components/cards/__tests__/CardActions.test.tsx
@@ -162,9 +162,24 @@ describe("CardActions quick CTA row", () => {
       expect(trigger).toHaveAttribute("aria-expanded", "false");
       fireEvent.click(trigger);
       expect(screen.getByLabelText(/下次聯絡日期/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "今天" })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /\+3 天/ })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /\+7 天/ })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /\+14 天/ })).toBeInTheDocument();
+    });
+
+    it("clicking 今天 fires setFollowUpAction with today's local YMD", async () => {
+      const { setFollowUpAction } = await import("@/app/(app)/cards/actions");
+      const { localYmdAfterDays } = await import("@/lib/cards/follow-up-date");
+      const mocked = vi.mocked(setFollowUpAction);
+      mocked.mockClear();
+      render(<CardActions cardId="abc" />);
+      fireEvent.click(screen.getByRole("button", { name: /設定下次聯絡/ }));
+      fireEvent.click(screen.getByRole("button", { name: "今天" }));
+      await vi.waitFor(() => {
+        expect(mocked).toHaveBeenCalledTimes(1);
+      });
+      expect(mocked.mock.calls[0]![0]!.followUpAt).toBe(localYmdAfterDays(0));
     });
 
     it("shows existing reminder date in the trigger label and offers 取消提醒", () => {


### PR DESCRIPTION
## Summary
- Adds 「今天」 chip to the CardActions follow-up picker (before +3 / +7 / +14).
- Click sets \`followUpAt = localYmdAfterDays(0)\` (today's local YMD), making the card surface under 今日提醒 immediately.
- 1 new unit test on the chip + setFollowUpAction wiring.

Closes #212

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.1%; +1 test
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`