### PR TITLE
security: open-redirect + URL scheme + magic-byte + OCR rate limit (P0+P1x3)

### DIFF
--- a/src/app/(app)/cards/[id]/page.tsx
+++ b/src/app/(app)/cards/[id]/page.tsx
@@ -26,6 +26,7 @@ import { companySlug, pickCanonicalCompany } from "@/lib/companies/group";
 import { computeTemperature } from "@/lib/cards/relationship-temp";
 import { linkedInSearchUrl } from "@/lib/share/linkedin-search";
 import { lineDeepLink } from "@/lib/share/line-url";
+import { safeExternalUrl } from "@/lib/share/url-safety";
 import { findAnniversariesToday } from "@/lib/timeline/anniversaries";
 import { readSession } from "@/lib/firebase/session";
 
@@ -346,11 +347,11 @@ export default async function CardDetailPage({ params, searchParams }: DetailPag
                   </a>
                 </li>
               ))}
-              {card.social?.linkedinUrl && (
+              {safeExternalUrl(card.social?.linkedinUrl) && (
                 <li>
                   <span className={styles.contactLabel}>linkedin</span>
                   <a
-                    href={card.social.linkedinUrl}
+                    href={safeExternalUrl(card.social?.linkedinUrl)!}
                     className={styles.contactLink}
                     target="_blank"
                     rel="noreferrer noopener"

--- a/src/app/(app)/cards/actions.ts
+++ b/src/app/(app)/cards/actions.ts
@@ -51,6 +51,7 @@ import { callReengageLlm } from "@/lib/coach/reengage-llm";
 import { readReengageCache, writeReengageCache } from "@/lib/coach/reengage-store";
 import { readCoachCache, writeCoachCache } from "@/lib/coach/store";
 import { pickCanonicalCompany } from "@/lib/companies/group";
+import { validateImageMagicBytes } from "@/lib/scan/file-validation";
 import { encodePrefill, type ExtractedCard } from "@/lib/voice/extract";
 import { callExtractLlm, callExtractLlmMulti } from "@/lib/voice/extract-llm";
 
@@ -813,6 +814,16 @@ export const attachCardImageAction = authedAction
       const buffer = Buffer.from(parsedInput.fileBase64, "base64");
       if (buffer.byteLength === 0) return { ok: false, reason: "empty image payload" };
       if (buffer.byteLength > 10 * 1024 * 1024) return { ok: false, reason: "image exceeds 10MB" };
+
+      // P1: magic-byte validation — reject SVG / non-image payloads before
+      // they touch Storage (prevents SVG-XSS via uploaded "images").
+      const magicCheck = validateImageMagicBytes(buffer);
+      if (!magicCheck.valid) {
+        return {
+          ok: false,
+          reason: "invalid-image: file signature does not match a supported image format",
+        };
+      }
 
       // Lazy-import keeps the storage helper (Sharp, Firebase Admin)
       // out of any cold-import budget that doesn't need it.

--- a/src/app/(app)/cards/scan/actions.ts
+++ b/src/app/(app)/cards/scan/actions.ts
@@ -3,6 +3,8 @@
 import { z } from "zod";
 
 import { authedAction } from "@/lib/auth/safe-action";
+import { incrementAndCheckScanLimit } from "@/db/scanLimits";
+import { validateImageMagicBytes } from "@/lib/scan/file-validation";
 import { getOcrProvider } from "@/lib/ocr";
 import { uploadCardImage } from "@/lib/storage/card-images";
 
@@ -30,6 +32,34 @@ export const scanCardAction = authedAction
     }
     if (buffer.byteLength > 10 * 1024 * 1024) {
       throw new Error("image exceeds 10MB limit");
+    }
+
+    // P1: magic-byte validation — reject SVG / non-image payloads before
+    // they touch OCR or Storage (prevents SVG-XSS via uploaded "images").
+    const magicCheck = validateImageMagicBytes(buffer);
+    if (!magicCheck.valid) {
+      return {
+        ok: false as const,
+        error: {
+          kind: "invalid-image" as const,
+          message: "檔案格式不符，僅接受 JPEG/PNG/WebP/HEIC",
+        },
+      };
+    }
+
+    // P1: per-user daily OCR rate limit (default 50/day, override via env).
+    const limit = Number(process.env.OCR_DAILY_LIMIT_PER_USER ?? "50");
+    const limitCheck = await incrementAndCheckScanLimit(ctx.user.uid, limit);
+    if (!limitCheck.allowed) {
+      return {
+        ok: false as const,
+        error: {
+          kind: "rate-limit-exceeded" as const,
+          message: `今日掃描次數已達上限（${limit} 張/天），請明日再試。`,
+          usedToday: limitCheck.usedToday,
+          limit,
+        },
+      };
     }
 
     const upload = await uploadCardImage({

--- a/src/app/(auth)/login/actions.ts
+++ b/src/app/(auth)/login/actions.ts
@@ -17,7 +17,15 @@ export const signInWithIdTokenAction = publicAction
   .action(async ({ parsedInput }) => {
     const user = await createSession(parsedInput.idToken);
     await ensurePersonalWorkspace({ uid: user.uid, displayName: user.displayName });
-    return { ok: true as const, next: parsedInput.next ?? "/" };
+    // Belt-and-suspenders: re-validate the `next` redirect target server-side.
+    // The page already sanitises it, but defence-in-depth rejects anything that
+    // slipped through (e.g. direct API callers). Only allow relative paths.
+    const rawNext = parsedInput.next;
+    const safeNext =
+      typeof rawNext === "string" && rawNext.startsWith("/") && !rawNext.startsWith("//")
+        ? rawNext
+        : "/";
+    return { ok: true as const, next: safeNext };
   });
 
 export async function signOutAction(): Promise<void> {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -11,7 +11,13 @@ interface LoginPageProps {
 export default async function LoginPage({ searchParams }: LoginPageProps) {
   const user = await readSession();
   if (user) redirect("/");
-  const { next } = await searchParams;
+  const { next: rawNext } = await searchParams;
+  // P0 open-redirect guard: only allow relative paths that start with "/"
+  // but not "//" (which browsers treat as protocol-relative, i.e. external).
+  const safeNext =
+    typeof rawNext === "string" && rawNext.startsWith("/") && !rawNext.startsWith("//")
+      ? rawNext
+      : null;
   return (
     <main className={styles.shell}>
       <article className={styles.article}>
@@ -24,7 +30,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
           <br />
           只有被允許的 email 能存取。
         </p>
-        <LoginForm next={next} />
+        <LoginForm next={safeNext ?? undefined} />
         <p className={styles.footnote}>未被授權卻該有存取權？請聯絡管理員更新 ALLOWED_EMAILS。</p>
       </article>
     </main>

--- a/src/app/u/[slug]/page.tsx
+++ b/src/app/u/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { getCardByPublicSlug } from "@/db/cards";
+import { safeExternalUrl } from "@/lib/share/url-safety";
 
 import styles from "./profile.module.css";
 
@@ -67,9 +68,10 @@ export default async function PublicProfilePage({ params }: PageProps) {
   const phones = card.phones ?? [];
   const emails = card.emails ?? [];
   const lineId = card.social?.lineId;
-  const linkedinUrl = card.social?.linkedinUrl;
+  // Sanitize at render: only pass through href if scheme is in allowlist (P1, #248).
+  const linkedinUrl = safeExternalUrl(card.social?.linkedinUrl);
   const wechatId = card.social?.wechatId;
-  const websiteUrl = card.social?.websiteUrl;
+  const websiteUrl = safeExternalUrl(card.social?.websiteUrl);
 
   return (
     <main className={styles.page}>

--- a/src/components/scan/ScanFlow.tsx
+++ b/src/components/scan/ScanFlow.tsx
@@ -304,10 +304,13 @@ function formatOcrError(err: {
   message: string;
   retryAfterMs?: number;
   timeoutMs?: number;
+  limit?: number;
 }): string {
   switch (err.kind) {
     case "rate-limit":
       return `API 流量限制，請 ${Math.ceil((err.retryAfterMs ?? 5000) / 1000)} 秒後再試`;
+    case "rate-limit-exceeded":
+      return `今日掃描次數已達上限（${err.limit ?? 50} 張/天），請明日再試。`;
     case "timeout":
       return `辨識逾時（${Math.round((err.timeoutMs ?? 30000) / 1000)} 秒）。MiniMax 目前較慢，請稍後再試，或改手動輸入。`;
     case "network":
@@ -316,6 +319,8 @@ function formatOcrError(err: {
       return "OCR 回傳格式異常，改手動輸入較快";
     case "unsupported":
       return "OCR 服務未配置";
+    case "invalid-image":
+      return "檔案格式不符，僅接受 JPEG/PNG/WebP/HEIC 圖片。";
     case "payload-too-large":
       return "照片太大（已嘗試壓縮但仍超過 20MB）。請改用較小解析度。";
     default:

--- a/src/db/__tests__/scanLimits.test.ts
+++ b/src/db/__tests__/scanLimits.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock "server-only" so the module can be imported in test (jsdom) env.
+vi.mock("server-only", () => ({}));
+
+function buildMockDb(snapCount: number) {
+  const mockSnap = { data: () => ({ count: snapCount }) };
+  const mockTx = {
+    get: vi.fn().mockResolvedValue(mockSnap),
+    set: vi.fn(),
+  };
+  const mockDb = {
+    collection: vi.fn().mockReturnThis(),
+    doc: vi.fn().mockReturnThis(),
+    runTransaction: vi
+      .fn()
+      .mockImplementation((fn: (tx: unknown) => Promise<unknown>) => fn(mockTx)),
+  };
+  return { mockDb, mockTx };
+}
+
+vi.mock("@/lib/firebase/server", () => ({
+  getAdminFirestore: vi.fn(),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    increment: (n: number) => ({ __increment: n }),
+    serverTimestamp: () => ({ __serverTimestamp: true }),
+  },
+}));
+
+import { getAdminFirestore } from "@/lib/firebase/server";
+import { incrementAndCheckScanLimit } from "../scanLimits";
+
+describe("incrementAndCheckScanLimit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("allows first scan when count is 0", async () => {
+    const { mockDb, mockTx } = buildMockDb(0);
+    vi.mocked(getAdminFirestore).mockReturnValue(mockDb as never);
+
+    const result = await incrementAndCheckScanLimit("uid-1", 50);
+    expect(result).toEqual({ allowed: true, usedToday: 1 });
+    expect(mockTx.set).toHaveBeenCalledOnce();
+  });
+
+  it("allows scan when count is below limit", async () => {
+    const { mockDb } = buildMockDb(20);
+    vi.mocked(getAdminFirestore).mockReturnValue(mockDb as never);
+
+    const result = await incrementAndCheckScanLimit("uid-1", 50);
+    expect(result).toEqual({ allowed: true, usedToday: 21 });
+  });
+
+  it("rejects scan when count equals limit", async () => {
+    const { mockDb, mockTx } = buildMockDb(50);
+    vi.mocked(getAdminFirestore).mockReturnValue(mockDb as never);
+
+    const result = await incrementAndCheckScanLimit("uid-1", 50);
+    expect(result).toEqual({ allowed: false, usedToday: 50 });
+    expect(mockTx.set).not.toHaveBeenCalled();
+  });
+
+  it("rejects scan when count exceeds limit", async () => {
+    const { mockDb, mockTx } = buildMockDb(55);
+    vi.mocked(getAdminFirestore).mockReturnValue(mockDb as never);
+
+    const result = await incrementAndCheckScanLimit("uid-1", 50);
+    expect(result).toEqual({ allowed: false, usedToday: 55 });
+    expect(mockTx.set).not.toHaveBeenCalled();
+  });
+
+  it("uses today's date as the document key", async () => {
+    const { mockDb } = buildMockDb(0);
+    vi.mocked(getAdminFirestore).mockReturnValue(mockDb as never);
+
+    await incrementAndCheckScanLimit("uid-abc", 10);
+
+    const today = new Date().toISOString().slice(0, 10);
+    // The chain: db.collection("users").doc(uid).collection("scanLimits").doc(today)
+    expect(mockDb.doc).toHaveBeenCalledWith("uid-abc");
+    expect(mockDb.doc).toHaveBeenCalledWith(today);
+  });
+});

--- a/src/db/scanLimits.ts
+++ b/src/db/scanLimits.ts
@@ -1,0 +1,39 @@
+import "server-only";
+
+import { FieldValue } from "firebase-admin/firestore";
+
+import { getAdminFirestore } from "@/lib/firebase/server";
+
+/**
+ * Per-user daily OCR scan limit enforced via a Firestore counter.
+ *
+ * Document path: users/{uid}/scanLimits/{YYYY-MM-DD}
+ * The document is created on first scan and auto-expires semantically
+ * (a new date key is used each day; no TTL config needed for correctness).
+ *
+ * Atomic via a Firestore transaction so concurrent requests from the same
+ * user can't race past the limit (P1, #248).
+ */
+
+export async function incrementAndCheckScanLimit(
+  uid: string,
+  limit: number,
+): Promise<{ allowed: boolean; usedToday: number }> {
+  const db = getAdminFirestore();
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD UTC
+  const docRef = db.collection("users").doc(uid).collection("scanLimits").doc(today);
+
+  return await db.runTransaction(async (tx) => {
+    const snap = await tx.get(docRef);
+    const current = (snap.data()?.count ?? 0) as number;
+    if (current >= limit) {
+      return { allowed: false, usedToday: current };
+    }
+    tx.set(
+      docRef,
+      { count: FieldValue.increment(1), updatedAt: FieldValue.serverTimestamp() },
+      { merge: true },
+    );
+    return { allowed: true, usedToday: current + 1 };
+  });
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { isAllowedUrlOrEmpty } from "@/lib/share/url-safety";
+
 /**
  * Firestore schema & Zod validators.
  *
@@ -44,14 +46,16 @@ export const addressSchema = z.object({
   postalCode: z.string().max(30).optional(),
 });
 
+const urlSchemeMsg = "URL 只允許 http(s)、mailto 或 tel 協議";
+
 export const socialSchema = z.object({
   lineId: z.string().max(100).optional(),
   wechatId: z.string().max(100).optional(),
-  linkedinUrl: z.string().max(500).optional(),
+  linkedinUrl: z.string().max(500).refine(isAllowedUrlOrEmpty, urlSchemeMsg).optional(),
   twitterHandle: z.string().max(60).optional(),
   instagramHandle: z.string().max(60).optional(),
-  facebookUrl: z.string().max(500).optional(),
-  websiteUrl: z.string().max(500).optional(),
+  facebookUrl: z.string().max(500).refine(isAllowedUrlOrEmpty, urlSchemeMsg).optional(),
+  websiteUrl: z.string().max(500).refine(isAllowedUrlOrEmpty, urlSchemeMsg).optional(),
 });
 
 /** Base schema shared between create / update / DB representation. */
@@ -69,7 +73,7 @@ const cardBaseShape = {
   // Company
   companyZh: z.string().max(100).optional(),
   companyEn: z.string().max(100).optional(),
-  companyWebsite: z.string().max(500).optional(),
+  companyWebsite: z.string().max(500).refine(isAllowedUrlOrEmpty, urlSchemeMsg).optional(),
 
   // Multi-value
   phones: z.array(phoneSchema).max(10).default([]),

--- a/src/lib/scan/__tests__/file-validation.test.ts
+++ b/src/lib/scan/__tests__/file-validation.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { detectImageKind, validateImageMagicBytes } from "../file-validation";
+
+// Helper to build a buffer with specific magic bytes padded to 12 bytes.
+function makeBuffer(bytes: number[]): Buffer {
+  const padded = [...bytes, ...new Array(Math.max(0, 12 - bytes.length)).fill(0)];
+  return Buffer.from(padded);
+}
+
+const JPEG_MAGIC = [0xff, 0xd8, 0xff, 0xe0];
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+// RIFF (4) + size (4) + WEBP (4)
+const WEBP_MAGIC = [0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50];
+// ftyp at offset 4, brand "heic" at offset 8
+const HEIC_MAGIC = [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63];
+// ftyp at offset 4, brand "mif1" at offset 8
+const HEIF_MAGIC = [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x69, 0x66, 0x31];
+// SVG (XML text): "<svg"
+const SVG_MAGIC = [0x3c, 0x73, 0x76, 0x67];
+// Corrupt / random bytes
+const CORRUPT = [0x00, 0x01, 0x02, 0x03];
+
+describe("detectImageKind", () => {
+  it("detects JPEG", () => {
+    expect(detectImageKind(makeBuffer(JPEG_MAGIC))).toBe("jpeg");
+  });
+
+  it("detects PNG", () => {
+    expect(detectImageKind(makeBuffer(PNG_MAGIC))).toBe("png");
+  });
+
+  it("detects WebP", () => {
+    expect(detectImageKind(makeBuffer(WEBP_MAGIC))).toBe("webp");
+  });
+
+  it("detects HEIC", () => {
+    expect(detectImageKind(makeBuffer(HEIC_MAGIC))).toBe("heic");
+  });
+
+  it("detects HEIF", () => {
+    expect(detectImageKind(makeBuffer(HEIF_MAGIC))).toBe("heif");
+  });
+
+  it("rejects SVG (XML text)", () => {
+    expect(detectImageKind(makeBuffer(SVG_MAGIC))).toBeNull();
+  });
+
+  it("rejects corrupt bytes", () => {
+    expect(detectImageKind(makeBuffer(CORRUPT))).toBeNull();
+  });
+
+  it("rejects too-short buffer (< 12 bytes)", () => {
+    expect(detectImageKind(Buffer.from([0xff, 0xd8]))).toBeNull();
+  });
+
+  it("rejects empty buffer", () => {
+    expect(detectImageKind(Buffer.alloc(0))).toBeNull();
+  });
+});
+
+describe("validateImageMagicBytes", () => {
+  it("returns valid=true with kind for JPEG", () => {
+    const result = validateImageMagicBytes(makeBuffer(JPEG_MAGIC));
+    expect(result).toEqual({ valid: true, kind: "jpeg" });
+  });
+
+  it("returns valid=false with no kind for SVG", () => {
+    const result = validateImageMagicBytes(makeBuffer(SVG_MAGIC));
+    expect(result).toEqual({ valid: false });
+  });
+
+  it("returns valid=false with no kind for too-short buffer", () => {
+    const result = validateImageMagicBytes(Buffer.from([0x89, 0x50]));
+    expect(result).toEqual({ valid: false });
+  });
+});

--- a/src/lib/scan/file-validation.ts
+++ b/src/lib/scan/file-validation.ts
@@ -1,0 +1,65 @@
+/**
+ * Magic-byte (file signature) validation for uploaded images.
+ *
+ * Rejects files whose actual bytes don't match a known image format,
+ * which prevents SVG-XSS and other MIME-type spoofing attacks (P1, #248).
+ */
+
+export type ImageKind = "jpeg" | "png" | "webp" | "heic" | "heif";
+
+/**
+ * Inspects the first 12 bytes of a Buffer and returns the image format
+ * if recognized, or null if the bytes don't match any known signature.
+ */
+export function detectImageKind(buffer: Buffer): ImageKind | null {
+  if (buffer.length < 12) return null;
+
+  // JPEG: FF D8 FF
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return "jpeg";
+
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return "png";
+  }
+
+  // WebP: RIFF????WEBP (bytes 0-3 = "RIFF", bytes 8-11 = "WEBP")
+  if (
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46 &&
+    buffer[8] === 0x57 &&
+    buffer[9] === 0x45 &&
+    buffer[10] === 0x42 &&
+    buffer[11] === 0x50
+  ) {
+    return "webp";
+  }
+
+  // HEIC/HEIF: bytes 4-7 = "ftyp", bytes 8-11 = brand
+  if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
+    const brand = buffer.slice(8, 12).toString("ascii");
+    if (["heic", "heix", "hevc"].includes(brand)) return "heic";
+    if (["mif1", "msf1"].includes(brand)) return "heif";
+  }
+
+  return null; // unknown — REJECT
+}
+
+/**
+ * Returns `{ valid: true, kind }` when the buffer matches a known safe
+ * image format, or `{ valid: false }` when it should be rejected.
+ */
+export function validateImageMagicBytes(buffer: Buffer): { valid: boolean; kind?: ImageKind } {
+  const kind = detectImageKind(buffer);
+  return { valid: kind !== null, kind: kind ?? undefined };
+}

--- a/src/lib/share/__tests__/url-safety.test.ts
+++ b/src/lib/share/__tests__/url-safety.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { isAllowedUrlOrEmpty, safeExternalUrl } from "../url-safety";
+
+describe("safeExternalUrl", () => {
+  it("allows http: URLs", () => {
+    expect(safeExternalUrl("http://example.com")).toBe("http://example.com");
+  });
+
+  it("allows https: URLs", () => {
+    expect(safeExternalUrl("https://linkedin.com/in/somebody")).toBe(
+      "https://linkedin.com/in/somebody",
+    );
+  });
+
+  it("allows mailto: URLs", () => {
+    expect(safeExternalUrl("mailto:user@example.com")).toBe("mailto:user@example.com");
+  });
+
+  it("allows tel: URLs", () => {
+    expect(safeExternalUrl("tel:+886912345678")).toBe("tel:+886912345678");
+  });
+
+  it("rejects javascript: URLs", () => {
+    expect(safeExternalUrl("javascript:alert(1)")).toBeNull();
+  });
+
+  it("rejects data: URLs", () => {
+    expect(safeExternalUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
+  });
+
+  it("rejects vbscript: URLs", () => {
+    expect(safeExternalUrl("vbscript:msgbox(1)")).toBeNull();
+  });
+
+  it("rejects file: URLs", () => {
+    expect(safeExternalUrl("file:///etc/passwd")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(safeExternalUrl("")).toBeNull();
+  });
+
+  it("returns null for null", () => {
+    expect(safeExternalUrl(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(safeExternalUrl(undefined)).toBeNull();
+  });
+
+  it("returns null for malformed URL", () => {
+    expect(safeExternalUrl("not-a-url")).toBeNull();
+  });
+
+  it("returns null for protocol-relative URL", () => {
+    expect(safeExternalUrl("//evil.com/steal")).toBeNull();
+  });
+});
+
+describe("isAllowedUrlOrEmpty", () => {
+  it("returns true for empty string", () => {
+    expect(isAllowedUrlOrEmpty("")).toBe(true);
+  });
+
+  it("returns true for whitespace-only string", () => {
+    expect(isAllowedUrlOrEmpty("   ")).toBe(true);
+  });
+
+  it("returns true for valid https URL", () => {
+    expect(isAllowedUrlOrEmpty("https://example.com")).toBe(true);
+  });
+
+  it("returns false for javascript: URL", () => {
+    expect(isAllowedUrlOrEmpty("javascript:alert(1)")).toBe(false);
+  });
+
+  it("returns false for data: URL", () => {
+    expect(isAllowedUrlOrEmpty("data:text/html,<h1>xss</h1>")).toBe(false);
+  });
+});

--- a/src/lib/share/url-safety.ts
+++ b/src/lib/share/url-safety.ts
@@ -1,0 +1,32 @@
+/**
+ * URL safety helpers — allowlist-based scheme validation.
+ *
+ * Used to prevent XSS via javascript: / data: / vbscript: / file: URLs
+ * embedded in social or website link fields (P1 finding, #248).
+ */
+
+const ALLOWED_SCHEMES = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+/**
+ * Returns the URL unchanged if its scheme is in the allowlist,
+ * or null if the scheme is disallowed, the URL is malformed, or the
+ * value is empty / null / undefined.
+ */
+export function safeExternalUrl(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    const u = new URL(value);
+    return ALLOWED_SCHEMES.has(u.protocol) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Zod `.refine()` predicate — allows empty strings (optional fields)
+ * and validates non-empty values against the scheme allowlist.
+ */
+export function isAllowedUrlOrEmpty(value: string): boolean {
+  if (value.trim() === "") return true;
+  return safeExternalUrl(value) !== null;
+}


### PR DESCRIPTION
Closes #248

Implements all four security findings from the 2026-04-27 audit.

## Changes

**P0 — Open redirect via `?next=`**
- `src/app/(auth)/login/page.tsx`: sanitise `rawNext` — only allow values starting with `/` but not `//`
- `src/app/(auth)/login/actions.ts`: belt-and-suspenders re-validation server-side before returning the redirect target

**P1 — URL scheme allowlist**
- New `src/lib/share/url-safety.ts`: `safeExternalUrl()` + `isAllowedUrlOrEmpty()` allowing only `http:`, `https:`, `mailto:`, `tel:`
- `src/db/schema.ts`: `.refine(isAllowedUrlOrEmpty)` on `linkedinUrl`, `facebookUrl`, `websiteUrl` (socialSchema) and `companyWebsite` (cardBaseShape)
- `src/app/u/[slug]/page.tsx` + `src/app/(app)/cards/[id]/page.tsx`: `safeExternalUrl()` at render before passing to `href`

**P1 — Magic-byte check (SVG XSS)**
- New `src/lib/scan/file-validation.ts`: `detectImageKind()` / `validateImageMagicBytes()` for JPEG, PNG, WebP, HEIC/HEIF
- `src/app/(app)/cards/scan/actions.ts`: reject before OCR + Storage
- `src/app/(app)/cards/actions.ts` (`attachCardImageAction`): reject before Storage

**P1 — OCR rate limit**
- New `src/db/scanLimits.ts`: `incrementAndCheckScanLimit()` via Firestore transaction, `users/{uid}/scanLimits/{YYYY-MM-DD}`
- `src/app/(app)/cards/scan/actions.ts`: enforced before OCR call; default 50/day (env: `OCR_DAILY_LIMIT_PER_USER`)
- `src/components/scan/ScanFlow.tsx`: `formatOcrError` handles `rate-limit-exceeded` and `invalid-image` cases

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (2 pre-existing warnings unrelated to this PR)
- [x] 64 unit tests: 15 url-safety + 12 file-validation + 5 scanLimits + 32 pre-existing, all pass
- [ ] Manual: scan upload on iPhone to verify rate-limit counter increments
- [ ] Manual: attempt `javascript:alert(1)` in LinkedIn URL field — form should reject