### PR TITLE
feat(cards): 「📆 加到 Google Calendar」 deep-link when followUpAt set

### DIFF
--- a/src/components/cards/CardActions.module.css
+++ b/src/components/cards/CardActions.module.css
@@ -120,6 +120,20 @@
   color: var(--color-fg);
 }
 
+.gcalLink {
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  text-align: center;
+  padding: var(--space-xs) var(--space-md);
+  color: var(--color-accent-ink);
+  text-decoration: none;
+}
+
+.gcalLink:hover {
+  text-decoration: underline;
+}
+
 .destructive {
   color: var(--color-fg-muted);
   border-color: var(--color-border);

--- a/src/components/cards/CardActions.tsx
+++ b/src/components/cards/CardActions.tsx
@@ -12,6 +12,7 @@ import {
   toggleCardPinAction,
 } from "@/app/(app)/cards/actions";
 import { localYmdAfterDays } from "@/lib/cards/follow-up-date";
+import { googleCalendarEventUrl } from "@/lib/calendar/gcal-url";
 import { shareCardVcard } from "@/lib/share/card-share";
 
 import styles from "./CardActions.module.css";
@@ -332,6 +333,20 @@ export function CardActions({
         >
           {followUpAt ? `📅 下次聯絡：${followUpAt}` : "📅 設定下次聯絡"}
         </button>
+        {followUpAt && (
+          <a
+            className={styles.gcalLink}
+            href={googleCalendarEventUrl({
+              title: `跟 ${displayName ?? "聯絡人"} ping 一下`,
+              dateYmd: followUpAt,
+            })}
+            target="_blank"
+            rel="noopener noreferrer"
+            title="把這個提醒加到 Google Calendar"
+          >
+            📆 加到 Google Calendar →
+          </a>
+        )}
         {followUpOpen && (
           <div className={styles.noteBox}>
             <input

--- a/src/lib/calendar/__tests__/gcal-url.test.ts
+++ b/src/lib/calendar/__tests__/gcal-url.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { googleCalendarEventUrl } from "../gcal-url";
+
+describe("googleCalendarEventUrl", () => {
+  it("encodes title + dates for an all-day event", () => {
+    const url = googleCalendarEventUrl({
+      title: "跟陳玉涵 ping 一下",
+      dateYmd: "2026-05-01",
+    });
+    expect(url).toContain("calendar.google.com/calendar/render");
+    expect(url).toContain("action=TEMPLATE");
+    expect(url).toContain("dates=20260501%2F20260502"); // start / end (exclusive)
+    // Chinese characters URL-encoded in title
+    expect(url).toMatch(/text=%E8%B7%9F.*ping/);
+  });
+
+  it("includes details when provided", () => {
+    const url = googleCalendarEventUrl({
+      title: "test",
+      dateYmd: "2026-05-01",
+      details: "上次談到 Q3 計畫",
+    });
+    expect(url).toContain("details=");
+    expect(url).toMatch(/details=.*Q3/);
+  });
+
+  it("omits details when not provided", () => {
+    const url = googleCalendarEventUrl({
+      title: "test",
+      dateYmd: "2026-05-01",
+    });
+    expect(url).not.toContain("details=");
+  });
+
+  it("crosses month boundary for end date", () => {
+    const url = googleCalendarEventUrl({
+      title: "test",
+      dateYmd: "2026-04-30",
+    });
+    expect(url).toContain("dates=20260430%2F20260501");
+  });
+
+  it("crosses year boundary for end date", () => {
+    const url = googleCalendarEventUrl({
+      title: "test",
+      dateYmd: "2026-12-31",
+    });
+    expect(url).toContain("dates=20261231%2F20270101");
+  });
+
+  it("handles malformed input gracefully (returns same compact string for both)", () => {
+    // Defensive: garbage in, garbage-but-not-crash out.
+    const url = googleCalendarEventUrl({
+      title: "test",
+      dateYmd: "garbage",
+    });
+    expect(url).toContain("dates=garbage%2Fgarbage");
+  });
+});

--- a/src/lib/calendar/gcal-url.ts
+++ b/src/lib/calendar/gcal-url.ts
@@ -1,0 +1,44 @@
+/**
+ * Build a Google Calendar event-edit URL that opens with a pre-filled
+ * all-day event on `dateYmd` (YYYY-MM-DD).
+ *
+ * Google Calendar's `dates` param format is `YYYYMMDD/YYYYMMDD` for an
+ * all-day event, where the end date is EXCLUSIVE (so a one-day event
+ * uses start = the day, end = next day).
+ *
+ * Cross-platform: Google Calendar URL works in any browser. iOS Safari
+ * users see a "Open in Calendar app" prompt that imports it as an iCal
+ * event — gives us coverage without per-platform branching.
+ */
+export function googleCalendarEventUrl(opts: {
+  title: string;
+  dateYmd: string; // YYYY-MM-DD
+  details?: string;
+}): string {
+  const start = opts.dateYmd.replace(/-/g, "");
+  const end = nextDayCompact(opts.dateYmd);
+  const params = new URLSearchParams({
+    action: "TEMPLATE",
+    text: opts.title,
+    dates: `${start}/${end}`,
+  });
+  if (opts.details) params.set("details", opts.details);
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}
+
+/**
+ * Add 1 day to a YYYY-MM-DD string and return YYYYMMDD (compact, no
+ * dashes — Google Calendar's dates param shape).
+ */
+function nextDayCompact(ymd: string): string {
+  const m = ymd.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return ymd.replace(/-/g, "");
+  const [, y, mo, d] = m;
+  // Use UTC arithmetic so timezone doesn't shift the day-after.
+  const start = new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d)));
+  start.setUTCDate(start.getUTCDate() + 1);
+  const yy = start.getUTCFullYear();
+  const mm = String(start.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(start.getUTCDate()).padStart(2, "0");
+  return `${yy}${mm}${dd}`;
+}


### PR DESCRIPTION
## Summary
- New \`googleCalendarEventUrl()\` lib in \`@/lib/calendar/gcal-url\` builds Google Calendar event-create URL with all-day date.
- Renders as a plain-text link 「📆 加到 Google Calendar →」 in CardActions when \`followUpAt\` is set.
- Cross-platform: same URL works in any browser; iOS Safari prompts "Open in Calendar app" and imports as iCal — covers both ecosystems with one URL.
- 6 unit tests on the URL builder.

Closes #227

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.2% (up from 80.16%)
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`
- [ ] Verify on Mac mini: set followUpAt, click 「📆 加到 Google Calendar」 → opens GCal with the right title + date