### PR TITLE
feat(group-detail): 🔥/✨/💫/🌙/💤 temp distribution strip on /companies + /events

### DIFF
--- a/src/app/(app)/companies/[slug]/company.module.css
+++ b/src/app/(app)/companies/[slug]/company.module.css
@@ -75,6 +75,10 @@
   text-decoration: underline;
 }
 
+.tempStripRow {
+  margin: var(--space-xs) 0 0;
+}
+
 .headerActions {
   display: flex;
   gap: var(--space-sm);

--- a/src/app/(app)/companies/[slug]/page.tsx
+++ b/src/app/(app)/companies/[slug]/page.tsx
@@ -2,7 +2,9 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
+import { TemperatureMixStrip } from "@/components/cards/TemperatureMixStrip";
 import { listCardsForUser } from "@/db/cards";
+import { countByTemperature } from "@/lib/cards/filter";
 import { computeTemperature } from "@/lib/cards/relationship-temp";
 import { findCompanyBySlug } from "@/lib/companies/group";
 import { readSession } from "@/lib/firebase/session";
@@ -49,7 +51,9 @@ export default async function CompanyDetailPage({ params }: PageProps) {
   const sharedEvents = Array.from(
     new Set(group.cards.map((c) => c.firstMetEventTag).filter(Boolean) as string[]),
   );
-  const followupCount = countFollowupsInCards(group.cards, new Date());
+  const now = new Date();
+  const followupCount = countFollowupsInCards(group.cards, now);
+  const tempCounts = countByTemperature(group.cards, now);
 
   return (
     <article className={styles.article}>
@@ -87,6 +91,9 @@ export default async function CompanyDetailPage({ params }: PageProps) {
               ))}
             </>
           )}
+        </p>
+        <p className={styles.tempStripRow}>
+          <TemperatureMixStrip counts={tempCounts} />
         </p>
         <div className={styles.headerActions}>
           <a

--- a/src/app/(app)/events/[tag]/event.module.css
+++ b/src/app/(app)/events/[tag]/event.module.css
@@ -68,6 +68,10 @@
   text-decoration: underline;
 }
 
+.tempStripRow {
+  margin: var(--space-xs) 0 0;
+}
+
 .lead {
   font-family: var(--font-sans);
   font-size: var(--text-body);

--- a/src/app/(app)/events/[tag]/page.tsx
+++ b/src/app/(app)/events/[tag]/page.tsx
@@ -2,7 +2,9 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { TemperatureBadge } from "@/components/cards/TemperatureBadge";
+import { TemperatureMixStrip } from "@/components/cards/TemperatureMixStrip";
 import { listCardsForUser } from "@/db/cards";
+import { countByTemperature } from "@/lib/cards/filter";
 import { computeTemperature } from "@/lib/cards/relationship-temp";
 import { companySlug } from "@/lib/companies/group";
 import { findEventBySlug } from "@/lib/events/group";
@@ -53,7 +55,9 @@ export default async function EventDetailPage({ params }: PageProps) {
       group.cards.map((c) => c.companyZh || c.companyEn || "").filter((s) => s.trim().length > 0),
     ),
   );
-  const followupCount = countFollowupsInCards(group.cards, new Date());
+  const now = new Date();
+  const followupCount = countFollowupsInCards(group.cards, now);
+  const tempCounts = countByTemperature(group.cards, now);
 
   return (
     <article className={styles.article}>
@@ -94,6 +98,9 @@ export default async function EventDetailPage({ params }: PageProps) {
               ))}
             </>
           )}
+        </p>
+        <p className={styles.tempStripRow}>
+          <TemperatureMixStrip counts={tempCounts} />
         </p>
       </header>
 

--- a/src/components/cards/TemperatureMixStrip.module.css
+++ b/src/components/cards/TemperatureMixStrip.module.css
@@ -1,0 +1,15 @@
+.strip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-fg-muted);
+}
+
+.entry {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+}

--- a/src/components/cards/TemperatureMixStrip.tsx
+++ b/src/components/cards/TemperatureMixStrip.tsx
@@ -1,0 +1,48 @@
+import type { TemperatureLevel } from "@/lib/cards/relationship-temp";
+
+import styles from "./TemperatureMixStrip.module.css";
+
+interface TemperatureMixStripProps {
+  counts: Record<TemperatureLevel, number>;
+}
+
+const ORDER: readonly TemperatureLevel[] = ["hot", "warm", "active", "quiet", "cold"];
+
+const EMOJI: Record<TemperatureLevel, string> = {
+  hot: "🔥",
+  warm: "✨",
+  active: "💫",
+  quiet: "🌙",
+  cold: "💤",
+};
+
+const LABEL: Record<TemperatureLevel, string> = {
+  hot: "hot",
+  warm: "warm",
+  active: "active",
+  quiet: "quiet",
+  cold: "cold",
+};
+
+/**
+ * Inline distribution strip: "🔥 2 · ✨ 1 · 💤 2".
+ * Only renders levels with count > 0 — keeps the strip minimal.
+ * Used on /companies/[slug] and /events/[tag] headers to give a
+ * quick read of the relationship-state mix per group.
+ */
+export function TemperatureMixStrip({ counts }: TemperatureMixStripProps) {
+  const present = ORDER.filter((level) => counts[level] > 0);
+  if (present.length === 0) return null;
+  return (
+    <span className={styles.strip} aria-label="Temperature distribution">
+      {present.map((level, i) => (
+        <span key={level} className={styles.entry}>
+          {i > 0 && <span aria-hidden="true">·</span>}
+          <span title={LABEL[level]}>
+            {EMOJI[level]} {counts[level]}
+          </span>
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/src/components/cards/__tests__/TemperatureMixStrip.test.tsx
+++ b/src/components/cards/__tests__/TemperatureMixStrip.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { TemperatureMixStrip } from "../TemperatureMixStrip";
+
+describe("TemperatureMixStrip", () => {
+  it("renders nothing when all counts are 0", () => {
+    const { container } = render(
+      <TemperatureMixStrip counts={{ hot: 0, warm: 0, active: 0, quiet: 0, cold: 0 }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders only levels with count > 0, in canonical order", () => {
+    const { container } = render(
+      <TemperatureMixStrip counts={{ hot: 2, warm: 0, active: 1, quiet: 0, cold: 3 }} />,
+    );
+    const text = container.textContent ?? "";
+    // canonical order: hot → warm → active → quiet → cold
+    const hotIdx = text.indexOf("🔥 2");
+    const activeIdx = text.indexOf("💫 1");
+    const coldIdx = text.indexOf("💤 3");
+    expect(hotIdx).toBeGreaterThanOrEqual(0);
+    expect(activeIdx).toBeGreaterThan(hotIdx);
+    expect(coldIdx).toBeGreaterThan(activeIdx);
+    // skipped levels are absent
+    expect(text).not.toContain("✨"); // warm = 0
+    expect(text).not.toContain("🌙"); // quiet = 0
+  });
+
+  it("aria-label is descriptive for screen readers", () => {
+    render(<TemperatureMixStrip counts={{ hot: 1, warm: 0, active: 0, quiet: 0, cold: 0 }} />);
+    expect(screen.getByLabelText(/Temperature distribution/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- New \`TemperatureMixStrip\` component renders 「🔥 2 · ✨ 1 · 💤 2」 inline, only showing levels with count > 0.
- Wired into /companies/[slug] and /events/[tag] headers — uses existing \`countByTemperature\` helper, zero new compute.
- Tells business users at a glance whether a company/event relationship is healthy or going cold.

Closes #214

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.14% (up from 80.10%)
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`