### PR TITLE
feat(shell): emoji-prefix every rail item — visual consistency

### DIFF
--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -22,19 +22,23 @@ interface NavGroup {
 
 // Grouped to avoid the dashboard-by-numbers anti-pattern (15+ items
 // flat). Order within groups goes most-frequent-first.
+//
+// Every item has a leading emoji for visual anchoring — partial emoji
+// coverage (some with, some without) is worse than uniform application.
+// Per UX audit §3.1.
 const NAV_GROUPS: NavGroup[] = [
   {
     label: "行動",
     items: [
-      { href: "/", label: "時間軸", description: "最近沒聯絡 · 本月認識" },
-      { href: "/followups", label: "追蹤", description: "誰該 ping 了" },
+      { href: "/", label: "📆 時間軸", description: "最近沒聯絡 · 本月認識" },
+      { href: "/followups", label: "⏰ 追蹤", description: "誰該 ping 了" },
       { href: "/intros", label: "🤝 介紹建議", description: "AI 找誰跟誰應該認識" },
     ],
   },
   {
     label: "捕捉",
     items: [
-      { href: "/cards/new", label: "新增", description: "手動建立一張" },
+      { href: "/cards/new", label: "✏️ 新增", description: "手動建立一張" },
       { href: "/cards/scan", label: "📷 拍照建檔", description: "拍紙本名片 OCR 自動填" },
       { href: "/cards/voice", label: "🎙️ 語音建卡", description: "講 30 秒讓 AI 解析" },
       { href: "/log", label: "🗣️ 對話速記", description: "講一句 log 進對方的卡" },
@@ -43,20 +47,20 @@ const NAV_GROUPS: NavGroup[] = [
   {
     label: "回顧",
     items: [
-      { href: "/cards", label: "名片冊", description: "畫廊 · 清單" },
+      { href: "/cards", label: "📇 名片冊", description: "畫廊 · 清單" },
       { href: "/recap", label: "📓 對話日誌", description: "最近 14 天 log 過的對話" },
-      { href: "/prep", label: "📅 會議準備", description: "貼上出席者，10 秒拿到 context" },
+      { href: "/prep", label: "🗓️ 會議準備", description: "貼上出席者，10 秒拿到 context" },
       { href: "/stats", label: "📊 儀表板", description: "本週對話、新人脈、溫度、streak" },
-      { href: "/companies", label: "公司", description: "同公司聯絡人聚合" },
-      { href: "/events", label: "場合", description: "同場合認識的人" },
-      { href: "/tags", label: "標籤", description: "分類 · 重新命名" },
+      { href: "/companies", label: "🏢 公司", description: "同公司聯絡人聚合" },
+      { href: "/events", label: "🎟️ 場合", description: "同場合認識的人" },
+      { href: "/tags", label: "🏷️ 標籤", description: "分類 · 重新命名" },
     ],
   },
   {
     label: "設定",
     items: [
-      { href: "/import", label: "匯入", description: "vCard / CSV / LinkedIn" },
-      { href: "/workspace/members", label: "成員", description: "邀請 · 權限" },
+      { href: "/import", label: "📥 匯入", description: "vCard / CSV / LinkedIn" },
+      { href: "/workspace/members", label: "👥 成員", description: "邀請 · 權限" },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
Closes UX audit §3.1: 7 of 16 rail items had emoji prefixes, 9 didn't. Partial coverage looks like an unfinished design pass. Establishes one rule: every rail item gets a leading emoji, picked for visual distinctness at the caption size.

Closes #220 (covered §3.1)

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.16% (stable; existing tests use partial-match)
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`