### PR TITLE
fix(scan): MiniMax timeout error kind + escalating progress feedback

### DIFF
--- a/src/components/scan/OcrRescanPanel.tsx
+++ b/src/components/scan/OcrRescanPanel.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 
 import { updateCardAction } from "@/app/(app)/cards/actions";
 import { scanCardAction } from "@/app/(app)/cards/scan/actions";
@@ -164,7 +164,7 @@ export function OcrRescanPanel({ cardId, current }: OcrRescanPanelProps) {
             height={200}
             unoptimized
           />
-          <p className={styles.uploading}>解析中…</p>
+          <OcrRescanProgressHint />
         </div>
       )}
 
@@ -299,6 +299,32 @@ function fieldPreviewRow(label: string, value: string | undefined) {
 
 function phaseWithPreview(phase: Extract<Phase, { kind: "review" }>): string {
   return phase.previewUrl;
+}
+
+/**
+ * Escalating hint for OcrRescanPanel's uploading state.
+ * Mirrors the logic in ScanFlow's OcrProgressHint.
+ */
+function OcrRescanProgressHint() {
+  const [elapsed, setElapsed] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      setElapsed((prev) => prev + 1);
+    }, 1000);
+    return () => {
+      if (intervalRef.current !== null) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  if (elapsed < 8) {
+    return <p className={styles.uploading}>解析中…通常 3-6 秒。</p>;
+  }
+  if (elapsed < 18) {
+    return <p className={styles.uploading}>還在解析中，稍候…</p>;
+  }
+  return <p className={styles.uploading}>快好了，最長等到 30 秒。</p>;
 }
 
 async function blobToBase64(file: File): Promise<string> {

--- a/src/components/scan/ScanFlow.tsx
+++ b/src/components/scan/ScanFlow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 
 import { createCardAction } from "@/app/(app)/cards/actions";
 import { scanCardAction } from "@/app/(app)/cards/scan/actions";
@@ -128,7 +128,7 @@ export function ScanFlow() {
         <ImagePane url={phase.previewUrl} />
         <div className={styles.pane}>
           <div className={styles.statusPill}>辨識中…</div>
-          <p className={styles.statusHint}>MiniMax 正在讀這張卡。通常 3-6 秒。</p>
+          <OcrProgressHint />
         </div>
       </div>
     );
@@ -213,10 +213,46 @@ function ImagePane({ url }: { url: string }) {
   );
 }
 
-function formatOcrError(err: { kind: string; message: string; retryAfterMs?: number }): string {
+/**
+ * Shows an escalating hint while MiniMax OCR is running.
+ *
+ * Phases: initial (0-8s) → slow (8-18s) → very slow (18s+).
+ * All thresholds are comfortably under the 30s server-side AbortController
+ * timeout, so the user always sees a final message before the error appears.
+ */
+function OcrProgressHint() {
+  const [elapsed, setElapsed] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      setElapsed((prev) => prev + 1);
+    }, 1000);
+    return () => {
+      if (intervalRef.current !== null) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  if (elapsed < 8) {
+    return <p className={styles.statusHint}>MiniMax 正在讀這張卡。通常 3-6 秒。</p>;
+  }
+  if (elapsed < 18) {
+    return <p className={styles.statusHint}>還在辨識中，MiniMax 有時比較慢，請稍候…</p>;
+  }
+  return <p className={styles.statusHint}>快好了，最長等到 30 秒後會告知結果。</p>;
+}
+
+function formatOcrError(err: {
+  kind: string;
+  message: string;
+  retryAfterMs?: number;
+  timeoutMs?: number;
+}): string {
   switch (err.kind) {
     case "rate-limit":
       return `API 流量限制，請 ${Math.ceil((err.retryAfterMs ?? 5000) / 1000)} 秒後再試`;
+    case "timeout":
+      return `辨識逾時（${Math.round((err.timeoutMs ?? 30000) / 1000)} 秒）。MiniMax 目前較慢，請稍後再試，或改手動輸入。`;
     case "network":
       return `網路錯誤：${err.message}`;
     case "invalid-response":

--- a/src/lib/ocr/__tests__/minimax.test.ts
+++ b/src/lib/ocr/__tests__/minimax.test.ts
@@ -173,6 +173,38 @@ describe("minimax provider", () => {
     expect(result.error.kind).toBe("invalid-response");
   });
 
+  it("surfaces AbortError as timeout error with timeoutMs", async () => {
+    const fetchImpl = (async (_url: unknown, init: unknown) => {
+      const signal = (init as RequestInit)?.signal;
+      // Immediately abort so the AbortError fires synchronously-ish.
+      await new Promise<void>((_, reject) => {
+        if (signal?.aborted) {
+          reject(Object.assign(new Error("The operation was aborted."), { name: "AbortError" }));
+          return;
+        }
+        signal?.addEventListener("abort", () => {
+          reject(Object.assign(new Error("The operation was aborted."), { name: "AbortError" }));
+        });
+      });
+      return new Response("never");
+    }) as unknown as typeof fetch;
+
+    const provider = createMinimaxProvider({
+      apiKey: "test-key",
+      fetchImpl,
+    });
+    // Use a very short timeout so the AbortController fires immediately.
+    const result = await provider.extract({
+      source: { kind: "url", url: "https://img.example/x.jpg" },
+      timeoutMs: 1,
+    });
+    if (result.ok) throw new Error("expected not-ok");
+    expect(result.error.kind).toBe("timeout");
+    if (result.error.kind === "timeout") {
+      expect(result.error.timeoutMs).toBe(1);
+    }
+  });
+
   it("returns invalid-response when completion JSON fails Zod schema", async () => {
     const provider = createMinimaxProvider({
       apiKey: "test-key",

--- a/src/lib/ocr/minimax.ts
+++ b/src/lib/ocr/minimax.ts
@@ -184,11 +184,21 @@ export function createMinimaxProvider(overrides?: {
           },
         };
       } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") {
+          return {
+            ok: false,
+            error: {
+              kind: "timeout",
+              message: `MiniMax did not respond within ${timeoutMs}ms`,
+              timeoutMs,
+            },
+          };
+        }
         const msg = err instanceof Error ? err.message : String(err);
         return {
           ok: false,
           error: {
-            kind: msg.includes("abort") ? "network" : "unknown",
+            kind: "unknown",
             message: msg,
           },
         };

--- a/src/lib/ocr/types.ts
+++ b/src/lib/ocr/types.ts
@@ -39,6 +39,7 @@ export type OcrError =
   | { kind: "rate-limit"; message: string; retryAfterMs?: number }
   | { kind: "invalid-response"; message: string; raw?: unknown }
   | { kind: "unsupported"; message: string }
+  | { kind: "timeout"; message: string; timeoutMs: number }
   | { kind: "unknown"; message: string };
 
 /**


### PR DESCRIPTION
## Summary

- **Abort detection fixed**: `minimax.ts` previously used `msg.includes("abort")` to detect timeouts — fragile and wrong. Now uses `err.name === "AbortError"` (the spec-correct check).
- **New `timeout` OcrError kind**: `types.ts` adds `{ kind: "timeout"; message: string; timeoutMs: number }` so callers can pattern-match reliably. User sees: `辨識逾時（30 秒）。MiniMax 目前較慢，請稍後再試，或改手動輸入。`
- **Escalating progress hint in ScanFlow**: Replaces static "通常 3-6 秒" with `OcrProgressHint` component that ticks every second:
  - 0–8s: "MiniMax 正在讀這張卡。通常 3-6 秒。"
  - 8–18s: "還在辨識中，MiniMax 有時比較慢，請稍候…"
  - 18s+: "快好了，最長等到 30 秒後會告知結果。"
- **`OcrRescanPanel` parity**: same escalating hint in its uploading phase (previously showed bare "解析中…" with no duration hint at all).
- **Unit test**: new test in `minimax.test.ts` asserts AbortError → `timeout` kind with correct `timeoutMs`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (2 pre-existing warnings unrelated to this change)
- [x] `pnpm test src/lib/ocr/__tests__/minimax.test.ts` — 10/10 pass (includes new timeout test)

Manual verification (iOS Safari over Tailscale):
- [ ] Upload a card photo → see "MiniMax 正在讀這張卡" initially
- [ ] Wait 8s without network → hint changes to slow-message
- [ ] Wait 30s → see timeout error with retry button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #235