### PR TITLE
security: redact tailnet hostname and macOS username from repo

### DIFF
--- a/.claude/skills/namecard-web-deploy/SKILL.md
+++ b/.claude/skills/namecard-web-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: namecard-web-deploy
-description: Mac mini M4 deployment operations for namecard-web — use when deploying, restarting, rebuilding after merge, recovering after reboot, troubleshooting Tailscale sub-path routing, or verifying the `https://mac-mini.tailde842d.ts.net/namecard-web/` endpoint. Covers PM2 / Tailscale serve / Typesense / Firebase auth domain / basePath build invariants.
+description: Mac mini M4 deployment operations for namecard-web — use when deploying, restarting, rebuilding after merge, recovering after reboot, troubleshooting Tailscale sub-path routing, or verifying the `https://<tailnet-host>/namecard-web/` endpoint. Covers PM2 / Tailscale serve / Typesense / Firebase auth domain / basePath build invariants.
 ---
 
 # namecard-web 部署 skill
@@ -10,10 +10,10 @@ description: Mac mini M4 deployment operations for namecard-web — use when dep
 ## 架構事實
 
 - **Host**: Mac mini M4（你當前環境）
-- **Public URL**: `https://mac-mini.tailde842d.ts.net/namecard-web/`
+- **Public URL**: `https://<tailnet-host>/namecard-web/`
 - **Routing**: Tailscale serve sub-path（**no** Nginx）
 - **Process mgr**: PM2 id=10 `namecard-web`，`NODE_ENV=production`，listen `*:3014`
-- **Project dir**: `/Users/openclaw/.openclaw/shared/projects/namecard-web`
+- **Project dir**: `~/.openclaw/shared/projects/namecard-web`
 - **Working project dir = PM2 cwd** — 在此跑 `pnpm build` 會覆蓋 live `.next/`（見 pitfall #1）
 - **Search**: Typesense Docker container `namecard-typesense`，bind `127.0.0.1:8108`
 - **Firebase project**: `namecard-web-prd`（service-account at `~/.config/namecard/service-account.json`）
@@ -24,15 +24,15 @@ description: Mac mini M4 deployment operations for namecard-web — use when dep
 | 組件                     | 機制                                                          | 檔案                                                                                                                   | 健檢                                          |
 | ------------------------ | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
 | Tailscale daemon         | macOS System Extension                                        | (App Store Tailscale.app)                                                                                              | `tailscale status`                            |
-| Tailscale serve mappings | LaunchAgent `com.openclaw.tailscale-serve` delay 30s          | `~/Library/LaunchAgents/com.openclaw.tailscale-serve.plist` → `/Users/openclaw/.openclaw/bin/tailscale-serve-setup.sh` | `tailscale serve status \| grep namecard-web` |
+| Tailscale serve mappings | LaunchAgent `com.openclaw.tailscale-serve` delay 30s          | `~/Library/LaunchAgents/com.openclaw.tailscale-serve.plist` → `~/.openclaw/bin/tailscale-serve-setup.sh` | `tailscale serve status \| grep namecard-web` |
 | PM2 daemon + processes   | LaunchAgent `com.PM2` runs `pm2 resurrect`                    | `~/Library/LaunchAgents/pm2.openclaw.plist` (reads `~/.pm2/dump.pm2`)                                                  | `pm2 list \| grep namecard-web`               |
 | Typesense container      | Docker Desktop login item + compose `restart: unless-stopped` | `docker-compose.prod.yml`                                                                                              | `docker ps \| grep namecard-typesense`        |
 
 **關鍵不變量**: 若新增 PM2 process 或改 Tailscale serve 映射，**必須**：
 
 1. `pm2 save` — 更新 `~/.pm2/dump.pm2` 讓 resurrect 抓到新 process
-2. 編輯 `/Users/openclaw/.openclaw/bin/tailscale-serve-setup.sh` 的 `PATH_MAPPINGS` 或 `MAPPINGS` 陣列
-3. 跑一次 setup 腳本驗證：`bash /Users/openclaw/.openclaw/bin/tailscale-serve-setup.sh`
+2. 編輯 `~/.openclaw/bin/tailscale-serve-setup.sh` 的 `PATH_MAPPINGS` 或 `MAPPINGS` 陣列
+3. 跑一次 setup 腳本驗證：`bash ~/.openclaw/bin/tailscale-serve-setup.sh`
 
 否則重開機後會掉。
 
@@ -62,8 +62,8 @@ tailscale status                                     # 應 online
 
 # 2) Tailscale serve mappings
 tailscale serve status | grep namecard-web           # 應有 /namecard-web 一行
-# 若缺：bash /Users/openclaw/.openclaw/bin/tailscale-serve-setup.sh
-#       tail -20 /Users/openclaw/.openclaw/logs/tailscale-serve-setup.log  # 看錯誤
+# 若缺：bash ~/.openclaw/bin/tailscale-serve-setup.sh
+#       tail -20 ~/.openclaw/logs/tailscale-serve-setup.log  # 看錯誤
 
 # 3) PM2 processes
 pm2 list | grep namecard-web                         # 應 online uptime > 0
@@ -75,7 +75,7 @@ docker ps --filter name=namecard-typesense           # 應 Up
 
 # 5) End-to-end probe
 curl -skL -o /dev/null -w "HTTP %{http_code} final=%{url_effective}\n" \
-  https://mac-mini.tailde842d.ts.net/namecard-web/
+  https://<tailnet-host>/namecard-web/
 # 預期: HTTP 200 final=.../namecard-web/login
 ```
 
@@ -85,7 +85,7 @@ curl -skL -o /dev/null -w "HTTP %{http_code} final=%{url_effective}\n" \
 
 ```bash
 # 在專案根
-cd /Users/openclaw/.openclaw/shared/projects/namecard-web
+cd ~/.openclaw/shared/projects/namecard-web
 git pull --ff-only origin main
 pnpm install --prod=false
 
@@ -97,7 +97,7 @@ pm2 reload namecard-web --update-env
 
 # 驗證
 curl -s -o /dev/null -w "local %{http_code}\n" http://127.0.0.1:3014/namecard-web/api/health
-curl -skL -o /dev/null -w "public %{http_code}\n" https://mac-mini.tailde842d.ts.net/namecard-web/
+curl -skL -o /dev/null -w "public %{http_code}\n" https://<tailnet-host>/namecard-web/
 
 # 看新 log 有無 error（看前 2 分鐘）
 pm2 logs namecard-web --lines 40 --nostream --err | tail -20
@@ -128,14 +128,14 @@ bash scripts/verify-deploy.sh
 
 **症狀**: `tailscale serve status` 清單缺 `/namecard-web`（或全都沒）。
 **根因**: Tailscale serve state 存在 tailnet 節點上，但依 daemon 生命週期可能被清空。
-**解法**: 編輯 `/Users/openclaw/.openclaw/bin/tailscale-serve-setup.sh` 把映射列進去（已完成）。重開後 `com.openclaw.tailscale-serve` LaunchAgent 會延遲 30 秒自動跑。手動跑：`bash /Users/openclaw/.openclaw/bin/tailscale-serve-setup.sh`。
+**解法**: 編輯 `~/.openclaw/bin/tailscale-serve-setup.sh` 把映射列進去（已完成）。重開後 `com.openclaw.tailscale-serve` LaunchAgent 會延遲 30 秒自動跑。手動跑：`bash ~/.openclaw/bin/tailscale-serve-setup.sh`。
 **預防**: 新增任何 sub-path 映射時，**必須**同步改這支腳本並跑一次驗證。
 
 ### 3. Firebase `auth/unauthorized-domain`
 
 **症狀**: 登入頁選 Google 後彈 `Firebase: Error (auth/unauthorized-domain)`。
 **根因**: Firebase Auth 白名單只認 `localhost` + Firebase Hosting domain，不認 Tailscale domain。
-**解法**: https://console.firebase.google.com/project/namecard-web-prd/authentication/settings → Authorized domains → Add `mac-mini.tailde842d.ts.net`。這是 Firebase Console 手動設定，沒有 CLI / API 可 autonomously 改。
+**解法**: https://console.firebase.google.com/project/namecard-web-prd/authentication/settings → Authorized domains → Add `<tailnet-host>`。這是 Firebase Console 手動設定，沒有 CLI / API 可 autonomously 改。
 **預防**: 新增任何對外 domain（含 Tailscale Funnel、自定義 DNS）時要同步加。
 
 ### 4. `pm2 save` 漏了
@@ -245,9 +245,9 @@ module.exports = { apps: [{ ..., env_production: { ...dotenvProd, PORT, NAMECARD
 | 看 runtime log（含 error） | `pm2 logs namecard-web --lines 50 --nostream --err`                                           |
 | 看 stdout log              | `pm2 logs namecard-web --lines 20 --nostream --out`                                           |
 | 看 Tailscale 路由表        | `tailscale serve status`                                                                      |
-| 重載 Tailscale 所有映射    | `bash /Users/openclaw/.openclaw/bin/tailscale-serve-setup.sh`                                 |
+| 重載 Tailscale 所有映射    | `bash ~/.openclaw/bin/tailscale-serve-setup.sh`                                 |
 | 本機 health probe          | `curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3014/namecard-web/api/health`      |
-| 外部 health probe          | `curl -skL -o /dev/null -w "%{http_code}\n" https://mac-mini.tailde842d.ts.net/namecard-web/` |
+| 外部 health probe          | `curl -skL -o /dev/null -w "%{http_code}\n" https://<tailnet-host>/namecard-web/` |
 | 看 Typesense               | `docker ps --filter name=namecard-typesense`                                                  |
 | zero-downtime 重載         | `pm2 reload namecard-web --update-env`                                                        |
 | 強制重起（cold）           | `pm2 restart namecard-web --update-env`                                                       |
@@ -261,7 +261,7 @@ module.exports = { apps: [{ ..., env_production: { ...dotenvProd, PORT, NAMECARD
 1. **先做非侵入式觀察**（不 restart、不 build）：
    - `pm2 list | grep namecard-web`
    - `tailscale serve status | head -15`
-   - `curl -skL -o /dev/null -w "%{http_code}\n" https://mac-mini.tailde842d.ts.net/namecard-web/`
+   - `curl -skL -o /dev/null -w "%{http_code}\n" https://<tailnet-host>/namecard-web/`
    - `pm2 logs namecard-web --lines 30 --nostream --err | tail -15`
 2. **定位到 pitfall 表**，用匹配的 symptom 找根因
 3. **小步修復**：能用 reload 就別 restart；能用 setup 腳本就別手動 `tailscale serve --set-path`
@@ -274,7 +274,7 @@ module.exports = { apps: [{ ..., env_production: { ...dotenvProd, PORT, NAMECARD
 
 - [ ] `.env.production` 從 `.env.production.example` 填值（Firebase public config、`SESSION_SECRET`、`MINIMAX_API_KEY`、`TYPESENSE_API_KEY`、`ALLOWED_EMAILS`）
 - [ ] `service-account.json` 放 `~/.config/namecard/` 並 `chmod 600`
-- [ ] Firebase Console 加 authorized domain `mac-mini.tailde842d.ts.net`（見 pitfall #3）
+- [ ] Firebase Console 加 authorized domain `<tailnet-host>`（見 pitfall #3）
 - [ ] GCS backup bucket 建立 + 30-day lifecycle，填 `scripts/backup-firestore.sh`
 - [ ] `launchctl` 排 `scripts/backup-firestore.sh` 每日（建議 `ai.namecard.backup.plist`）
 - [ ] UptimeRobot HTTPS 探測 + Telegram Bot 告警

--- a/.env.production.example
+++ b/.env.production.example
@@ -14,7 +14,7 @@
 # Project Settings → Service Accounts → Generate new private key.
 # Recommended location: ~/.config/namecard/service-account.json
 # (outside the repo, not world-readable)
-GOOGLE_APPLICATION_CREDENTIALS=/Users/openclaw/.config/namecard/service-account.json
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 FIREBASE_ADMIN_PROJECT_ID=namecard-web-prd
 
 # ------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ src/
 
 生產環境部署至 Mac mini M4，透過 PM2 + Tailscale Serve 提供服務。
 
-- 目標 URL：`https://mac-mini.tailde842d.ts.net/namecard-web/`
+- 目標 URL：`https://<tailnet-host>/namecard-web/`
 - 詳細部署流程、排查指南、備份與災難還原：[RUNBOOK.md](./RUNBOOK.md)
 
 ## 📜 License

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,6 @@
 # namecard-web 運維手冊 (RUNBOOK)
 
-> 目標 URL：**https://mac-mini.tailde842d.ts.net/namecard-web/**
+> 目標 URL：**https://<tailnet-host>/namecard-web/**
 > 機器：Mac mini M4（macOS Darwin 25.x）
 > 管理帳號：openclaw
 
@@ -23,7 +23,7 @@
 
 ```
 Tailscale MagicDNS (HTTPS)
-  └── mac-mini.tailde842d.ts.net/namecard-web/*
+  └── <tailnet-host>/namecard-web/*
         │
         ▼
   tailscale serve (TLS termination + path routing)
@@ -61,8 +61,8 @@ Tailscale MagicDNS (HTTPS)
 ```bash
 # 1. Clone（若尚未 clone）
 git clone https://github.com/cct08311github/namecard-web.git \
-  /Users/openclaw/.openclaw/shared/projects/namecard-web
-cd /Users/openclaw/.openclaw/shared/projects/namecard-web
+  ~/.openclaw/shared/projects/namecard-web
+cd ~/.openclaw/shared/projects/namecard-web
 
 # 2. 安裝依賴
 pnpm install
@@ -116,7 +116,7 @@ scripts/verify-deploy.sh
 每次 `git pull` 後執行以下步驟（已有 PM2 管理、Tailscale Serve 已設定）：
 
 ```bash
-cd /Users/openclaw/.openclaw/shared/projects/namecard-web
+cd ~/.openclaw/shared/projects/namecard-web
 
 # 1. 拉取最新程式碼
 git pull origin main
@@ -204,7 +204,7 @@ tailscale serve status
 tailscale serve --bg --set-path=/namecard-web http://localhost:3014/namecard-web
 
 # 驗證
-curl -s https://mac-mini.tailde842d.ts.net/namecard-web/api/health
+curl -s https://<tailnet-host>/namecard-web/api/health
 ```
 
 ### Session Cookie 失效（用戶被踢出）
@@ -277,8 +277,8 @@ npm install -g pm2@latest
 
 # 3. Clone 程式碼
 git clone https://github.com/cct08311github/namecard-web.git \
-  /Users/openclaw/.openclaw/shared/projects/namecard-web
-cd /Users/openclaw/.openclaw/shared/projects/namecard-web
+  ~/.openclaw/shared/projects/namecard-web
+cd ~/.openclaw/shared/projects/namecard-web
 
 # 4. 還原 service account + env
 mkdir -p ~/.config/namecard

--- a/e2e/journeys/UX-AUDIT-REPORT.md
+++ b/e2e/journeys/UX-AUDIT-REPORT.md
@@ -7,7 +7,7 @@
 
 > **⚠️ Live Playwright run aborted at journey A**: The MCP browser instance hit `/login` because no `__nc_session` cookie was present in this isolated browser profile. The user's signed-in session lives in their own browser, not in MCP's headless one. **Per task instructions, this report is grounded in code-level analysis** (which conclusively answers all 8 journeys' "is the entry point reachable?" question — that was the audit's primary concern).
 >
-> A future live run requires either: (a) a service-account auth-bypass for `mac-mini.tailde842d.ts.net`, (b) a pre-warmed Playwright profile dir with the session cookie copied in, or (c) an env-flagged dev-mode that auto-mocks `readSession`. Any of those is a separate task — flagging it here so it doesn't get lost.
+> A future live run requires either: (a) a service-account auth-bypass for `<tailnet-host>`, (b) a pre-warmed Playwright profile dir with the session cookie copied in, or (c) an env-flagged dev-mode that auto-mocks `readSession`. Any of those is a separate task — flagging it here so it doesn't get lost.
 
 ---
 

--- a/e2e/journeys/business-user-flows.json
+++ b/e2e/journeys/business-user-flows.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Core business-user journeys for namecard-web UX audit. Each journey starts on `/` (the timeline home) unless noted. The `expected_clicks` is the click budget assuming the user has zero prior knowledge of URLs and only uses visible UI. Routes were extracted from src/app/(app)/ on 2026-04-26 and matched against AppShell PRIMARY (15 entries), MobileFab actions (4 entries), home quickActions (3 entries) and OnboardingHero PATHS (4 entries — only visible when cards.length === 0).",
-  "base_url": "https://mac-mini.tailde842d.ts.net/namecard-web",
+  "base_url": "https://<tailnet-host>/namecard-web",
   "auth": {
     "method": "google_oauth_session_cookie",
     "cookie_name": "__nc_session",

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -52,7 +52,7 @@ function parseDotenv(filepath) {
   return env;
 }
 
-const PROJECT_DIR = "/Users/openclaw/.openclaw/shared/projects/namecard-web";
+const PROJECT_DIR = process.env.HOME + "/.openclaw/shared/projects/namecard-web";
 const dotenvProd = parseDotenv(path.join(PROJECT_DIR, ".env.production"));
 
 module.exports = {
@@ -77,8 +77,8 @@ module.exports = {
         PORT: "3014",
         NAMECARD_BASE_PATH: "/namecard-web",
       },
-      error_file: "/Users/openclaw/.pm2/logs/namecard-web-error.log",
-      out_file: "/Users/openclaw/.pm2/logs/namecard-web-out.log",
+      error_file: process.env.HOME + "/.pm2/logs/namecard-web-error.log",
+      out_file: process.env.HOME + "/.pm2/logs/namecard-web-out.log",
       merge_logs: true,
       log_date_format: "YYYY-MM-DD HH:mm:ss Z",
     },

--- a/scripts/verify-deploy.sh
+++ b/scripts/verify-deploy.sh
@@ -142,7 +142,7 @@ echo ""
 echo "=================================================="
 if [ "$FAILED" -eq 0 ]; then
   echo -e "${GREEN}全部通過 — namecard-web 運行正常${NC}"
-  echo " 外部存取：https://mac-mini.tailde842d.ts.net/namecard-web/"
+  echo " 外部存取：https://<tailnet-host>/namecard-web/"
 else
   echo -e "${RED}部分檢查失敗 — 請依上方提示排查${NC}"
 fi


### PR DESCRIPTION
Closes #256

## Summary

Redact 33 references to internal infrastructure across 8 files.

## Strategy
- Docs (SKILL.md, RUNBOOK.md, README.md, UX-AUDIT-REPORT.md): hostname -> `<tailnet-host>`; path -> `~/`
- Test journey JSON: base_url -> `https://<tailnet-host>` placeholder
- PM2 config (ecosystem.config.cjs): hardcoded paths -> `process.env.HOME + ...`
- .env.production.example: placeholder example values
- scripts/verify-deploy.sh: literal -> placeholder

## Exceptions
None — all 33 hits redacted.