### PR TITLE
fix(fab): add 📷 拍照建檔 entry to MobileFab action sheet

### DIFF
--- a/src/components/shell/MobileFab.tsx
+++ b/src/components/shell/MobileFab.tsx
@@ -19,10 +19,10 @@ interface MobileFabProps {
 
 /**
  * Mobile-only floating action button. Defaults to a single ⊕ glyph in
- * the bottom-right; tap toggles a small action sheet with the three
- * highest-frequency captures (對話速記, 語音建卡, 找人). When pending
- * follow-ups exist, a 4th 「⏰ 追蹤」 action appears in the sheet and
- * a numeric badge overlays the closed FAB — same urgency cue as the
+ * the bottom-right; tap toggles a small action sheet with the four
+ * highest-frequency captures (對話速記, 語音建卡, 拍照建檔, 找人). When
+ * pending follow-ups exist, a 5th 「⏰ 追蹤」 action appears in the sheet
+ * and a numeric badge overlays the closed FAB — same urgency cue as the
  * desktop AppShell rail badge.
  *
  * Backdrop click + Esc both close. Hidden on ≥769px via media query
@@ -85,6 +85,14 @@ export function MobileFab({ followupsTotal = 0 }: MobileFabProps) {
             onClick={() => setOpen(false)}
           >
             🎙️ 語音建卡
+          </Link>
+          <Link
+            href="/cards/scan"
+            className={styles.action}
+            role="menuitem"
+            onClick={() => setOpen(false)}
+          >
+            📷 拍照建檔
           </Link>
           <button type="button" className={styles.action} role="menuitem" onClick={handleSearch}>
             🔍 找人

--- a/src/components/shell/__tests__/MobileFab.test.tsx
+++ b/src/components/shell/__tests__/MobileFab.test.tsx
@@ -35,4 +35,11 @@ describe("MobileFab follow-up integration", () => {
     fireEvent.click(screen.getByLabelText("打開快速動作"));
     expect(screen.queryByText(/⏰ 追蹤/)).toBeNull();
   });
+
+  it("includes 📷 拍照建檔 sheet action linking to /cards/scan", () => {
+    render(<MobileFab />);
+    fireEvent.click(screen.getByLabelText("打開快速動作"));
+    const link = screen.getByText(/📷 拍照建檔/).closest("a");
+    expect(link?.getAttribute("href")).toBe("/cards/scan");
+  });
 });


### PR DESCRIPTION
## Summary

- **User report:** 右下方的+沒有照相建檔的選項 — users couldn't reach `/cards/scan` from the mobile FAB bottom-right + button
- Added `📷 拍照建檔` Link to `/cards/scan` as the 4th fixed action in the `MobileFab` sheet, positioned after `🎙️ 語音建卡` (same capture-mode grouping)
- Added 1 unit test asserting the link is present and href is `/cards/scan`

## Context

- `/cards/scan` was made discoverable on desktop (rail) and home (quickActions) via #220
- The mobile FAB was deliberately deferred in #220 pending the broader spike #221 (FAB IA strategy)
- The concrete user report makes this a P0 gap — adding 1 action (4 fixed total) is within the safe space of the current sheet layout on 375pt iPhone

## Test plan

- [x] `pnpm test src/components/shell/__tests__/MobileFab.test.tsx` — 6/6 pass (5 existing + 1 new)
- [x] `eslint src/components/shell/MobileFab.tsx src/components/shell/__tests__/MobileFab.test.tsx` — clean
- [x] Pre-existing typecheck/lint failures in `ScanFlow.tsx` confirmed unrelated (different in-flight session, present before this branch)

Closes #236