### PR TITLE
feat(card-detail): 「💬 互動 N 次」 badge in header

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -174,10 +174,18 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
                     : temp.daysSince === 0
                       ? "今天聯絡過"
                       : `上次互動 ${temp.daysSince} 天前`;
+                // contactEvents loaded with limit=30; show "30+" when capped.
+                const eventCountLabel =
+                  contactEvents.length === 0
+                    ? null
+                    : contactEvents.length >= 30
+                      ? "💬 互動 30+ 次"
+                      : `💬 互動 ${contactEvents.length} 次`;
                 return (
                   <span className={styles.kickerMeta}>
                     <TemperatureBadge temperature={temp} />
                     <span className={styles.lastSeen}>{lastSeen}</span>
+                    {eventCountLabel && <span className={styles.lastSeen}>{eventCountLabel}</span>}
                   </span>
                 );
               })()}


### PR DESCRIPTION
## Summary
- New 「💬 互動 N 次」 chip in /cards/[id] header next to TemperatureBadge + 上次互動.
- Depth-of-tie indicator at a glance — recently noticed this gap when thinking about what 'context awareness' the detail page lacks.
- Reuses the \`contactEvents\` array already fetched (limit=30) — no new query cost.
- Shows "30+" when the limit caps; hidden when count===0.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.16% (stable; pure presentation)
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`