### PR TITLE
feat(companies/events): page-level 「其中 N 家有人該追蹤」 sub-stat

### DIFF
--- a/src/app/(app)/companies/companies.module.css
+++ b/src/app/(app)/companies/companies.module.css
@@ -54,6 +54,14 @@
   color: var(--color-accent);
 }
 
+.subStat {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  font-weight: 400;
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-normal);
+}
+
 .lead {
   font-family: var(--font-sans);
   font-size: var(--text-body);

--- a/src/app/(app)/companies/page.tsx
+++ b/src/app/(app)/companies/page.tsx
@@ -71,6 +71,12 @@ export default async function CompaniesPage() {
         <p className={styles.kicker}>公司視角</p>
         <h1 className={styles.title}>
           <em>{items.length}</em> 家公司
+          {(() => {
+            const needing = items.filter((i) => i.followupCount > 0).length;
+            return needing > 0 ? (
+              <span className={styles.subStat}> · 其中 {needing} 家有人該追蹤</span>
+            ) : null;
+          })()}
         </h1>
         {items.length > 0 ? (
           <p className={styles.lead}>

--- a/src/app/(app)/events/events.module.css
+++ b/src/app/(app)/events/events.module.css
@@ -54,6 +54,14 @@
   color: var(--color-accent);
 }
 
+.subStat {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  font-weight: 400;
+  color: var(--color-ink-muted);
+  letter-spacing: var(--tracking-normal);
+}
+
 .lead {
   font-family: var(--font-sans);
   font-size: var(--text-body);

--- a/src/app/(app)/events/page.tsx
+++ b/src/app/(app)/events/page.tsx
@@ -61,6 +61,12 @@ export default async function EventsPage() {
         <p className={styles.kicker}>場合視角</p>
         <h1 className={styles.title}>
           <em>{items.length}</em> 個場合
+          {(() => {
+            const needing = items.filter((i) => i.followupCount > 0).length;
+            return needing > 0 ? (
+              <span className={styles.subStat}> · 其中 {needing} 個有人該追蹤</span>
+            ) : null;
+          })()}
         </h1>
         {items.length > 0 ? (
           <p className={styles.lead}>


### PR DESCRIPTION
## Summary
- /companies and /events titles now show a quiet sub-stat 「12 家公司 · 其中 3 家有人該追蹤」 when applicable.
- Page-level prioritization signal that complements the per-row badges (PR #191) and urgency-first sort (PR #193).
- Computed from the existing decorated items array — no new compute.

Closes #216

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.14% (stable)
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`