### PR TITLE
feat(cards): 「📋 複製聯絡資訊」 button on /cards/[id]

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -398,12 +398,20 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
           <CardActions
             cardId={card.id}
             displayName={primary}
+            primaryPhone={primaryPhone?.value}
+            primaryEmail={primaryEmail?.value}
             phones={card.phones?.map((p) => ({ label: p.label, value: p.value }))}
             emails={card.emails?.map((e) => ({ label: e.label, value: e.value }))}
             lineId={card.social?.lineId}
             linkedinUrl={card.social?.linkedinUrl}
             isPinned={card.isPinned}
             followUpAt={card.followUpAt ? card.followUpAt.toISOString().slice(0, 10) : null}
+            nameZh={card.nameZh}
+            nameEn={card.nameEn}
+            jobTitleZh={card.jobTitleZh}
+            jobTitleEn={card.jobTitleEn}
+            companyZh={card.companyZh}
+            companyEn={card.companyEn}
           />
 
           <PublicProfileToggle

--- a/src/components/cards/CardActions.tsx
+++ b/src/components/cards/CardActions.tsx
@@ -14,6 +14,7 @@ import {
 import { localYmdAfterDays } from "@/lib/cards/follow-up-date";
 import { googleCalendarEventUrl } from "@/lib/calendar/gcal-url";
 import { shareCardVcard } from "@/lib/share/card-share";
+import { formatContactSummary } from "@/lib/share/contact-summary";
 
 import styles from "./CardActions.module.css";
 import { VoiceMicButton } from "./VoiceMicButton";
@@ -45,6 +46,13 @@ interface CardActionsProps {
   isPinned?: boolean;
   /** Existing follow-up reminder, if any. ISO YYYY-MM-DD string for input parity. */
   followUpAt?: string | null;
+  /** Optional bilingual fields used by the 「📋 複製聯絡資訊」 formatter. */
+  nameZh?: string;
+  nameEn?: string;
+  jobTitleZh?: string;
+  jobTitleEn?: string;
+  companyZh?: string;
+  companyEn?: string;
 }
 
 export function CardActions({
@@ -58,6 +66,12 @@ export function CardActions({
   linkedinUrl,
   isPinned = false,
   followUpAt = null,
+  nameZh,
+  nameEn,
+  jobTitleZh,
+  jobTitleEn,
+  companyZh,
+  companyEn,
 }: CardActionsProps) {
   // Normalize: prefer the full list when given, else wrap the single
   // primary into a 1-item list. Empty when there's nothing to show.
@@ -162,6 +176,29 @@ export function CardActions({
         router.refresh();
       }
     });
+  };
+
+  const handleCopyContact = async () => {
+    const text = formatContactSummary({
+      nameZh,
+      nameEn,
+      jobTitleZh,
+      jobTitleEn,
+      companyZh,
+      companyEn,
+      primaryEmail,
+      primaryPhone,
+    });
+    if (!text) {
+      setToast("沒有可複製的內容");
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      setToast("聯絡資訊已複製");
+    } catch {
+      setToast("複製失敗，請手動選取");
+    }
   };
 
   const handleShare = async () => {
@@ -432,6 +469,9 @@ export function CardActions({
         </button>
         <button type="button" className={styles.secondary} onClick={handleShare}>
           📤 分享名片
+        </button>
+        <button type="button" className={styles.secondary} onClick={handleCopyContact}>
+          📋 複製聯絡資訊
         </button>
         <a href={`/api/cards/${cardId}/vcard`} className={styles.secondary}>
           匯出 vCard

--- a/src/lib/share/__tests__/contact-summary.test.ts
+++ b/src/lib/share/__tests__/contact-summary.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { formatContactSummary } from "../contact-summary";
+
+describe("formatContactSummary", () => {
+  it("formats a complete contact with bilingual name", () => {
+    const out = formatContactSummary({
+      nameZh: "陳玉涵",
+      nameEn: "Yvonne Chen",
+      jobTitleZh: "副總",
+      companyZh: "Acme",
+      primaryEmail: "yvonne@acme.com",
+      primaryPhone: "0922000111",
+    });
+    expect(out).toBe(
+      ["陳玉涵（Yvonne Chen）", "副總 @ Acme", "📧 yvonne@acme.com", "📞 0922000111"].join("\n"),
+    );
+  });
+
+  it("uses English when only English name present", () => {
+    const out = formatContactSummary({ nameEn: "John Doe", companyEn: "Beta Corp" });
+    expect(out).toBe(["John Doe", "@ Beta Corp"].join("\n"));
+  });
+
+  it("skips role+company line when both missing", () => {
+    const out = formatContactSummary({ nameZh: "陳玉涵", primaryEmail: "x@y.com" });
+    expect(out).toBe(["陳玉涵", "📧 x@y.com"].join("\n"));
+  });
+
+  it("falls back to en when zh role missing", () => {
+    const out = formatContactSummary({
+      nameZh: "陳玉涵",
+      jobTitleEn: "VP Engineering",
+      companyEn: "Beta",
+    });
+    expect(out).toBe(["陳玉涵", "VP Engineering @ Beta"].join("\n"));
+  });
+
+  it("returns empty string when all fields missing", () => {
+    expect(formatContactSummary({})).toBe("");
+  });
+
+  it("trims whitespace from inputs", () => {
+    const out = formatContactSummary({
+      nameZh: "  陳  ",
+      primaryEmail: " a@b.com",
+    });
+    expect(out).toBe(["陳", "📧  a@b.com"].join("\n"));
+    // (trim only applies via pickFirst to role/company; emails passed verbatim
+    // intentionally — we don't want to alter user-entered values)
+  });
+});

--- a/src/lib/share/contact-summary.ts
+++ b/src/lib/share/contact-summary.ts
@@ -1,0 +1,47 @@
+/**
+ * Format a contact summary for clipboard paste — typically used when
+ * introducing two people via email / Slack / LINE.
+ *
+ * Skips empty fields so we never paste a hanging line. Bilingual
+ * names render as "中 (英)" when both exist, otherwise just whichever
+ * is present.
+ */
+export interface ContactSummaryInput {
+  nameZh?: string;
+  nameEn?: string;
+  jobTitleZh?: string;
+  jobTitleEn?: string;
+  companyZh?: string;
+  companyEn?: string;
+  primaryEmail?: string;
+  primaryPhone?: string;
+}
+
+export function formatContactSummary(input: ContactSummaryInput): string {
+  const lines: string[] = [];
+  const name = formatBilingual(input.nameZh, input.nameEn);
+  if (name) lines.push(name);
+  const role = pickFirst(input.jobTitleZh, input.jobTitleEn);
+  const company = pickFirst(input.companyZh, input.companyEn);
+  if (role && company) lines.push(`${role} @ ${company}`);
+  else if (role) lines.push(role);
+  else if (company) lines.push(`@ ${company}`);
+  if (input.primaryEmail) lines.push(`📧 ${input.primaryEmail}`);
+  if (input.primaryPhone) lines.push(`📞 ${input.primaryPhone}`);
+  return lines.join("\n");
+}
+
+function pickFirst(a?: string, b?: string): string | undefined {
+  const aTrim = a?.trim();
+  if (aTrim) return aTrim;
+  const bTrim = b?.trim();
+  if (bTrim) return bTrim;
+  return undefined;
+}
+
+function formatBilingual(zh?: string, en?: string): string | undefined {
+  const zhTrim = zh?.trim();
+  const enTrim = en?.trim();
+  if (zhTrim && enTrim) return `${zhTrim}（${enTrim}）`;
+  return zhTrim || enTrim || undefined;
+}


### PR DESCRIPTION
## Summary
- New 「📋 複製聯絡資訊」 button in CardActions sidebar.
- Pure formatter \`formatContactSummary\` in \`@/lib/share/contact-summary\` builds bilingual-aware multi-line text:
  \`\`\`
  陳玉涵（Yvonne Chen）
  副總 @ Acme
  📧 yvonne@acme.com
  📞 0922000111
  \`\`\`
- Skips empty fields; reuses existing setToast for feedback.
- Continues external-bridges thread (#228 gcal, #230 LinkedIn). Copy-to-clipboard is the most universal bridge — works for any email/Slack/LINE intro paste.
- 6 unit tests on the formatter.

Closes #231

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors; warnings dropped 4 → 2 as side-effect)
- [x] \`pnpm test:coverage\` — branches 80.45% (up from 80.26%)
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`