### PR TITLE
feat(contact): LINE tap-to-open + 44px touch targets for tel/mailto/linkedin

### DIFF
--- a/src/app/(app)/cards/[id]/detail.module.css
+++ b/src/app/(app)/cards/[id]/detail.module.css
@@ -274,8 +274,8 @@
   display: grid;
   grid-template-columns: 5rem 1fr;
   gap: var(--space-sm);
-  align-items: baseline;
-  padding: var(--space-xs) 0;
+  align-items: center;
+  padding: 0;
   border-bottom: var(--border-hair) solid var(--color-border);
 }
 
@@ -291,14 +291,25 @@
   color: var(--color-fg-subtle);
 }
 
-.contactValue {
+.contactValue,
+.contactLink {
   font-family: var(--font-serif);
   font-size: var(--text-body);
   color: var(--color-fg);
   text-decoration: none;
+  /* Ensure minimum 44px touch target on mobile (Apple HIG / WCAG 2.5.8) */
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: var(--space-xs) 0;
 }
 
-.contactValue:hover {
+.contactLink {
+  color: var(--color-accent-ink);
+}
+
+.contactValue:is(a):hover,
+.contactLink:hover {
   color: var(--color-accent-ink);
   text-decoration: underline;
 }

--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -25,6 +25,7 @@ import { isCoachConfigured } from "@/lib/coach/llm";
 import { companySlug, pickCanonicalCompany } from "@/lib/companies/group";
 import { computeTemperature } from "@/lib/cards/relationship-temp";
 import { linkedInSearchUrl } from "@/lib/share/linkedin-search";
+import { lineDeepLink } from "@/lib/share/line-url";
 import { findAnniversariesToday } from "@/lib/timeline/anniversaries";
 import { readSession } from "@/lib/firebase/session";
 
@@ -332,7 +333,7 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
               {card.phones.map((phone, index) => (
                 <li key={`phone-${index}`}>
                   <span className={styles.contactLabel}>{phone.label}</span>
-                  <a href={`tel:${phone.value}`} className={styles.contactValue}>
+                  <a href={`tel:${phone.value}`} className={styles.contactLink}>
                     {phone.value}
                   </a>
                 </li>
@@ -340,7 +341,7 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
               {card.emails.map((email, index) => (
                 <li key={`email-${index}`}>
                   <span className={styles.contactLabel}>{email.label}</span>
-                  <a href={`mailto:${email.value}`} className={styles.contactValue}>
+                  <a href={`mailto:${email.value}`} className={styles.contactLink}>
                     {email.value}
                   </a>
                 </li>
@@ -350,7 +351,7 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
                   <span className={styles.contactLabel}>linkedin</span>
                   <a
                     href={card.social.linkedinUrl}
-                    className={styles.contactValue}
+                    className={styles.contactLink}
                     target="_blank"
                     rel="noreferrer noopener"
                   >
@@ -361,7 +362,19 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
               {card.social?.lineId && (
                 <li>
                   <span className={styles.contactLabel}>line</span>
-                  <span className={styles.contactValue}>{card.social.lineId}</span>
+                  {lineDeepLink(card.social.lineId) ? (
+                    <a
+                      href={lineDeepLink(card.social.lineId)!}
+                      className={styles.contactLink}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      aria-label={`開啟 LINE：${card.social.lineId}`}
+                    >
+                      {card.social.lineId}
+                    </a>
+                  ) : (
+                    <span className={styles.contactValue}>{card.social.lineId}</span>
+                  )}
                 </li>
               )}
               {card.social?.wechatId && (

--- a/src/components/cards/CardActions.tsx
+++ b/src/components/cards/CardActions.tsx
@@ -15,6 +15,7 @@ import { localYmdAfterDays } from "@/lib/cards/follow-up-date";
 import { googleCalendarEventUrl } from "@/lib/calendar/gcal-url";
 import { shareCardVcard } from "@/lib/share/card-share";
 import { formatContactSummary } from "@/lib/share/contact-summary";
+import { lineDeepLink } from "@/lib/share/line-url";
 
 import styles from "./CardActions.module.css";
 import { VoiceMicButton } from "./VoiceMicButton";
@@ -222,11 +223,8 @@ export function CardActions({
     }
   };
 
-  // LINE deep-link: older LINE IDs (@foo) use line://ti/p/@foo, user IDs
-  // without @ use ~{id}. Both open the LINE app when present.
-  const lineHref = lineId
-    ? `https://line.me/ti/p/${lineId.startsWith("@") ? encodeURIComponent(lineId) : `~${encodeURIComponent(lineId)}`}`
-    : null;
+  // LINE deep-link: shared formula centralised in lineDeepLink().
+  const lineHref = lineDeepLink(lineId);
 
   return (
     <section className={styles.actions} aria-label="Actions">

--- a/src/lib/share/__tests__/line-url.test.ts
+++ b/src/lib/share/__tests__/line-url.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { lineDeepLink } from "../line-url";
+
+describe("lineDeepLink", () => {
+  it("returns null for null input", () => {
+    expect(lineDeepLink(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(lineDeepLink(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(lineDeepLink("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only string", () => {
+    expect(lineDeepLink("   ")).toBeNull();
+  });
+
+  it("builds @-style public channel link", () => {
+    const url = lineDeepLink("@mychannel");
+    expect(url).toBe("https://line.me/ti/p/%40mychannel");
+  });
+
+  it("builds personal user link without @ prefix", () => {
+    const url = lineDeepLink("johndoe123");
+    expect(url).toBe("https://line.me/ti/p/~johndoe123");
+  });
+
+  it("encodes special characters in personal ID", () => {
+    const url = lineDeepLink("john doe");
+    expect(url).toBe("https://line.me/ti/p/~john%20doe");
+  });
+
+  it("encodes special characters in public ID", () => {
+    const url = lineDeepLink("@hello world");
+    expect(url).toBe("https://line.me/ti/p/%40hello%20world");
+  });
+
+  it("trims surrounding whitespace before checking", () => {
+    const url = lineDeepLink("  johndoe  ");
+    expect(url).toBe("https://line.me/ti/p/~johndoe");
+  });
+
+  it("trims surrounding whitespace for @-style IDs", () => {
+    const url = lineDeepLink("  @channel  ");
+    expect(url).toBe("https://line.me/ti/p/%40channel");
+  });
+});

--- a/src/lib/share/line-url.ts
+++ b/src/lib/share/line-url.ts
@@ -1,0 +1,21 @@
+/**
+ * Build a LINE deep-link URL for a given LINE ID.
+ *
+ * LINE ID formats:
+ *  - Public IDs starting with "@" use `line://ti/p/@foo` / `https://line.me/ti/p/%40foo`
+ *  - Personal user IDs (no "@") use `https://line.me/ti/p/~{id}`
+ *
+ * Returns null when lineId is empty or whitespace.
+ *
+ * This is the single source of truth for the LINE deep-link formula; both
+ * the card-detail sidebar and CardActions import from here so the two
+ * surfaces always stay in sync.
+ */
+export function lineDeepLink(lineId: string | null | undefined): string | null {
+  const id = lineId?.trim();
+  if (!id) return null;
+  if (id.startsWith("@")) {
+    return `https://line.me/ti/p/${encodeURIComponent(id)}`;
+  }
+  return `https://line.me/ti/p/~${encodeURIComponent(id)}`;
+}


### PR DESCRIPTION
## Summary

- **LINE ID is now tappable on iPhone.** The sidebar contact block previously showed LINE IDs as plain `<span>` text — Taiwan's #1 messaging app was unreachable without copy-paste. It now renders as `<a href="https://line.me/ti/p/...">` using a shared `lineDeepLink()` helper.
- **44px touch targets on all contact links.** The `tel:`, `mailto:`, and LinkedIn links in the sidebar had text-height (~16px) hit areas. They now have `min-height: 44px` + `display: flex; align-items: center` meeting Apple HIG and WCAG 2.5.8 on mobile Safari.
- **Single source of truth for LINE URL formula.** `src/lib/share/line-url.ts` centralises the `@`-style vs `~`-style deep-link logic; `CardActions` now imports from there instead of duplicating inline.

## Files changed

| File | Change |
|------|--------|
| `src/lib/share/line-url.ts` | New: `lineDeepLink()` helper (10 unit tests) |
| `src/lib/share/__tests__/line-url.test.ts` | New: unit tests for all ID formats + edge cases |
| `src/app/(app)/cards/[id]/page.tsx` | LINE ID → `<a>`; tel/mailto/LinkedIn → `contactLink` class |
| `src/app/(app)/cards/[id]/detail.module.css` | `contactLink` class with 44px min-height; `contactValue` inherits same |
| `src/components/cards/CardActions.tsx` | Uses shared `lineDeepLink()` instead of inline formula |

## Test plan

- [x] `pnpm test src/lib/share/__tests__/line-url.test.ts` — 10/10 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — only pre-existing warnings (not this PR)
- [x] `pnpm test:coverage` — 90.19% statements / 80.49% branches (above 80% gate)
- [ ] Manual: open card detail on iPhone Safari → tap LINE ID → LINE app opens
- [ ] Manual: tap phone number → dialler opens; tap email → mail client opens
- [ ] Manual: verify touch targets feel comfortable at thumb size

Closes #239