### PR TITLE
fix(login): iOS Safari signInWithRedirect + 15s watchdog

### DIFF
--- a/src/app/(auth)/login/LoginForm.tsx
+++ b/src/app/(auth)/login/LoginForm.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { FirebaseError } from "firebase/app";
-import { signInWithPopup } from "firebase/auth";
+import { getRedirectResult, signInWithPopup, signInWithRedirect } from "firebase/auth";
 import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 
 import { getClientAuth, googleAuthProvider } from "@/lib/firebase/client";
 
@@ -14,11 +14,26 @@ interface LoginFormProps {
   next?: string;
 }
 
+/**
+ * iOS Safari (and most in-app browsers) silently break signInWithPopup —
+ * popup gets blocked, opens but never resolves the credential, or the
+ * 3rd-party-cookie story breaks. Detect those and fall back to the
+ * redirect-based flow.
+ *
+ * Conservative — when uncertain we'd rather take the redirect path
+ * than let the user stare at a hung popup (issue #233).
+ */
+function shouldUseRedirect(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
 type ErrorKind =
   | null
   | { kind: "popup-blocked" }
   | { kind: "popup-closed" }
   | { kind: "not-allowed" }
+  | { kind: "timeout" }
   | { kind: "unknown"; message: string };
 
 function describeError(error: ErrorKind): string | null {
@@ -30,22 +45,118 @@ function describeError(error: ErrorKind): string | null {
       return "你關閉了登入視窗。再試一次。";
     case "not-allowed":
       return "此 Google 帳號不在 ALLOWED_EMAILS 白名單內。";
+    case "timeout":
+      return "登入超過 15 秒沒有回應。試試清掉 cookie 或開無痕視窗，或按 F12 看 console 有什麼紅字。";
     case "unknown":
       return error.message;
   }
 }
 
+/**
+ * 15 s — long enough for slow popup + Firebase verify + workspace
+ * bootstrap; short enough that a wedged action surfaces feedback
+ * before the user gives up.
+ */
+export const SIGNIN_TIMEOUT_MS = 15_000;
+
 export function LoginForm({ next }: LoginFormProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<ErrorKind>(null);
+  // Watchdog: if the transition doesn't resolve in 15 s, surface a
+  // visible timeout error. Without this the button just sits on
+  // 「驗證中…」 forever — the symptom user reported in #233.
+  const [timedOut, setTimedOut] = useState(false);
+  const watchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the watchdog whenever pending flips back to false (success
+  // OR caught-error path — both setError(...) calls above end the
+  // transition naturally).
+  useEffect(() => {
+    if (!pending && watchdogRef.current) {
+      clearTimeout(watchdogRef.current);
+      watchdogRef.current = null;
+    }
+  }, [pending]);
+
+  const finalizeSignIn = (idToken: string) => {
+    setError(null);
+    setTimedOut(false);
+    if (watchdogRef.current) clearTimeout(watchdogRef.current);
+    watchdogRef.current = setTimeout(() => {
+      setTimedOut(true);
+      setError({ kind: "timeout" });
+    }, SIGNIN_TIMEOUT_MS);
+    startTransition(async () => {
+      const result = await signInWithIdTokenAction({ idToken, next });
+      if (result?.serverError) {
+        setError(
+          result.serverError.includes("ALLOWED_EMAILS")
+            ? { kind: "not-allowed" }
+            : { kind: "unknown", message: result.serverError },
+        );
+        return;
+      }
+      const target = result?.data?.next ?? "/";
+      router.push(target);
+      router.refresh();
+    });
+  };
+
+  // After a redirect-based sign-in (iOS Safari path), Google bounces
+  // the user back here. getRedirectResult returns the credential; we
+  // exchange it for a session cookie via the same server action.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const auth = getClientAuth();
+        const credential = await getRedirectResult(auth);
+        if (cancelled || !credential) return;
+        const idToken = await credential.user.getIdToken(true);
+        finalizeSignIn(idToken);
+      } catch (err) {
+        if (cancelled) return;
+        setError({
+          kind: "unknown",
+          message: err instanceof Error ? err.message : "未知錯誤",
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // mount-only — getRedirectResult is one-shot per page load
 
   const handleSignIn = () => {
     setError(null);
+    setTimedOut(false);
+    const auth = getClientAuth();
+    const provider = googleAuthProvider();
+
+    if (shouldUseRedirect()) {
+      // signInWithRedirect navigates away — the result comes back via
+      // the useEffect above on the next page load. Don't start a
+      // transition here; pending will flip true after redirect.
+      signInWithRedirect(auth, provider).catch((err) => {
+        setError({
+          kind: "unknown",
+          message: err instanceof Error ? err.message : "redirect failed",
+        });
+      });
+      return;
+    }
+
+    // Desktop / non-iOS: popup is faster, no page reload.
+    if (watchdogRef.current) clearTimeout(watchdogRef.current);
+    watchdogRef.current = setTimeout(() => {
+      setTimedOut(true);
+      setError({ kind: "timeout" });
+    }, SIGNIN_TIMEOUT_MS);
     startTransition(async () => {
       try {
-        const auth = getClientAuth();
-        const credential = await signInWithPopup(auth, googleAuthProvider());
+        const credential = await signInWithPopup(auth, provider);
         const idToken = await credential.user.getIdToken(true);
         const result = await signInWithIdTokenAction({ idToken, next });
         if (result?.serverError) {
@@ -74,11 +185,15 @@ export function LoginForm({ next }: LoginFormProps) {
     });
   };
 
+  // Button label: timed-out trumps pending so the user sees something
+  // actionable; without timeout we fall back to the original two states.
+  const buttonLabel = timedOut ? "請重新整理頁面再試" : pending ? "驗證中…" : "以 Google 帳號登入";
+
   return (
     <div className={styles.formWrap}>
       <button type="button" className={styles.button} onClick={handleSignIn} disabled={pending}>
         <GoogleG />
-        <span>{pending ? "驗證中…" : "以 Google 帳號登入"}</span>
+        <span>{buttonLabel}</span>
       </button>
       {error && (
         <p role="alert" className={styles.error}>

--- a/src/app/(auth)/login/__tests__/LoginForm.timeout.test.tsx
+++ b/src/app/(auth)/login/__tests__/LoginForm.timeout.test.tsx
@@ -6,16 +6,22 @@ import { LoginForm, SIGNIN_TIMEOUT_MS } from "../LoginForm";
 
 // Stub away all the auth surface so we can drive the LoginForm flow
 // in isolation. Each test re-mocks signInWithPopup as needed.
-const signInWithPopupMock = vi.fn();
-const signInWithIdTokenActionMock = vi.fn();
-
-const signInWithRedirectMock = vi.fn(() => Promise.resolve());
-const getRedirectResultMock = vi.fn(() => Promise.resolve(null));
+const {
+  signInWithPopupMock,
+  signInWithIdTokenActionMock,
+  signInWithRedirectMock,
+  getRedirectResultMock,
+} = vi.hoisted(() => ({
+  signInWithPopupMock: vi.fn(),
+  signInWithIdTokenActionMock: vi.fn(),
+  signInWithRedirectMock: vi.fn(),
+  getRedirectResultMock: vi.fn(),
+}));
 
 vi.mock("firebase/auth", () => ({
-  signInWithPopup: (...args: unknown[]) => signInWithPopupMock(...args),
-  signInWithRedirect: (...args: unknown[]) => signInWithRedirectMock(...args),
-  getRedirectResult: (...args: unknown[]) => getRedirectResultMock(...args),
+  signInWithPopup: signInWithPopupMock,
+  signInWithRedirect: signInWithRedirectMock,
+  getRedirectResult: getRedirectResultMock,
   GoogleAuthProvider: vi.fn(),
 }));
 vi.mock("@/lib/firebase/client", () => ({
@@ -23,7 +29,7 @@ vi.mock("@/lib/firebase/client", () => ({
   googleAuthProvider: vi.fn(() => ({})),
 }));
 vi.mock("../actions", () => ({
-  signInWithIdTokenAction: (...args: unknown[]) => signInWithIdTokenActionMock(...args),
+  signInWithIdTokenAction: signInWithIdTokenActionMock,
 }));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),

--- a/src/app/(auth)/login/__tests__/LoginForm.timeout.test.tsx
+++ b/src/app/(auth)/login/__tests__/LoginForm.timeout.test.tsx
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import { FirebaseError } from "firebase/app";
+
+import { LoginForm, SIGNIN_TIMEOUT_MS } from "../LoginForm";
+
+// Stub away all the auth surface so we can drive the LoginForm flow
+// in isolation. Each test re-mocks signInWithPopup as needed.
+const signInWithPopupMock = vi.fn();
+const signInWithIdTokenActionMock = vi.fn();
+
+const signInWithRedirectMock = vi.fn(() => Promise.resolve());
+const getRedirectResultMock = vi.fn(() => Promise.resolve(null));
+
+vi.mock("firebase/auth", () => ({
+  signInWithPopup: (...args: unknown[]) => signInWithPopupMock(...args),
+  signInWithRedirect: (...args: unknown[]) => signInWithRedirectMock(...args),
+  getRedirectResult: (...args: unknown[]) => getRedirectResultMock(...args),
+  GoogleAuthProvider: vi.fn(),
+}));
+vi.mock("@/lib/firebase/client", () => ({
+  getClientAuth: vi.fn(() => ({})),
+  googleAuthProvider: vi.fn(() => ({})),
+}));
+vi.mock("../actions", () => ({
+  signInWithIdTokenAction: (...args: unknown[]) => signInWithIdTokenActionMock(...args),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+describe("LoginForm watchdog timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    signInWithPopupMock.mockReset();
+    signInWithIdTokenActionMock.mockReset();
+    // Default: hang forever so timeout tests deterministically reach the deadline
+    signInWithPopupMock.mockImplementation(() => new Promise(() => {}));
+    signInWithIdTokenActionMock.mockImplementation(() => new Promise(() => {}));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not show timeout error before the deadline", async () => {
+    render(<LoginForm />);
+    await act(async () => {
+      screen.getByRole("button").click();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(SIGNIN_TIMEOUT_MS - 100);
+    });
+    expect(screen.queryByText(/登入超過 15 秒/)).toBeNull();
+  });
+
+  it("shows the timeout error after SIGNIN_TIMEOUT_MS elapses", async () => {
+    render(<LoginForm />);
+    await act(async () => {
+      screen.getByRole("button").click();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(SIGNIN_TIMEOUT_MS);
+    });
+    expect(screen.getByText(/登入超過 15 秒/)).toBeInTheDocument();
+    expect(screen.getByText(/請重新整理頁面再試/)).toBeInTheDocument();
+  });
+});
+
+describe("LoginForm error paths", () => {
+  beforeEach(() => {
+    signInWithPopupMock.mockReset();
+    signInWithIdTokenActionMock.mockReset();
+  });
+
+  it("shows the popup-blocked message when Firebase throws auth/popup-blocked", async () => {
+    signInWithPopupMock.mockRejectedValue(new FirebaseError("auth/popup-blocked", "popup blocked"));
+    render(<LoginForm />);
+    await act(async () => {
+      screen.getByRole("button").click();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/封鎖了彈出視窗/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows the popup-closed message when user dismisses the popup", async () => {
+    signInWithPopupMock.mockRejectedValue(new FirebaseError("auth/popup-closed-by-user", "closed"));
+    render(<LoginForm />);
+    await act(async () => {
+      screen.getByRole("button").click();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/關閉了登入視窗/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows the not-allowed message when server rejects ALLOWED_EMAILS", async () => {
+    signInWithPopupMock.mockResolvedValue({
+      user: { getIdToken: vi.fn().mockResolvedValue("fake-token") },
+    });
+    signInWithIdTokenActionMock.mockResolvedValue({
+      serverError: "Email x@y.com is not in ALLOWED_EMAILS whitelist",
+    });
+    render(<LoginForm />);
+    await act(async () => {
+      screen.getByRole("button").click();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/ALLOWED_EMAILS 白名單內/)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("LoginForm iOS redirect path", () => {
+  beforeEach(() => {
+    signInWithPopupMock.mockReset();
+    signInWithIdTokenActionMock.mockReset();
+    signInWithRedirectMock.mockReset();
+    signInWithRedirectMock.mockResolvedValue(undefined);
+    getRedirectResultMock.mockReset();
+    getRedirectResultMock.mockResolvedValue(null);
+    // Force the iOS branch
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      get: () => "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)",
+    });
+  });
+  afterEach(() => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      get: () => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    });
+  });
+
+  it("uses signInWithRedirect on iOS instead of popup", async () => {
+    render(<LoginForm />);
+    await act(async () => {
+      screen.getByRole("button").click();
+    });
+    await waitFor(() => {
+      expect(signInWithRedirectMock).toHaveBeenCalledTimes(1);
+    });
+    expect(signInWithPopupMock).not.toHaveBeenCalled();
+  });
+
+  it("calls finalizeSignIn when getRedirectResult returns a credential on mount", async () => {
+    signInWithIdTokenActionMock.mockResolvedValue({ data: { ok: true, next: "/" } });
+    getRedirectResultMock.mockResolvedValue({
+      user: { getIdToken: vi.fn().mockResolvedValue("redirect-token") },
+    });
+    render(<LoginForm />);
+    await waitFor(() => {
+      expect(signInWithIdTokenActionMock).toHaveBeenCalledTimes(1);
+    });
+    expect(signInWithIdTokenActionMock.mock.calls[0]![0].idToken).toBe("redirect-token");
+  });
+
+  it("surfaces an error when signInWithRedirect itself rejects", async () => {
+    signInWithRedirectMock.mockRejectedValueOnce(new Error("redirect blocked"));
+    render(<LoginForm />);
+    await act(async () => {
+      screen.getByRole("button").click();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/redirect blocked/)).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces an error when getRedirectResult on mount throws", async () => {
+    getRedirectResultMock.mockRejectedValueOnce(new Error("invalid auth state"));
+    render(<LoginForm />);
+    await waitFor(() => {
+      expect(screen.getByText(/invalid auth state/)).toBeInTheDocument();
+    });
+  });
+
+  it("does not call signInWithIdTokenAction when getRedirectResult returns null", async () => {
+    getRedirectResultMock.mockResolvedValue(null);
+    render(<LoginForm />);
+    // Give the useEffect a microtask to settle
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(signInWithIdTokenActionMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
**Critical user-facing fix.** User reported "無法登入，一直停在驗證中" on iPhone Safari. Two-pronged fix:

1. **iOS Safari uses signInWithRedirect** — popup is the known-broken combination on iOS (third-party cookies, cross-frame messaging). Firebase docs explicitly recommend redirect for iOS. Page navigates to Google → comes back → \`getRedirectResult\` on mount completes flow.
2. **15s watchdog** — popup-flow timeout surfaces a visible error + recovery hint instead of leaving the user staring at 「驗證中…」.

Closes #233

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\` (0 errors)
- [x] \`pnpm test:coverage\` — 10 new tests, branches 80.01%
- [x] \`NAMECARD_BASE_PATH=/namecard-web pnpm build\`
- [ ] **User to verify**: iPhone Safari can complete sign-in via redirect

## Urgency
User is currently blocked on login. Will merge + deploy as soon as CI is green.