### PR TITLE
feat(home): celebratory headline when caught-up — '✨ 今天可以喘口氣'

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -41,8 +41,17 @@ export default async function HomePage() {
       <header className={styles.header}>
         <p className={styles.kicker}>今日</p>
         <h1 className={styles.title}>
-          {firstName ? `${firstName}，` : ""}
-          <em>今天</em>該問候誰？
+          {cards.length > 0 && followupsTotal === 0 ? (
+            <>
+              ✨ {firstName ? `${firstName}，` : ""}
+              <em>今天</em>可以喘口氣
+            </>
+          ) : (
+            <>
+              {firstName ? `${firstName}，` : ""}
+              <em>今天</em>該問候誰？
+            </>
+          )}
         </h1>
         <p className={styles.lead}>
           把「關係脈絡」放在第一位—— 這裡不是名片列表，是你的人脈節奏表。


### PR DESCRIPTION
## Summary
- Home headline now reflects the binary state of the user's day:
  - \`followupsTotal > 0\` → 「{firstName}，今天該問候誰？」 (prompting)
  - \`followupsTotal === 0\` (with cards present) → 「✨ {firstName}，今天可以喘口氣」 (celebratory)
- Empty-corpus / fresh install keeps the prompting variant (the celebratory cue would be hollow when there's literally nothing to be caught up on).

Closes #218

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.14% (stable; pure copy/conditional change)
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`