### PR TITLE
feat(card-detail): surface most-recent contact note inline near header

### DIFF
--- a/src/app/(app)/cards/[id]/__tests__/truncateNote.test.ts
+++ b/src/app/(app)/cards/[id]/__tests__/truncateNote.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+// Re-import the local helper via dynamic import. Currently it's a private
+// function inside page.tsx — copy here as a small mirror so we can lock
+// the truncation rules without exporting it from a Server Component file.
+function truncateNote(note: string, max: number): string {
+  if (note.length <= max) return note;
+  const slice = note.slice(0, max);
+  const lastSpace = slice.lastIndexOf(" ");
+  const cut = lastSpace > max * 0.6 ? lastSpace : max;
+  return `${slice.slice(0, cut).trimEnd()}…`;
+}
+
+describe("truncateNote", () => {
+  it("returns the original when within max length", () => {
+    expect(truncateNote("short", 100)).toBe("short");
+    expect(truncateNote("a".repeat(100), 100)).toBe("a".repeat(100));
+  });
+
+  it("truncates at the nearest space when one is past the 60% boundary", () => {
+    const note = "we agreed to revisit the proposal next quarter once funding clears";
+    const result = truncateNote(note, 30);
+    expect(result.endsWith("…")).toBe(true);
+    expect(result.length).toBeLessThan(35);
+    // Doesn't bisect a word — last char before … is end-of-word
+    const last = result.slice(0, -1).trim();
+    expect(last.endsWith("we") || last.endsWith("to") || /[a-z]$/.test(last)).toBe(true);
+  });
+
+  it("hard-cuts at max when no good space found in the high range", () => {
+    // Long word with no spaces past the 60% boundary
+    const note = "supercalifragilisticexpialidocious";
+    const result = truncateNote(note, 10);
+    expect(result).toBe("supercalif…");
+  });
+
+  it("trims trailing whitespace before the ellipsis", () => {
+    const note = "hello world   foo";
+    const result = truncateNote(note, 8);
+    expect(result.endsWith("…")).toBe(true);
+    expect(result).not.toContain(" …");
+  });
+});

--- a/src/app/(app)/cards/[id]/detail.module.css
+++ b/src/app/(app)/cards/[id]/detail.module.css
@@ -194,6 +194,16 @@
   text-decoration: underline;
 }
 
+.recentNote {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-body);
+  color: var(--color-fg-muted);
+  margin: var(--space-xs) 0 0;
+  line-height: var(--leading-snug);
+  max-width: 56ch;
+}
+
 .notesBody {
   font-family: var(--font-serif);
   font-size: var(--text-body);

--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -34,6 +34,19 @@ interface DetailPageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
+/**
+ * Truncate a contact-event note for inline display in the header.
+ * Cuts at the nearest space ≤ max so we don't bisect a word, then
+ * appends an ellipsis. Returns the original string when already short.
+ */
+function truncateNote(note: string, max: number): string {
+  if (note.length <= max) return note;
+  const slice = note.slice(0, max);
+  const lastSpace = slice.lastIndexOf(" ");
+  const cut = lastSpace > max * 0.6 ? lastSpace : max;
+  return `${slice.slice(0, cut).trimEnd()}…`;
+}
+
 export async function generateMetadata({ params }: DetailPageProps) {
   const { id } = await params;
   const user = await readSession();
@@ -190,6 +203,12 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
                 );
               })()}
             </div>
+            {contactEvents[0]?.note?.trim() && (
+              <p className={styles.recentNote} title="最近一次的對話速記">
+                <span aria-hidden="true">📓 </span>
+                {truncateNote(contactEvents[0].note.trim(), 100)}
+              </p>
+            )}
             <h1 className={styles.name}>
               <CardInlineEdit
                 cardId={card.id}


### PR DESCRIPTION
## Summary
- Continues PR #225 (互動 N 次): depth-of-tie metric is good, but the actual most-recent note was buried in ContactEventList at the bottom of the page.
- Now renders as a 1-line italic blockquote inline near the header — instant context without scrolling.
- Truncated at 100 chars to the nearest space (≥ 60% boundary keeps tails clean).
- Hidden when no note exists or note is whitespace-only (newly-added cards, or events from the inline ✅ 已聯絡 path which sends "").
- Italic serif matches the existing `.why` (whyRemember) styling — both are "voice memos from past me".

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.16% (stable); 4 new truncateNote tests
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`