### PR TITLE
security: redact personal email from e2e test journey

### DIFF
--- a/e2e/journeys/business-user-flows.json
+++ b/e2e/journeys/business-user-flows.json
@@ -4,7 +4,7 @@
   "auth": {
     "method": "google_oauth_session_cookie",
     "cookie_name": "__nc_session",
-    "note": "Tester (chiu0831@gmail.com) signed in earlier — middleware should let us straight in to /."
+    "note": "Tester (tester@example.com) signed in earlier — middleware should let us straight in to /."
   },
   "known_routes": {
     "primary_nav": [


### PR DESCRIPTION
## Summary

Redact `chiu0831@gmail.com` from `e2e/journeys/business-user-flows.json` (the only occurrence in the repo). Replaced with RFC 2606 example domain `tester@example.com`.

## Test plan

- [x] `git grep chiu0831` returns 0 hits
- [x] JSON still parses
- [x] No behavior change — journey `note` is documentation only, not asserted against
- [x] Commit author is anonymized noreply (not personal gmail)

Closes #254