### PR TITLE
feat(home): uncontacted 區塊升級為一鍵「✅ 已聯絡」快速標記

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -6,6 +6,7 @@ import { PwaInstallHint } from "@/components/home/PwaInstallHint";
 import { AnniversariesSection } from "@/components/timeline/AnniversariesSection";
 import { DueTodaySection } from "@/components/timeline/DueTodaySection";
 import { TimelineSection } from "@/components/timeline/TimelineSection";
+import { UncontactedSection } from "@/components/timeline/UncontactedSection";
 import { listCardsForUser } from "@/db/cards";
 import { isCoachConfigured } from "@/lib/coach/llm";
 import { readSession } from "@/lib/firebase/session";
@@ -106,6 +107,16 @@ export default async function HomePage() {
               if (section.id === "anniversaries") {
                 return (
                   <AnniversariesSection
+                    key={section.id}
+                    section={section}
+                    now={now}
+                    showAiDrafts={isCoachConfigured()}
+                  />
+                );
+              }
+              if (section.id === "uncontacted") {
+                return (
+                  <UncontactedSection
                     key={section.id}
                     section={section}
                     now={now}

--- a/src/components/timeline/UncontactedSection.tsx
+++ b/src/components/timeline/UncontactedSection.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { FollowupCardRow } from "@/components/followups/FollowupCardRow";
+import type { TimelineSection as TimelineSectionData } from "@/lib/timeline/categorize";
+import { daysSinceContact } from "@/lib/timeline/staleness";
+
+import styles from "./TimelineSection.module.css";
+
+interface UncontactedSectionProps {
+  section: TimelineSectionData;
+  now: Date;
+  showAiDrafts?: boolean;
+}
+
+/**
+ * Home-page rendering of the `uncontacted` timeline section using
+ * FollowupCardRow — the same interactive component as DueTodaySection.
+ *
+ * This lets users mark a contact as contacted with one tap directly
+ * from the home timeline, without navigating to the detail page first.
+ * The uncontacted section is the highest-volume actionable item for
+ * business users who open the app to triage their network each morning.
+ */
+export function UncontactedSection({
+  section,
+  now,
+  showAiDrafts = false,
+}: UncontactedSectionProps) {
+  if (section.cards.length === 0) return null;
+  return (
+    <section className={styles.section} aria-labelledby={`section-${section.id}`}>
+      <header className={styles.header}>
+        <h2 id={`section-${section.id}`} className={styles.title}>
+          {section.title}
+        </h2>
+        <p className={styles.description}>{section.description}</p>
+      </header>
+      <ol className={styles.actionableList}>
+        {section.cards.map((card) => {
+          const days = daysSinceContact(card, now) ?? 0;
+          return (
+            <FollowupCardRow
+              key={card.id}
+              card={card}
+              days={days}
+              daysLabel={`${days} 天沒聯絡`}
+              showAiDrafts={showAiDrafts}
+            />
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/src/components/timeline/__tests__/UncontactedSection.test.tsx
+++ b/src/components/timeline/__tests__/UncontactedSection.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { CardSummary } from "@/db/cards";
+import type { TimelineSection } from "@/lib/timeline/categorize";
+import { UncontactedSection } from "../UncontactedSection";
+
+vi.mock("@/app/(app)/cards/actions", () => ({
+  logContactAction: vi.fn(),
+  setFollowUpAction: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+
+// Fixed reference: 2026-04-26 12:00 local
+const NOW = new Date(2026, 3, 26, 12, 0, 0);
+
+function makeCard(overrides: Partial<CardSummary> = {}): CardSummary {
+  const createdAt = new Date(NOW.getTime() - 40 * 24 * 60 * 60 * 1000); // 40 days ago
+  return {
+    id: "c1",
+    nameZh: "陳小華",
+    emails: [{ value: "chen@example.com", primary: true, label: "work" as const }],
+    phones: [{ value: "0933111222", primary: true, label: "mobile" as const }],
+    social: {},
+    whyRemember: "台大同學",
+    tagIds: [],
+    tagNames: [],
+    memberUids: ["uid1"],
+    ownerUid: "uid1",
+    workspaceId: "wid1",
+    createdAt,
+    updatedAt: createdAt,
+    deletedAt: null,
+    lastContactedAt: null,
+    ...overrides,
+  } as CardSummary;
+}
+
+function makeSection(cards: CardSummary[]): TimelineSection {
+  return {
+    id: "uncontacted",
+    title: "最近沒聯絡",
+    description: "已經 30 天以上沒互動，可能該問候一下。",
+    cards,
+  };
+}
+
+describe("UncontactedSection", () => {
+  it("renders nothing when section is empty", () => {
+    const { container } = render(<UncontactedSection section={makeSection([])} now={NOW} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders section heading with correct title", () => {
+    render(<UncontactedSection section={makeSection([makeCard()])} now={NOW} />);
+    expect(screen.getByRole("heading", { name: "最近沒聯絡" })).toBeInTheDocument();
+  });
+
+  it("renders FollowupCardRow with mail/phone quick actions", () => {
+    render(<UncontactedSection section={makeSection([makeCard()])} now={NOW} />);
+    expect(screen.getByLabelText(/寄信給 陳小華/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/撥電話給 陳小華/)).toBeInTheDocument();
+  });
+
+  it("shows ✅ 已聯絡 button for each uncontacted card", () => {
+    render(<UncontactedSection section={makeSection([makeCard()])} now={NOW} />);
+    expect(screen.getByLabelText(/標記已聯絡 陳小華/)).toBeInTheDocument();
+    expect(screen.getByText("✅ 已聯絡")).toBeInTheDocument();
+  });
+
+  it("shows staleness label with days since last contact", () => {
+    // lastContactedAt null — falls back to createdAt (40 days ago)
+    render(<UncontactedSection section={makeSection([makeCard()])} now={NOW} />);
+    // Should show something like "40 天沒聯絡"
+    expect(screen.getByText(/天沒聯絡/)).toBeInTheDocument();
+  });
+
+  it("shows LINE quick action when lineId is set", () => {
+    const card = makeCard({ social: { lineId: "chenhw123" } });
+    render(<UncontactedSection section={makeSection([card])} now={NOW} />);
+    expect(screen.getByLabelText(/LINE 聯絡 陳小華/)).toBeInTheDocument();
+  });
+
+  it("renders multiple cards as separate rows", () => {
+    const cards = [
+      makeCard({ id: "c1", nameZh: "陳小華" }),
+      makeCard({
+        id: "c2",
+        nameZh: "李大偉",
+        emails: [{ value: "li@example.com", primary: true, label: "work" as const }],
+        phones: [],
+      }),
+    ];
+    render(<UncontactedSection section={makeSection(cards)} now={NOW} />);
+    expect(screen.getByLabelText(/標記已聯絡 陳小華/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/標記已聯絡 李大偉/)).toBeInTheDocument();
+  });
+
+  it("uses lastContactedAt over createdAt for staleness when available", () => {
+    // lastContactedAt = 35 days ago
+    const lastContactedAt = new Date(NOW.getTime() - 35 * 24 * 60 * 60 * 1000);
+    const card = makeCard({ lastContactedAt });
+    render(<UncontactedSection section={makeSection([card])} now={NOW} />);
+    expect(screen.getByText("35 天沒聯絡")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- 首頁「最近沒聯絡」區塊從純靜態連結升級為互動式 `FollowupCardRow`（與 `due-today` 區塊一致）
- 用戶可直接在時間軸原地：一鍵 ✅ 已聯絡 → 設下次聯絡時間，**省去進入詳情頁的 2 個多餘點擊**
- 新增 `UncontactedSection.tsx`（50 LOC），不動任何 off-limits 檔案

## 改動檔案

- `src/components/timeline/UncontactedSection.tsx` — 新增（複用 FollowupCardRow）
- `src/components/timeline/__tests__/UncontactedSection.test.tsx` — 新增（8 tests）
- `src/app/(app)/page.tsx` — 新增 `uncontacted` section 判斷分支，使用 UncontactedSection

**Off-limits 確認：MobileFab, ScanFlow, OcrRescanPanel, LoginForm, CardActions, cards/[id]/page.tsx 均未修改**

## Test plan

- [x] `pnpm test src/components/timeline/` — 15/15 passed（含新 8 tests）
- [x] `pnpm typecheck` — 無錯誤
- [x] `pnpm lint` — 0 errors（2 pre-existing warnings 與本 PR 無關）
- [ ] 手動：首頁「最近沒聯絡」section 應顯示 ✅ 已聯絡 / 📧 / 📞 / 💬 quick actions
- [ ] 手動：點「✅ 已聯絡」後出現下次聯絡選擇器，選擇後 refresh 正確移除該卡片

Closes #241