### PR TITLE
security(rules): explicit publicSlugs deny block + regression test

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -70,6 +70,14 @@ service cloud.firestore {
         resource.data.memberUids == incoming().memberUids;
     }
 
+    // ==================== publicSlugs (Admin SDK only) ====================
+    // Public card share slugs are created and resolved exclusively via the
+    // Firebase Admin SDK in server-side route handlers. Client SDK access is
+    // intentionally and unconditionally denied — do not relax this rule.
+    match /publicSlugs/{slug} {
+      allow read, write: if false;
+    }
+
     // ==================== Workspaces ====================
     match /workspaces/{wid} {
       allow read: if isMember(resource.data.memberUids);

--- a/src/__tests__/firestore.rules.test.ts
+++ b/src/__tests__/firestore.rules.test.ts
@@ -351,6 +351,50 @@ describeIfEmulator("firestore.rules", () => {
     });
   });
 
+  describe("publicSlugs collection", () => {
+    // publicSlugs is Admin-SDK-only. All client SDK access must be denied,
+    // even for authenticated users — there is no scenario where the browser
+    // should read or write this collection directly.
+
+    it("anonymous client SDK cannot read publicSlugs/foo", async () => {
+      await testEnv.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), "publicSlugs", "foo"), {
+          cardId: "card1",
+          workspaceId: UID_ALICE,
+          ownerUid: UID_ALICE,
+          createdAt: new Date(),
+        });
+      });
+      const anon = testEnv.unauthenticatedContext().firestore();
+      await assertFails(getDoc(doc(anon, "publicSlugs", "foo")));
+    });
+
+    it("authenticated client SDK cannot read publicSlugs/{slug} (Admin SDK only)", async () => {
+      await testEnv.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), "publicSlugs", "bar"), {
+          cardId: "card2",
+          workspaceId: UID_ALICE,
+          ownerUid: UID_ALICE,
+          createdAt: new Date(),
+        });
+      });
+      const alice = testEnv.authenticatedContext(UID_ALICE).firestore();
+      await assertFails(getDoc(doc(alice, "publicSlugs", "bar")));
+    });
+
+    it("authenticated client SDK cannot write to publicSlugs/{slug}", async () => {
+      const alice = testEnv.authenticatedContext(UID_ALICE).firestore();
+      await assertFails(
+        setDoc(doc(alice, "publicSlugs", "new-slug"), {
+          cardId: "card3",
+          workspaceId: UID_ALICE,
+          ownerUid: UID_ALICE,
+          createdAt: new Date(),
+        }),
+      );
+    });
+  });
+
   describe("tags", () => {
     beforeEach(async () => {
       await testEnv.withSecurityRulesDisabled(async (ctx) => {


### PR DESCRIPTION
## Summary

- Add explicit `match /publicSlugs/{slug} { allow read, write: if false; }` block in `firestore.rules` so the Admin-SDK-only collection is locked by name, not just by the global catch-all.
- Add `describe("publicSlugs collection", ...)` block in `src/__tests__/firestore.rules.test.ts` with 3 `assertFails` cases (anonymous read, authenticated read, authenticated write).

Closes #247

## Changes

| File | What changed |
|------|-------------|
| `firestore.rules` | +8 lines: explicit deny match block with comment explaining Admin-SDK-only intent |
| `src/__tests__/firestore.rules.test.ts` | +44 lines: 3 new regression test cases |

## Rules helpers used

No custom helpers needed — the block unconditionally returns `false`, so no `isAuthed()`, `isMember()`, or `isWorkspaceMember()` calls. The tests use `assertFails`, `assertSucceeds` (none needed — all paths denied), `unauthenticatedContext`, and `authenticatedContext` consistent with existing patterns.

## Test plan

- [ ] `pnpm typecheck` — passes (verified locally)
- [ ] `pnpm exec vitest --typecheck run src/__tests__/firestore.rules.test.ts` — 0 type errors (verified locally)
- [ ] `pnpm test:rules` — runs against Firestore emulator (requires Java 21 + `firebase emulators:exec`); CI rules job will exercise all 3 new cases
- [ ] All 3 new tests expected to pass: `assertFails` for anonymous read, authenticated read, authenticated write

## Post-merge deployment note

**CI does not auto-deploy rules.** After this PR merges, manually deploy rules to production:

```bash
pnpm exec firebase deploy --only firestore:rules --project namecard-web-prd
```

Without this step the explicit deny block will not be active in production (though the catch-all still protects the collection until deploy).