### PR TITLE
feat(cards): 「🔗 LinkedIn 搜尋」 deep-link on card detail

### DIFF
--- a/src/app/(app)/cards/[id]/detail.module.css
+++ b/src/app/(app)/cards/[id]/detail.module.css
@@ -204,6 +204,20 @@
   max-width: 56ch;
 }
 
+.linkedinSearch {
+  display: inline-block;
+  margin-top: var(--space-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-accent-ink);
+  text-decoration: none;
+}
+
+.linkedinSearch:hover {
+  text-decoration: underline;
+}
+
 .notesBody {
   font-family: var(--font-serif);
   font-size: var(--text-body);

--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -24,6 +24,7 @@ import type { CardCreateInput } from "@/db/schema";
 import { isCoachConfigured } from "@/lib/coach/llm";
 import { companySlug, pickCanonicalCompany } from "@/lib/companies/group";
 import { computeTemperature } from "@/lib/cards/relationship-temp";
+import { linkedInSearchUrl } from "@/lib/share/linkedin-search";
 import { findAnniversariesToday } from "@/lib/timeline/anniversaries";
 import { readSession } from "@/lib/firebase/session";
 
@@ -370,6 +371,28 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
                 </li>
               )}
             </ul>
+            {(() => {
+              // Surface a LinkedIn-search shortcut only when no explicit
+              // linkedinUrl is already saved — otherwise the existing
+              // 「打開連結」 above is the better path.
+              if (card.social?.linkedinUrl) return null;
+              const url = linkedInSearchUrl({
+                name: card.nameZh || card.nameEn,
+                company: card.companyZh || card.companyEn,
+              });
+              if (!url) return null;
+              return (
+                <a
+                  className={styles.linkedinSearch}
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title="在 LinkedIn 找這個人"
+                >
+                  🔗 LinkedIn 搜尋 →
+                </a>
+              );
+            })()}
           </section>
 
           <CardActions

--- a/src/lib/share/__tests__/linkedin-search.test.ts
+++ b/src/lib/share/__tests__/linkedin-search.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { linkedInSearchUrl } from "../linkedin-search";
+
+describe("linkedInSearchUrl", () => {
+  it("combines name and company into the keywords param", () => {
+    const url = linkedInSearchUrl({ name: "陳玉涵", company: "Acme Inc" });
+    expect(url).toContain("linkedin.com/search/results/people/");
+    expect(url).toContain("keywords=");
+    expect(decodeURIComponent(url!).replace(/\+/g, " ")).toContain("陳玉涵 Acme Inc");
+  });
+
+  it("works with only name", () => {
+    const url = linkedInSearchUrl({ name: "John Doe" });
+    expect(url).not.toBeNull();
+    expect(decodeURIComponent(url!).replace(/\+/g, " ")).toContain("John Doe");
+    expect(url).not.toContain("undefined");
+  });
+
+  it("works with only company (rare but possible)", () => {
+    const url = linkedInSearchUrl({ company: "Acme" });
+    expect(url).not.toBeNull();
+    expect(decodeURIComponent(url!).replace(/\+/g, " ")).toContain("Acme");
+  });
+
+  it("returns null when both fields are empty", () => {
+    expect(linkedInSearchUrl({})).toBeNull();
+    expect(linkedInSearchUrl({ name: "", company: "" })).toBeNull();
+    expect(linkedInSearchUrl({ name: "   ", company: "  " })).toBeNull();
+  });
+
+  it("trims whitespace from inputs", () => {
+    const url = linkedInSearchUrl({ name: "  John  ", company: "  Acme  " });
+    expect(decodeURIComponent(url!).replace(/\+/g, " ")).toContain("John Acme");
+    // No double-space from preserving raw whitespace
+    expect(decodeURIComponent(url!).replace(/\+/g, " ")).not.toContain("  ");
+  });
+});

--- a/src/lib/share/linkedin-search.ts
+++ b/src/lib/share/linkedin-search.ts
@@ -1,0 +1,19 @@
+/**
+ * Build a LinkedIn people-search URL pre-filled with the contact's
+ * name + company. Returns null when neither field has content (no
+ * usable search query).
+ *
+ * LinkedIn URL: https://www.linkedin.com/search/results/people/?keywords={...}
+ * Both Chinese and Latin names work — LinkedIn's search handles
+ * either. Combining name + company narrows the result set
+ * dramatically vs. name alone for common names like "陳玉涵".
+ */
+export function linkedInSearchUrl(opts: { name?: string; company?: string }): string | null {
+  const parts: string[] = [];
+  if (opts.name?.trim()) parts.push(opts.name.trim());
+  if (opts.company?.trim()) parts.push(opts.company.trim());
+  if (parts.length === 0) return null;
+  const keywords = parts.join(" ");
+  const params = new URLSearchParams({ keywords });
+  return `https://www.linkedin.com/search/results/people/?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary
- New \`linkedInSearchUrl()\` lib in \`@/lib/share/linkedin-search\` builds LinkedIn people-search URL pre-filled with name + company.
- Renders as a small 「🔗 LinkedIn 搜尋 →」 link in /cards/[id] sidebar contactBlock.
- Conditional: only shown when no explicit \`linkedinUrl\` is already saved (otherwise the existing 「打開連結」 row is the better path).
- Continuing external-bridges thread from PR #228 (gcal).
- 5 unit tests on the URL builder.

Closes #229

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — branches 80.26% (up from 80.20%)
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`